### PR TITLE
Change "base IRI" of entity id values to "site IRI"

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -10,6 +10,13 @@ New features:
 * Dump files are downloaded to temporary files first to prevent incomplete downloads
   from causing errors
 
+Minor changes:
+* ItemIdValue and PropertyIdValue objects now have a "site IRI" that can be retrieved.
+  This was called "base IRI" in earlier releases and was only used to construct the full
+  IRI. The new concept is that this IRI is actually the identifier for the site that the
+  entity comes from. It is important to make it retrievable since it is needed (like in
+  previous versions) to construct the object using the factory.
+
 Bug fixes:
 * Fix grouping of Statements when reading data from dumps (Issue #78)
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImpl.java
@@ -59,13 +59,13 @@ import org.wikidata.wdtk.datamodel.interfaces.ValueSnak;
 public class DataObjectFactoryImpl implements DataObjectFactory {
 
 	@Override
-	public ItemIdValue getItemIdValue(String id, String baseIri) {
-		return new ItemIdValueImpl(id, baseIri);
+	public ItemIdValue getItemIdValue(String id, String siteIri) {
+		return new ItemIdValueImpl(id, siteIri);
 	}
 
 	@Override
-	public PropertyIdValue getPropertyIdValue(String id, String baseIri) {
-		return new PropertyIdValueImpl(id, baseIri);
+	public PropertyIdValue getPropertyIdValue(String id, String siteIri) {
+		return new PropertyIdValueImpl(id, siteIri);
 	}
 
 	@Override

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/EntityIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/EntityIdValueImpl.java
@@ -28,47 +28,53 @@ import org.wikidata.wdtk.datamodel.interfaces.ValueVisitor;
 /**
  * Generic implementation of {@link EntityIdValue} that works with arbitrary
  * Wikibase instances: it requires a baseIri that identifies the site globally.
- * 
+ *
  * TODO It would be cleaner to have an object that manages the site context
  * instead of passing a base IRI string that is simply concatenated.
- * 
+ *
  * TODO For our common use case that Wikidata entities are processed, it might
  * be useful to have a more lightweight object that does not store this known
  * base IRI.
- * 
+ *
  * @author Markus Kroetzsch
- * 
+ *
  */
 public abstract class EntityIdValueImpl implements EntityIdValue {
 
 	final String id;
-	final String baseIri;
+	final String siteIri;
 
 	/**
 	 * Constructor.
-	 * 
+	 *
 	 * @param id
 	 *            the ID string, e.g., "Q1234". The required format depends on
 	 *            the specific type of entity
-	 * @param baseIri
-	 *            the first part of the entity IRI of the site this belongs to,
-	 *            e.g., "http://www.wikidata.org/entity/"
+	 * @param siteIri
+	 *            IRI to identify the site, usually the first part of the entity
+	 *            IRI of the site this belongs to, e.g.,
+	 *            "http://www.wikidata.org/entity/"
 	 */
-	EntityIdValueImpl(String id, String baseIri) {
+	EntityIdValueImpl(String id, String siteIri) {
 		Validate.notNull(id, "Entity ids cannot be null");
-		Validate.notNull(baseIri, "Entity base IRIs cannot be null");
+		Validate.notNull(siteIri, "Entity site IRIs cannot be null");
 		this.id = id;
-		this.baseIri = baseIri;
+		this.siteIri = siteIri;
 	}
 
 	@Override
 	public String getIri() {
-		return baseIri.concat(id);
+		return siteIri.concat(id);
 	}
 
 	@Override
 	public String getId() {
 		return id;
+	}
+
+	@Override
+	public String getSiteIri() {
+		return this.siteIri;
 	}
 
 	@Override
@@ -83,7 +89,7 @@ public abstract class EntityIdValueImpl implements EntityIdValue {
 	 */
 	@Override
 	public int hashCode() {
-		return new HashCodeBuilder(773, 241).append(baseIri).append(id)
+		return new HashCodeBuilder(773, 241).append(siteIri).append(id)
 				.toHashCode();
 	}
 
@@ -105,7 +111,7 @@ public abstract class EntityIdValueImpl implements EntityIdValue {
 		}
 
 		EntityIdValueImpl other = (EntityIdValueImpl) obj;
-		return id.equals(other.id) && baseIri.equals(other.baseIri);
+		return id.equals(other.id) && siteIri.equals(other.siteIri);
 	}
-	
+
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemIdValueImpl.java
@@ -60,6 +60,6 @@ public class ItemIdValueImpl extends EntityIdValueImpl implements ItemIdValue {
 
 	@Override
 	public String toString() {
-		return "(ItemId)" + this.baseIri + "/" + this.id;
+		return "(ItemId)" + this.siteIri + "/" + this.id;
 	}
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyIdValueImpl.java
@@ -61,7 +61,7 @@ public class PropertyIdValueImpl extends EntityIdValueImpl implements
 
 	@Override
 	public String toString() {
-		return "(PropertyId)" + this.baseIri + "/" + this.id;
+		return "(PropertyId)" + this.siteIri + "/" + this.id;
 	}
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DataObjectFactory.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DataObjectFactory.java
@@ -27,43 +27,45 @@ import java.util.Map;
 /**
  * Interface for factories that create data objects that implement the
  * interfaces from this package.
- * 
+ *
  * @author Markus Kroetzsch
- * 
+ *
  */
 public interface DataObjectFactory {
 
 	/**
 	 * Creates an {@link ItemIdValue}.
-	 * 
+	 *
 	 * @param id
 	 *            a string of the form Qn... where n... is the string
 	 *            representation of a positive integer number
-	 * @param baseIri
-	 *            the first part of the entity IRI of the site this belongs to,
-	 *            e.g., "http://www.wikidata.org/entity/"
+	 * @param siteIri
+	 *            IRI to identify the site, usually the first part of the entity
+	 *            IRI of the site this belongs to, e.g.,
+	 *            "http://www.wikidata.org/entity/"
 	 * @return an {@link ItemIdValue} corresponding to the input
 	 */
-	ItemIdValue getItemIdValue(String id, String baseIri);
+	ItemIdValue getItemIdValue(String id, String siteIri);
 
 	/**
 	 * Creates a {@link PropertyIdValue}.
-	 * 
+	 *
 	 * @param id
 	 *            a string of the form Pn... where n... is the string
 	 *            representation of a positive integer number
-	 * @param baseIri
-	 *            the first part of the entity IRI of the site this belongs to,
-	 *            e.g., "http://www.wikidata.org/entity/"
+	 * @param siteIri
+	 *            IRI to identify the site, usually the first part of the entity
+	 *            IRI of the site this belongs to, e.g.,
+	 *            "http://www.wikidata.org/entity/"
 	 * @return a {@link PropertyIdValue} corresponding to the input
 	 */
-	PropertyIdValue getPropertyIdValue(String id, String baseIri);
+	PropertyIdValue getPropertyIdValue(String id, String siteIri);
 
 	/**
 	 * Creates a {@link DatatypeIdValue}. The datatype IRI is usually one of the
 	 * constants defined in {@link DatatypeIdValue}, but this is not enforced,
 	 * since there might be extensions that provide additional types.
-	 * 
+	 *
 	 * @param id
 	 *            the IRI string that identifies the datatype
 	 * @return a {@link DatatypeIdValue} corresponding to the input
@@ -72,7 +74,7 @@ public interface DataObjectFactory {
 
 	/**
 	 * Creates a {@link TimeValue}.
-	 * 
+	 *
 	 * @param year
 	 *            a year number, where 0 refers to 1BCE
 	 * @param month
@@ -109,7 +111,7 @@ public interface DataObjectFactory {
 
 	/**
 	 * Creates a {@link GlobeCoordinatesValue}.
-	 * 
+	 *
 	 * @param latitude
 	 *            the latitude of the coordinates in nanodegrees
 	 * @param longitude
@@ -125,7 +127,7 @@ public interface DataObjectFactory {
 
 	/**
 	 * Creates a {@link StringValue}.
-	 * 
+	 *
 	 * @param string
 	 * @return a {@link StringValue} corresponding to the input
 	 */
@@ -133,7 +135,7 @@ public interface DataObjectFactory {
 
 	/**
 	 * Creates a {@link MonolingualTextValue}.
-	 * 
+	 *
 	 * @param text
 	 *            the text of the value
 	 * @param languageCode
@@ -145,7 +147,7 @@ public interface DataObjectFactory {
 
 	/**
 	 * Creates a {@link QuantityValue}.
-	 * 
+	 *
 	 * @param numericValue
 	 *            the numeric value of this quantity
 	 * @param lowerBound
@@ -159,7 +161,7 @@ public interface DataObjectFactory {
 
 	/**
 	 * Creates a {@link ValueSnak}.
-	 * 
+	 *
 	 * @param propertyId
 	 * @param value
 	 * @return a {@link ValueSnak} corresponding to the input
@@ -168,7 +170,7 @@ public interface DataObjectFactory {
 
 	/**
 	 * Creates a {@link SomeValueSnak}.
-	 * 
+	 *
 	 * @param propertyId
 	 * @return a {@link SomeValueSnak} corresponding to the input
 	 */
@@ -176,7 +178,7 @@ public interface DataObjectFactory {
 
 	/**
 	 * Creates a {@link NoValueSnak}.
-	 * 
+	 *
 	 * @param propertyId
 	 * @return a {@link NoValueSnak} corresponding to the input
 	 */
@@ -184,7 +186,7 @@ public interface DataObjectFactory {
 
 	/**
 	 * Creates a {@link SnakGroup}.
-	 * 
+	 *
 	 * @param snaks
 	 *            a non-empty list of snaks that use the same property
 	 * @return a {@link SnakGroup} corresponding to the input
@@ -193,7 +195,7 @@ public interface DataObjectFactory {
 
 	/**
 	 * Creates a {@link Claim}.
-	 * 
+	 *
 	 * @param subject
 	 *            the subject the Statement refers to
 	 * @param mainSnak
@@ -207,7 +209,7 @@ public interface DataObjectFactory {
 
 	/**
 	 * Creates a {@link Reference}.
-	 * 
+	 *
 	 * @param snakGroups
 	 *            list of snak groups
 	 * @return a {@link Reference} corresponding to the input
@@ -220,7 +222,7 @@ public interface DataObjectFactory {
 	 * The string id is used mainly for communication with a Wikibase site, in
 	 * order to refer to statements of that site. When creating new statements
 	 * that are not on any site, the empty string can be used.
-	 * 
+	 *
 	 * @param claim
 	 *            the main claim the Statement refers to
 	 * @param references
@@ -236,7 +238,7 @@ public interface DataObjectFactory {
 
 	/**
 	 * Creates a {@link StatementGroup}.
-	 * 
+	 *
 	 * @param statements
 	 *            a non-empty list of statements that use the same subject and
 	 *            main-snak property in their claim
@@ -246,7 +248,7 @@ public interface DataObjectFactory {
 
 	/**
 	 * Creates a {@link SiteLink}.
-	 * 
+	 *
 	 * @param title
 	 *            the title string of the linked page, including namespace
 	 *            prefixes if any
@@ -260,7 +262,7 @@ public interface DataObjectFactory {
 
 	/**
 	 * Creates a {@link PropertyDocument}.
-	 * 
+	 *
 	 * @param propertyId
 	 *            the id of the property that data is about
 	 * @param labels
@@ -282,7 +284,7 @@ public interface DataObjectFactory {
 
 	/**
 	 * Creates an {@link ItemDocument}.
-	 * 
+	 *
 	 * @param itemIdValue
 	 *            the id of the item that data is about
 	 * @param labels

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/EntityIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/EntityIdValue.java
@@ -26,11 +26,21 @@ package org.wikidata.wdtk.datamodel.interfaces;
  * entities are Items (with identifiers of the form Q1234) and Properties (with
  * identifiers of the form P1234).
  * <p>
+ * When considering entities from multiple sites, the (local) ID alone is not
+ * enough to identify an entity unambiguously. In this case, the site IRI also
+ * needs to be taken into account.
+ * <p>
+ * An alternative to using the local ID and site IRI together is to use the full
+ * IRI. By default, this is computed by appending the local ID to the site IRI.
+ * However, for some sites and some entity types, more elaborate computations
+ * might be required, so this construction scheme for IRIs should not be
+ * presumed.
+ * <p>
  * The full IRI of an entity is used in export formats like RDF, but also
  * internally, e.g., for identifying the calendar model of time values.
- * 
+ *
  * @author Markus Kroetzsch
- * 
+ *
  */
 public interface EntityIdValue extends IriIdentifiedValue {
 
@@ -44,19 +54,27 @@ public interface EntityIdValue extends IriIdentifiedValue {
 	static final String ET_PROPERTY = "http://www.wikidata.org/ontology#Property";
 
 	/**
-	 * Get the type of this entity. This should be an IRI that identifies an
+	 * Returns the type of this entity. This should be an IRI that identifies an
 	 * entity type, such as {@link EntityIdValue#ET_ITEM} or
 	 * {@link EntityIdValue#ET_PROPERTY}.
-	 * 
-	 * @return String
+	 *
+	 * @return IRI string to identify the type of the entity
 	 */
 	String getEntityType();
 
 	/**
-	 * Get the id of this entity.
-	 * 
+	 * Returns the id of this entity.
+	 *
 	 * @return String id of this entity
 	 */
 	String getId();
+
+	/**
+	 * Returns an IRI that identifies the site that this entity comes from,,
+	 * e.g., "http://www.wikidata.org/entity/" for Wikidata.
+	 *
+	 * @return the site IRI string
+	 */
+	String getSiteIri();
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemIdValueImplTest.java
@@ -56,6 +56,11 @@ public class ItemIdValueImplTest {
 	}
 
 	@Test
+	public void siteIriIsCorrect() {
+		assertEquals(item1.getSiteIri(), "http://www.wikidata.org/entity/");
+	}
+
+	@Test
 	public void idIsCorrect() {
 		assertEquals(item1.getId(), "Q42");
 	}


### PR DESCRIPTION
- Site IRI is the same string as before, but now interpreted as an
  identifier for the site the entity comes from.
- A new getter makes this string retrievable (extended interface of
  EntityIDValue).

This is necessary to ensure that one can construct new ItenIdValues and
PropertyIdValues from the information that one can get from an object of
this type. The re-interpretation of "base IRI" as "site IRI" is to
prepare for future Wikibase changes where entities may have different
IDs and different ways of constructing IRIs (e.g., Commons file name IDs
and URL-encoding as part of IRI construction).
