### PR TITLE
Call finishProcessingEntityDocuments() when finishing

### DIFF
--- a/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/WikibaseRevisionProcessor.java
+++ b/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/WikibaseRevisionProcessor.java
@@ -103,7 +103,7 @@ public class WikibaseRevisionProcessor implements MwRevisionProcessor {
 
 	@Override
 	public void finishRevisionProcessing() {
-		// Nothing to do
+		this.entityDocumentProcessor.finishProcessingEntityDocuments();
 	}
 
 }


### PR DESCRIPTION
This fixes a bug that prevented the respective EntityDocumentProcessor
method to be called, e.g., in DumpProcessingExample.
