### PR TITLE
Issue #106: support property statements

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -4,6 +4,10 @@ Wikidata Toolkit Release Notes
 Version 0.4.0
 -------------
 
+New features:
+* Support statements on property documents
+* More robust JSON parsing: recover after errors to process remaining file 
+
 Bug fixes:
 * Support RDF export of Monolingual Text Value data in statements.
 * Significant performance improvements in RDF export of taxonomy data.   

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Datamodel.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Datamodel.java
@@ -428,7 +428,7 @@ public class Datamodel {
 	}
 
 	/**
-	 * Creates a {@link PropertyDocument}.
+	 * Creates a {@link PropertyDocument} without statements.
 	 *
 	 * @param propertyId
 	 *            the id of the property that data is about
@@ -450,6 +450,35 @@ public class Datamodel {
 			List<MonolingualTextValue> aliases, DatatypeIdValue datatypeId) {
 		return factory.getPropertyDocument(propertyId, labels, descriptions,
 				aliases, datatypeId);
+	}
+
+	/**
+	 * Creates a {@link PropertyDocument}.
+	 *
+	 * @param propertyId
+	 *            the id of the property that data is about
+	 * @param labels
+	 *            the list of labels of this property, with at most one label
+	 *            for each language code
+	 * @param descriptions
+	 *            the list of descriptions of this property, with at most one
+	 *            description for each language code
+	 * @param aliases
+	 *            the list of aliases of this property
+	 * @param statementGroups
+	 *            the list of statement groups of this item; all of them must
+	 *            have the given itemIdValue as their subject
+	 * @param datatypeId
+	 *            the datatype of that property
+	 * @return a {@link PropertyDocument} corresponding to the input
+	 */
+	public static PropertyDocument makePropertyDocument(
+			PropertyIdValue propertyId, List<MonolingualTextValue> labels,
+			List<MonolingualTextValue> descriptions,
+			List<MonolingualTextValue> aliases,
+			List<StatementGroup> statementGroups, DatatypeIdValue datatypeId) {
+		return factory.getPropertyDocument(propertyId, labels, descriptions,
+				aliases, statementGroups, datatypeId);
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverter.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverter.java
@@ -164,7 +164,8 @@ public class DatamodelConverter implements SnakVisitor<Snak>,
 		return this.dataObjectFactory.getPropertyDocument(object
 				.getPropertyId(), new ArrayList<>(object.getLabels().values()),
 				new ArrayList<>(object.getDescriptions().values()),
-				convertAliasList(object.getAliases()), object.getDatatype());
+				convertAliasList(object.getAliases()), object
+						.getStatementGroups(), object.getDatatype());
 	}
 
 	public ItemDocument copy(ItemDocument object) {

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Equality.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Equality.java
@@ -505,7 +505,8 @@ public class Equality {
 		}
 		PropertyDocument other = (PropertyDocument) o2;
 		// Note: property id already compared by equalsTermedDocument()
-		return o1.getDatatype().equals(other.getDatatype());
+		return o1.getDatatype().equals(other.getDatatype())
+				&& o1.getStatementGroups().equals(other.getStatementGroups());
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Hash.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Hash.java
@@ -308,6 +308,7 @@ public class Hash {
 	public static int hashCode(PropertyDocument o) {
 		int result;
 		result = hashCodeForTermedDocument(o);
+		result = prime * result + o.getStatementGroups().hashCode();
 		result = prime * result + o.getDatatype().hashCode();
 		return result;
 	}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ToString.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ToString.java
@@ -40,6 +40,7 @@ import org.wikidata.wdtk.datamodel.interfaces.Snak;
 import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
 import org.wikidata.wdtk.datamodel.interfaces.SomeValueSnak;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
+import org.wikidata.wdtk.datamodel.interfaces.StatementDocument;
 import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
 import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
 import org.wikidata.wdtk.datamodel.interfaces.StringValue;
@@ -353,7 +354,8 @@ public class ToString {
 	public static String toString(PropertyDocument o) {
 		return "==PropertyDocument " + o.getPropertyId().getIri() + "==\n"
 				+ "* Datatype: " + o.getDatatype()
-				+ toStringForTermedDocument(o);
+				+ toStringForTermedDocument(o)
+				+ toStringForStatementDocument(o);
 	}
 
 	/**
@@ -368,16 +370,10 @@ public class ToString {
 		StringBuilder sb = new StringBuilder();
 		sb.append("==ItemDocument ").append(o.getItemId().getIri());
 		sb.append("==").append(toStringForTermedDocument(o));
-		boolean first;
-
-		sb.append("\n===Statements===\n");
-		for (StatementGroup sg : o.getStatementGroups()) {
-			sb.append(toString(sg));
-		}
-		sb.append("\n===End of statements===\n");
+		sb.append(toStringForStatementDocument(o));
 
 		sb.append("* Site links: ");
-		first = true;
+		boolean first = true;
 		SortedSet<String> siteKeys = new TreeSet<String>(o.getSiteLinks()
 				.keySet());
 		for (String key : siteKeys) {
@@ -388,6 +384,18 @@ public class ToString {
 			}
 			sb.append(toString(o.getSiteLinks().get(key)));
 		}
+
+		return sb.toString();
+	}
+
+	protected static String toStringForStatementDocument(StatementDocument o) {
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("\n===Statements===\n");
+		for (StatementGroup sg : o.getStatementGroups()) {
+			sb.append(toString(sg));
+		}
+		sb.append("\n===End of statements===\n");
 
 		return sb.toString();
 	}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImpl.java
@@ -21,6 +21,7 @@ package org.wikidata.wdtk.datamodel.implementation;
  */
 
 import java.math.BigDecimal;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -165,7 +166,17 @@ public class DataObjectFactoryImpl implements DataObjectFactory {
 			List<MonolingualTextValue> descriptions,
 			List<MonolingualTextValue> aliases, DatatypeIdValue datatypeId) {
 		return new PropertyDocumentImpl(propertyId, labels, descriptions,
-				aliases, datatypeId);
+				aliases, Collections.<StatementGroup> emptyList(), datatypeId);
+	}
+
+	@Override
+	public PropertyDocument getPropertyDocument(PropertyIdValue propertyId,
+			List<MonolingualTextValue> labels,
+			List<MonolingualTextValue> descriptions,
+			List<MonolingualTextValue> aliases,
+			List<StatementGroup> statementGroups, DatatypeIdValue datatypeId) {
+		return new PropertyDocumentImpl(propertyId, labels, descriptions,
+				aliases, statementGroups, datatypeId);
 	}
 
 	@Override

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImpl.java
@@ -21,7 +21,6 @@ package org.wikidata.wdtk.datamodel.implementation;
  */
 
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -34,15 +33,12 @@ import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
-import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
-import org.wikidata.wdtk.util.NestedIterator;
 
-public class ItemDocumentImpl extends TermedDocumentImpl implements
+public class ItemDocumentImpl extends TermedStatementDocumentImpl implements
 		ItemDocument {
 
 	final ItemIdValue itemId;
-	final List<StatementGroup> statementGroups;
 	final Map<String, SiteLink> siteLinks;
 
 	/**
@@ -70,24 +66,11 @@ public class ItemDocumentImpl extends TermedDocumentImpl implements
 			List<MonolingualTextValue> aliases,
 			List<StatementGroup> statementGroups,
 			Map<String, SiteLink> siteLinks) {
-		super(labels, descriptions, aliases);
+		super(itemIdValue, labels, descriptions, aliases, statementGroups);
 		Validate.notNull(itemIdValue, "item ID cannot be null");
-		Validate.notNull(statementGroups, "statement list cannot be null");
 		Validate.notNull(siteLinks, "site links cannot be null");
 
-		if (!statementGroups.isEmpty()) {
-			for (StatementGroup sg : statementGroups) {
-				if (!itemIdValue.equals(sg.getSubject())) {
-					throw new IllegalArgumentException(
-							"All statement groups in a document must have the same subject: found "
-									+ sg.getSubject() + " but expected "
-									+ itemIdValue);
-				}
-			}
-		}
-
 		this.itemId = itemIdValue;
-		this.statementGroups = statementGroups;
 		this.siteLinks = siteLinks;
 	}
 
@@ -99,16 +82,6 @@ public class ItemDocumentImpl extends TermedDocumentImpl implements
 	@Override
 	public ItemIdValue getItemId() {
 		return itemId;
-	}
-
-	@Override
-	public List<StatementGroup> getStatementGroups() {
-		return Collections.unmodifiableList(statementGroups);
-	}
-
-	@Override
-	public Iterator<Statement> getAllStatements() {
-		return new NestedIterator<>(statementGroups);
 	}
 
 	@Override

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImpl.java
@@ -31,6 +31,7 @@ import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
 
 /**
  * Implementation of {@link PropertyDocument}.
@@ -38,8 +39,8 @@ import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
  * @author Markus Kroetzsch
  *
  */
-public class PropertyDocumentImpl extends TermedDocumentImpl implements
-PropertyDocument {
+public class PropertyDocumentImpl extends TermedStatementDocumentImpl implements
+		PropertyDocument {
 
 	final PropertyIdValue propertyId;
 	final DatatypeIdValue datatypeId;
@@ -57,14 +58,18 @@ PropertyDocument {
 	 *            description for each language code
 	 * @param aliases
 	 *            the list of aliases of this property
+	 * @param statementGroups
+	 *            the list of statement groups of this item; all of them must
+	 *            have the given itemIdValue as their subject
 	 * @param datatypeId
 	 *            the datatype of that property
 	 */
 	PropertyDocumentImpl(PropertyIdValue propertyId,
 			List<MonolingualTextValue> labels,
 			List<MonolingualTextValue> descriptions,
-			List<MonolingualTextValue> aliases, DatatypeIdValue datatypeId) {
-		super(labels, descriptions, aliases);
+			List<MonolingualTextValue> aliases,
+			List<StatementGroup> statementGroups, DatatypeIdValue datatypeId) {
+		super(propertyId, labels, descriptions, aliases, statementGroups);
 		Validate.notNull(propertyId, "property ID cannot be null");
 		Validate.notNull(datatypeId, "datatype ID cannot be null");
 		this.propertyId = propertyId;

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SitesImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SitesImpl.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermedStatementDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermedStatementDocumentImpl.java
@@ -23,12 +23,18 @@ package org.wikidata.wdtk.datamodel.implementation;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.Validate;
+import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
+import org.wikidata.wdtk.datamodel.interfaces.StatementDocument;
+import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
 import org.wikidata.wdtk.datamodel.interfaces.TermedDocument;
+import org.wikidata.wdtk.util.NestedIterator;
 
 /**
  * Implementation of {@link TermedDocument}. This abstract class defines the
@@ -37,15 +43,20 @@ import org.wikidata.wdtk.datamodel.interfaces.TermedDocument;
  * @author Markus Kroetzsch
  *
  */
-public abstract class TermedDocumentImpl implements TermedDocument {
+public abstract class TermedStatementDocumentImpl implements TermedDocument,
+		StatementDocument {
 
 	final Map<String, MonolingualTextValue> labels;
 	final Map<String, MonolingualTextValue> descriptions;
 	final Map<String, List<MonolingualTextValue>> aliases;
+	final List<StatementGroup> statementGroups;
 
 	/**
 	 * Constructor.
 	 *
+	 * @param entityIdValue
+	 *            the entity that this document refers to; used to validate
+	 *            statements
 	 * @param labels
 	 *            the list of labels of this entity, with at most one label for
 	 *            each language code
@@ -54,13 +65,19 @@ public abstract class TermedDocumentImpl implements TermedDocument {
 	 *            description for each language code
 	 * @param aliases
 	 *            the list of aliases of this entity
+	 * @param statementGroups
+	 *            the list of statement groups of this item; all of them must
+	 *            have the given itemIdValue as their subject
 	 */
-	TermedDocumentImpl(List<MonolingualTextValue> labels,
+	TermedStatementDocumentImpl(EntityIdValue entityIdValue,
+			List<MonolingualTextValue> labels,
 			List<MonolingualTextValue> descriptions,
-			List<MonolingualTextValue> aliases) {
+			List<MonolingualTextValue> aliases,
+			List<StatementGroup> statementGroups) {
 		Validate.notNull(labels, "list of labels cannot be null");
 		Validate.notNull(descriptions, "list of descriptions cannot be null");
 		Validate.notNull(aliases, "list of aliases cannot be null");
+		Validate.notNull(statementGroups, "statement list cannot be null");
 
 		this.labels = new HashMap<String, MonolingualTextValue>();
 		for (MonolingualTextValue label : labels) {
@@ -93,6 +110,19 @@ public abstract class TermedDocumentImpl implements TermedDocument {
 				this.aliases.put(alias.getLanguageCode(), aliasesForLanguage);
 			}
 		}
+
+		if (!statementGroups.isEmpty()) {
+			for (StatementGroup sg : statementGroups) {
+				if (!entityIdValue.equals(sg.getSubject())) {
+					throw new IllegalArgumentException(
+							"All statement groups in a document must have the same subject: found "
+									+ sg.getSubject() + " but expected "
+									+ entityIdValue);
+				}
+			}
+		}
+
+		this.statementGroups = statementGroups;
 	}
 
 	@Override
@@ -110,6 +140,16 @@ public abstract class TermedDocumentImpl implements TermedDocument {
 		// TODO This still allows inner lists of aliases to be modified. Do
 		// we have to protect against this?
 		return Collections.unmodifiableMap(aliases);
+	}
+
+	@Override
+	public List<StatementGroup> getStatementGroups() {
+		return Collections.unmodifiableList(statementGroups);
+	}
+
+	@Override
+	public Iterator<Statement> getAllStatements() {
+		return new NestedIterator<>(statementGroups);
 	}
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DataObjectFactory.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DataObjectFactory.java
@@ -261,7 +261,9 @@ public interface DataObjectFactory {
 	SiteLink getSiteLink(String title, String siteKey, List<String> badges);
 
 	/**
-	 * Creates a {@link PropertyDocument}.
+	 * Creates a {@link PropertyDocument} without any statements. This is
+	 * provided for backwards compatibility (property documents did not support
+	 * statements in the past).
 	 *
 	 * @param propertyId
 	 *            the id of the property that data is about
@@ -281,6 +283,32 @@ public interface DataObjectFactory {
 			List<MonolingualTextValue> labels,
 			List<MonolingualTextValue> descriptions,
 			List<MonolingualTextValue> aliases, DatatypeIdValue datatypeId);
+
+	/**
+	 * Creates a {@link PropertyDocument}.
+	 *
+	 * @param propertyId
+	 *            the id of the property that data is about
+	 * @param labels
+	 *            the list of labels of this property, with at most one label
+	 *            for each language code
+	 * @param descriptions
+	 *            the list of descriptions of this property, with at most one
+	 *            description for each language code
+	 * @param aliases
+	 *            the list of aliases of this property
+	 * @param statementGroups
+	 *            the list of statement groups of this item; all of them must
+	 *            have the given itemIdValue as their subject
+	 * @param datatypeId
+	 *            the datatype of that property
+	 * @return a {@link PropertyDocument} corresponding to the input
+	 */
+	PropertyDocument getPropertyDocument(PropertyIdValue propertyId,
+			List<MonolingualTextValue> labels,
+			List<MonolingualTextValue> descriptions,
+			List<MonolingualTextValue> aliases,
+			List<StatementGroup> statementGroups, DatatypeIdValue datatypeId);
 
 	/**
 	 * Creates an {@link ItemDocument}.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DatatypeIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DatatypeIdValue.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.interfaces;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DatatypeIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DatatypeIdValue.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.interfaces;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,15 +24,19 @@ package org.wikidata.wdtk.datamodel.interfaces;
  * A value that represents one of the available Wikibase datatypes. The method
  * {@link IriIdentifiedValue#getIri() getIri()} will always return one of the
  * datatype IRIs defined in this interface.
- * 
+ *
  * @author Markus Kroetzsch
- * 
+ *
  */
 public interface DatatypeIdValue extends IriIdentifiedValue {
 	/**
 	 * IRI of the item datatype in Wikibase.
 	 */
 	static final String DT_ITEM = "http://www.wikidata.org/ontology#propertyTypeItem";
+	/**
+	 * IRI of the property datatype in Wikibase.
+	 */
+	static final String DT_PROPERTY = "http://www.wikidata.org/ontology#propertyTypeProperty";
 	/**
 	 * IRI of the string datatype in Wikibase.
 	 */

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/EntityDocumentProcessorBroker.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/EntityDocumentProcessorBroker.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.interfaces;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/PropertyDocument.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/PropertyDocument.java
@@ -25,24 +25,24 @@ package org.wikidata.wdtk.datamodel.interfaces;
  * {@link EntityDocument} with information about the datatype of a property.
  * <p>
  * Claims or Statements on properties might be supported in the future.
- * 
+ *
  * @author Markus Kroetzsch
- * 
+ *
  */
-public interface PropertyDocument extends TermedDocument {
+public interface PropertyDocument extends TermedDocument, StatementDocument {
 
 	/**
 	 * Return the ID of the property that the data refers to. The result is the
 	 * same as that of {@link EntityDocument#getEntityId()}, but declared with a
 	 * more specific result type.
-	 * 
+	 *
 	 * @return property id
 	 */
 	PropertyIdValue getPropertyId();
 
 	/**
 	 * Get the datatype id of the datatype defined for this property.
-	 * 
+	 *
 	 * @return {@link DatatypeIdValue}
 	 */
 	DatatypeIdValue getDatatype();

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/Sites.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/Sites.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.interfaces;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/StatementDocument.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/StatementDocument.java
@@ -20,31 +20,30 @@ package org.wikidata.wdtk.datamodel.interfaces;
  * #L%
  */
 
-import java.util.Map;
+import java.util.Iterator;
+import java.util.List;
 
 /**
- * Interface for datasets that describe items. It extends {@link EntityDocument}
- * with information about site links and statements.
+ * Interface for EntityDocuments that can have statements.
  *
  * @author Markus Kroetzsch
- *
  */
-public interface ItemDocument extends TermedDocument, StatementDocument {
+public interface StatementDocument extends EntityDocument {
 
 	/**
-	 * Return the ID of the item that the data refers to. The result is the same
-	 * as that of {@link EntityDocument#getEntityId()}, but declared with a more
-	 * specific result type.
+	 * Return the list of all StatementGroups stored for this item. The order of
+	 * StatementGroups is significant.
 	 *
-	 * @return item id
+	 * @return list of StatementGroups
 	 */
-	ItemIdValue getItemId();
+	List<StatementGroup> getStatementGroups();
 
 	/**
-	 * Get a Map of site keys to {@link SiteLink} objects.
+	 * Returns an iterator that provides access to all statements, without
+	 * considering the statement groups. The order of statements is preserved.
 	 *
-	 * @return map of SiteLinks
+	 * @return iterator over all statements
 	 */
-	Map<String, SiteLink> getSiteLinks();
+	Iterator<Statement> getAllStatements();
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/AliasesDeserializer.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/AliasesDeserializer.java
@@ -36,14 +36,14 @@ import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * A deserializer implementation for the aliases in an
- * {@link JacksonTermedDocument}.
+ * {@link JacksonTermedStatementDocument}.
  * <p>
  * It implements a workaround to cope with empty aliases being represented as
  * <code>"aliases":[]</code> despite its declaration as map and not as list or
  * array. This is neither nice nor fast, and should be obsolete as soon as
  * possible.
  *
- * @see JacksonTermedDocument#setAliases(Map)
+ * @see JacksonTermedStatementDocument#setAliases(Map)
  *
  * @author Fredo Erxleben
  *

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/ClaimFromJson.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/ClaimFromJson.java
@@ -27,6 +27,7 @@ import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;
 import org.wikidata.wdtk.datamodel.interfaces.Claim;
+import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.Snak;
 import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
@@ -51,7 +52,7 @@ public class ClaimFromJson implements Claim {
 
 	@Override
 	public EntityIdValue getSubject() {
-		JacksonItemDocument parentDocument = this.statement.getParentDocument();
+		EntityDocument parentDocument = this.statement.getParentDocument();
 		if (parentDocument != null) {
 			return parentDocument.getEntityId();
 		} else {

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonDatatypeId.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonDatatypeId.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.json.jackson;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonDatatypeId.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonDatatypeId.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.json.jackson;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -40,6 +40,11 @@ public class JacksonDatatypeId implements DatatypeIdValue {
 	 * {@link DatatypeIdValue#DT_ITEM} in JSON.
 	 */
 	public static final String JSON_DT_ITEM = "wikibase-item";
+	/**
+	 * String used to refer to the property datatype
+	 * {@link DatatypeIdValue#DT_PROPERTY} in JSON.
+	 */
+	public static final String JSON_DT_PROPERTY = "wikibase-property";
 	/**
 	 * String used to refer to the property datatype
 	 * {@link DatatypeIdValue#DT_GLOBE_COORDINATES} in JSON.
@@ -94,6 +99,8 @@ public class JacksonDatatypeId implements DatatypeIdValue {
 		switch (jsonDatatype) {
 		case JSON_DT_ITEM:
 			return DT_ITEM;
+		case JSON_DT_PROPERTY:
+			return DT_PROPERTY;
 		case JSON_DT_GLOBE_COORDINATES:
 			return DT_GLOBE_COORDINATES;
 		case JSON_DT_URL:

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonItemDocument.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonItemDocument.java
@@ -20,13 +20,9 @@ package org.wikidata.wdtk.datamodel.json.jackson;
  * #L%
  */
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
@@ -36,9 +32,6 @@ import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
-import org.wikidata.wdtk.datamodel.interfaces.Statement;
-import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
-import org.wikidata.wdtk.util.NestedIterator;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -57,24 +50,13 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  */
 @JsonInclude(Include.NON_EMPTY)
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class JacksonItemDocument extends JacksonTermedDocument implements
+public class JacksonItemDocument extends JacksonTermedStatementDocument implements
 		ItemDocument {
 
-	/**
-	 * This is what is called <i>claim</i> in the JSON model. It corresponds to
-	 * the statement group in the WDTK model.
-	 */
-	Map<String, List<JacksonStatement>> claims = new HashMap<>();
 	/**
 	 * Map to store site links.
 	 */
 	private Map<String, JacksonSiteLink> sitelinks = new HashMap<>();
-
-	/**
-	 * Statement groups. This member is initialized when statements are
-	 * accessed.
-	 */
-	private List<StatementGroup> statementGroups = null;
 
 	/**
 	 * Constructor. Creates an empty object that can be populated during JSON
@@ -85,7 +67,7 @@ public class JacksonItemDocument extends JacksonTermedDocument implements
 
 	@Override
 	public String getJsonType() {
-		return JacksonTermedDocument.JSON_TYPE_ITEM;
+		return JacksonTermedStatementDocument.JSON_TYPE_ITEM;
 	}
 
 	@JsonIgnore
@@ -104,19 +86,6 @@ public class JacksonItemDocument extends JacksonTermedDocument implements
 		return getItemId();
 	}
 
-	@JsonIgnore
-	@Override
-	public List<StatementGroup> getStatementGroups() {
-		if (this.statementGroups == null) {
-			this.statementGroups = new ArrayList<>(this.claims.size());
-			for (List<JacksonStatement> statements : this.claims.values()) {
-				this.statementGroups
-						.add(new StatementGroupFromJson(statements));
-			}
-		}
-		return this.statementGroups;
-	}
-
 	/**
 	 * Sets the site links to the given value. Only for use by Jackson during
 	 * deserialization.
@@ -133,60 +102,6 @@ public class JacksonItemDocument extends JacksonTermedDocument implements
 	@Override
 	public Map<String, SiteLink> getSiteLinks() {
 		return Collections.<String, SiteLink> unmodifiableMap(this.sitelinks);
-	}
-
-	/**
-	 * Sets the "claims" to the given value. Only for use by Jackson during
-	 * deserialization.
-	 * <p>
-	 * The name refers to the JSON model, where claims are similar to statement
-	 * groups. This should not be confused with claims as used in the WDTK data
-	 * model. This will probably only be used by the Jacksons' ObjectMapper.
-	 *
-	 * @param claims
-	 */
-	@JsonProperty("claims")
-	public void setJsonClaims(Map<String, List<JacksonStatement>> claims) {
-		this.claims = claims;
-		this.statementGroups = null; // clear cache
-		updateClaims();
-	}
-
-	/**
-	 * Sets the subject of each of the current statements ("claims" in JSON) to
-	 * the current entity id. This is required since the JSON serialization of
-	 * statements does not contain a subject id, but subject ids are part of the
-	 * statement data in WDTK. The update is needed whenever the statements have
-	 * changed.
-	 */
-	private void updateClaims() {
-		this.statementGroups = null; // clear cache
-
-		for (Entry<String, List<JacksonStatement>> entry : this.claims
-				.entrySet()) {
-			for (JacksonStatement statement : entry.getValue()) {
-				statement.setParentDocument(this);
-			}
-		}
-	}
-
-	/**
-	 * Returns the "claims". Only used by Jackson.
-	 * <p>
-	 * JSON "claims" correspond to statement groups in the WDTK model. You
-	 * should use {@link JacksonItemDocument#getStatementGroups()} to obtain
-	 * this data.
-	 *
-	 * @return map of statement groups
-	 */
-	@JsonProperty("claims")
-	public Map<String, List<JacksonStatement>> getJsonClaims() {
-		return this.claims;
-	}
-
-	@Override
-	public Iterator<Statement> getAllStatements() {
-		return new NestedIterator<>(this.getStatementGroups());
 	}
 
 	@Override

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonMonolingualTextValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonMonolingualTextValue.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.json.jackson;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonObjectFactory.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonObjectFactory.java
@@ -62,11 +62,10 @@ import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValue;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueGlobeCoordinates;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueItemId;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueMonolingualText;
+import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValuePropertyId;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueQuantity;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueString;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueTime;
-
-import com.fasterxml.jackson.databind.JsonMappingException;
 
 /**
  * Factory implementation to create Jackson versions of the datamodel objects,
@@ -85,13 +84,8 @@ public class JacksonObjectFactory implements DataObjectFactory {
 		if (id.length() > 0 && id.charAt(0) == 'Q') {
 			Integer numericId = Integer.valueOf(id.substring(1));
 			JacksonInnerEntityId innerEntity;
-			try {
-				innerEntity = new JacksonInnerEntityId(
-						JacksonInnerEntityId.JSON_ENTITY_TYPE_ITEM, numericId);
-			} catch (JsonMappingException e) {
-				throw new RuntimeException(
-						"Entities of type item not supported?", e);
-			}
+			innerEntity = new JacksonInnerEntityId(
+					JacksonInnerEntityId.JSON_ENTITY_TYPE_ITEM, numericId);
 
 			JacksonValueItemId result = new JacksonValueItemId();
 			result.setValue(innerEntity);
@@ -104,8 +98,19 @@ public class JacksonObjectFactory implements DataObjectFactory {
 
 	@Override
 	public PropertyIdValue getPropertyIdValue(String id, String siteIri) {
-		// Jackson has no dedicated property id values:
-		return Datamodel.makePropertyIdValue(id, siteIri);
+		if (id.length() > 0 && id.charAt(0) == 'P') {
+			Integer numericId = Integer.valueOf(id.substring(1));
+			JacksonInnerEntityId innerEntity;
+			innerEntity = new JacksonInnerEntityId(
+					JacksonInnerEntityId.JSON_ENTITY_TYPE_PROPERTY, numericId);
+
+			JacksonValuePropertyId result = new JacksonValuePropertyId();
+			result.setValue(innerEntity);
+			result.setParentDocument(getParentItemDocument("Qunknown", siteIri));
+			return result;
+		} else {
+			throw new IllegalArgumentException("Illegal property id: " + id);
+		}
 	}
 
 	@Override

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonPropertyDocument.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonPropertyDocument.java
@@ -43,7 +43,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class JacksonPropertyDocument extends JacksonTermedDocument implements
+public class JacksonPropertyDocument extends JacksonTermedStatementDocument implements
 		PropertyDocument {
 
 	/**
@@ -108,7 +108,7 @@ public class JacksonPropertyDocument extends JacksonTermedDocument implements
 
 	@Override
 	public String getJsonType() {
-		return JacksonTermedDocument.JSON_TYPE_PROPERTY;
+		return JacksonTermedStatementDocument.JSON_TYPE_PROPERTY;
 	}
 
 	@Override

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonSnak.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonSnak.java
@@ -75,10 +75,10 @@ public abstract class JacksonSnak implements Snak {
 	 * snaks, but is needed in WDTK to build {@link PropertyIdValue} objects
 	 * etc. Thus, it is necessary to set this information after each
 	 * deserialization using
-	 * {@link JacksonSnak#setParentDocument(JacksonItemDocument)}.
+	 * {@link JacksonSnak#setParentDocument(JacksonTermedStatementDocument)}.
 	 */
 	@JsonIgnore
-	JacksonTermedDocument parentDocument;
+	JacksonTermedStatementDocument parentDocument;
 
 	/**
 	 * Constructor. Creates an empty object that can be populated during JSON
@@ -153,7 +153,7 @@ public abstract class JacksonSnak implements Snak {
 	 *            new value
 	 */
 	@JsonIgnore
-	void setParentDocument(JacksonTermedDocument parentDocument) {
+	void setParentDocument(JacksonTermedStatementDocument parentDocument) {
 		this.parentDocument = parentDocument;
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonStatement.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonStatement.java
@@ -30,6 +30,7 @@ import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;
 import org.wikidata.wdtk.datamodel.interfaces.Claim;
+import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
 import org.wikidata.wdtk.datamodel.interfaces.Reference;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
@@ -70,10 +71,10 @@ public class JacksonStatement implements Statement {
 	 * serialization of statements, but is needed in WDTK as part of
 	 * {@link Claim}. Thus, it is necessary to set this information after each
 	 * deserialization using
-	 * {@link JacksonStatement#setParentDocument(JacksonItemDocument)}.
+	 * {@link JacksonStatement#setParentDocument(JacksonTermedStatementDocument)}.
 	 */
 	@JsonIgnore
-	JacksonItemDocument parentDocument;
+	JacksonTermedStatementDocument parentDocument;
 
 	/**
 	 * Rank of this statement.
@@ -139,7 +140,7 @@ public class JacksonStatement implements Statement {
 	 * @return the parent document of this statement
 	 */
 	@JsonIgnore
-	JacksonItemDocument getParentDocument() {
+	EntityDocument getParentDocument() {
 		return this.parentDocument;
 	}
 
@@ -153,7 +154,7 @@ public class JacksonStatement implements Statement {
 	 *            new value
 	 */
 	@JsonIgnore
-	void setParentDocument(JacksonItemDocument parentDocument) {
+	void setParentDocument(JacksonTermedStatementDocument parentDocument) {
 		this.parentDocument = parentDocument;
 
 		this.mainsnak.setParentDocument(parentDocument);

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonValueSnak.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonValueSnak.java
@@ -27,7 +27,7 @@ import org.wikidata.wdtk.datamodel.interfaces.SnakVisitor;
 import org.wikidata.wdtk.datamodel.interfaces.Value;
 import org.wikidata.wdtk.datamodel.interfaces.ValueSnak;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValue;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueItemId;
+import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueEntityId;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -110,8 +110,8 @@ public class JacksonValueSnak extends JacksonSnak implements ValueSnak {
 	@Override
 	void setParentDocument(JacksonTermedStatementDocument parentDocument) {
 		super.setParentDocument(parentDocument);
-		if (this.datavalue instanceof JacksonValueItemId) {
-			((JacksonValueItemId) this.datavalue)
+		if (this.datavalue instanceof JacksonValueEntityId) {
+			((JacksonValueEntityId) this.datavalue)
 					.setParentDocument(parentDocument);
 		}
 	}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonValueSnak.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonValueSnak.java
@@ -108,7 +108,7 @@ public class JacksonValueSnak extends JacksonSnak implements ValueSnak {
 	}
 
 	@Override
-	void setParentDocument(JacksonTermedDocument parentDocument) {
+	void setParentDocument(JacksonTermedStatementDocument parentDocument) {
 		super.setParentDocument(parentDocument);
 		if (this.datavalue instanceof JacksonValueItemId) {
 			((JacksonValueItemId) this.datavalue)

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonInnerEntityId.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonInnerEntityId.java
@@ -20,11 +20,8 @@ package org.wikidata.wdtk.datamodel.json.jackson.datavalues;
  * #L%
  */
 
-import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonMappingException;
 
 /**
  * This class represents the inner anonymous object in the JSON type of
@@ -68,11 +65,8 @@ public class JacksonInnerEntityId {
 	 * @param entityType
 	 *            (case-sensitive)
 	 * @param numericId
-	 * @throws JsonMappingException
-	 *             if an unsupported entity type is used
 	 */
-	public JacksonInnerEntityId(String entityType, int numericId)
-			throws JsonMappingException {
+	public JacksonInnerEntityId(String entityType, int numericId) {
 		setJsonEntityType(entityType);
 		this.numericId = numericId;
 	}
@@ -94,16 +88,9 @@ public class JacksonInnerEntityId {
 	 *
 	 * @param entityType
 	 *            new value
-	 * @throws JsonMappingException
-	 *             when using an entity type that is not supported yet
 	 */
 	@JsonProperty("entity-type")
-	public void setJsonEntityType(String entityType)
-			throws JsonMappingException {
-		if (!JSON_ENTITY_TYPE_ITEM.equals(entityType)) {
-			throw new JsonMappingException("Entities of type \"" + entityType
-					+ "\" are not supported as property values yet.");
-		}
+	public void setJsonEntityType(String entityType) {
 		this.entityType = entityType;
 	}
 
@@ -147,29 +134,6 @@ public class JacksonInnerEntityId {
 			return "Q" + this.numericId;
 		case JSON_ENTITY_TYPE_PROPERTY:
 			return "P" + this.numericId;
-		default:
-			throw new IllegalArgumentException("Entities of type \""
-					+ entityType + "\" are not supported in property values.");
-		}
-	}
-
-	/**
-	 * Returns the Wikidata Toolkit entity type string of the entity id encoded
-	 * in this value. For example, an id with entityType "item" is of type
-	 * {@link EntityIdValue#ET_ITEM}.
-	 *
-	 * @return the string id
-	 * @throws IllegalArgumentException
-	 *             if the entity type of this value is unknown and can thus not
-	 *             be mapped to a string id
-	 */
-	@JsonIgnore
-	public String getEntityType() throws IllegalArgumentException {
-		switch (entityType) {
-		case JSON_ENTITY_TYPE_ITEM:
-			return EntityIdValue.ET_ITEM;
-		case JSON_ENTITY_TYPE_PROPERTY:
-			return EntityIdValue.ET_PROPERTY;
 		default:
 			throw new IllegalArgumentException("Entities of type \""
 					+ entityType + "\" are not supported in property values.");

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonInnerEntityId.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonInnerEntityId.java
@@ -20,8 +20,11 @@ package org.wikidata.wdtk.datamodel.json.jackson.datavalues;
  * #L%
  */
 
+import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
+
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonMappingException;
 
 /**
  * This class represents the inner anonymous object in the JSON type of
@@ -32,15 +35,19 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  *
  */
 public class JacksonInnerEntityId {
-	// TODO replace IllegalArgumentException with a checked one
-	// NOTE make sure to adapt all methods, once more types than only
-	// "item" are supported
+	// TODO maybe replace IllegalArgumentException with a checked one; maybe do
+	// the check when the type is set
 
 	/**
 	 * The string used in JSON to denote the type of entity id values that are
 	 * items.
 	 */
 	public final static String JSON_ENTITY_TYPE_ITEM = "item";
+	/**
+	 * The string used in JSON to denote the type of entity id values that are
+	 * properties.
+	 */
+	public final static String JSON_ENTITY_TYPE_PROPERTY = "property";
 
 	@JsonProperty("entity-type")
 	private String entityType;
@@ -56,19 +63,17 @@ public class JacksonInnerEntityId {
 	}
 
 	/**
-	 * Constructor. The only known entity type so far is "item". In the future
-	 * "property" might also be available.
+	 * Constructor. Supported entity types so far are "item" and "property".
 	 *
 	 * @param entityType
 	 *            (case-sensitive)
 	 * @param numericId
-	 * @throws IllegalArgumentException
-	 *             if the entity type was unrecognized
+	 * @throws JsonMappingException
+	 *             if an unsupported entity type is used
 	 */
 	public JacksonInnerEntityId(String entityType, int numericId)
-			throws IllegalArgumentException {
-
-		setEntityType(entityType);
+			throws JsonMappingException {
+		setJsonEntityType(entityType);
 		this.numericId = numericId;
 	}
 
@@ -79,7 +84,7 @@ public class JacksonInnerEntityId {
 	 * @return the entity type string
 	 */
 	@JsonProperty("entity-type")
-	public String getEntityType() {
+	public String getJsonEntityType() {
 		return entityType;
 	}
 
@@ -89,16 +94,16 @@ public class JacksonInnerEntityId {
 	 *
 	 * @param entityType
 	 *            new value
+	 * @throws JsonMappingException
+	 *             when using an entity type that is not supported yet
 	 */
 	@JsonProperty("entity-type")
-	public void setEntityType(String entityType)
-			throws IllegalArgumentException {
-
+	public void setJsonEntityType(String entityType)
+			throws JsonMappingException {
 		if (!JSON_ENTITY_TYPE_ITEM.equals(entityType)) {
-			throw new IllegalArgumentException("Entities of type " + entityType
-					+ " are not supported in property values.");
+			throw new JsonMappingException("Entities of type \"" + entityType
+					+ "\" are not supported as property values yet.");
 		}
-
 		this.entityType = entityType;
 	}
 
@@ -114,7 +119,7 @@ public class JacksonInnerEntityId {
 	}
 
 	/**
-	 * Sets thenumeric item id to the given value. Only for use by Jackson
+	 * Sets the numeric item id to the given value. Only for use by Jackson
 	 * during deserialization.
 	 *
 	 * @param numericId
@@ -131,10 +136,44 @@ public class JacksonInnerEntityId {
 	 * normally identified as "Q42".
 	 *
 	 * @return the string id
+	 * @throws IllegalArgumentException
+	 *             if the entity type of this value is unknown and can thus not
+	 *             be mapped to a string id
 	 */
 	@JsonIgnore
-	public String getStringId() {
-		return "Q" + this.numericId;
+	public String getStringId() throws IllegalArgumentException {
+		switch (entityType) {
+		case JSON_ENTITY_TYPE_ITEM:
+			return "Q" + this.numericId;
+		case JSON_ENTITY_TYPE_PROPERTY:
+			return "P" + this.numericId;
+		default:
+			throw new IllegalArgumentException("Entities of type \""
+					+ entityType + "\" are not supported in property values.");
+		}
+	}
+
+	/**
+	 * Returns the Wikidata Toolkit entity type string of the entity id encoded
+	 * in this value. For example, an id with entityType "item" is of type
+	 * {@link EntityIdValue#ET_ITEM}.
+	 *
+	 * @return the string id
+	 * @throws IllegalArgumentException
+	 *             if the entity type of this value is unknown and can thus not
+	 *             be mapped to a string id
+	 */
+	@JsonIgnore
+	public String getEntityType() throws IllegalArgumentException {
+		switch (entityType) {
+		case JSON_ENTITY_TYPE_ITEM:
+			return EntityIdValue.ET_ITEM;
+		case JSON_ENTITY_TYPE_PROPERTY:
+			return EntityIdValue.ET_PROPERTY;
+		default:
+			throw new IllegalArgumentException("Entities of type \""
+					+ entityType + "\" are not supported in property values.");
+		}
 	}
 
 	@Override

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonInnerGlobeCoordinates.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonInnerGlobeCoordinates.java
@@ -13,9 +13,9 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonInnerMonolingualText.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonInnerMonolingualText.java
@@ -11,9 +11,9 @@ import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonInnerQuantity.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonInnerQuantity.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.json.jackson.datavalues;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonValue.java
@@ -23,9 +23,7 @@ package org.wikidata.wdtk.datamodel.json.jackson.datavalues;
 import org.wikidata.wdtk.datamodel.interfaces.Value;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Abstract Jackson implementation of {@link Value}.
@@ -33,14 +31,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
  * @author Fredo Erxleben
  *
  */
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
-@JsonSubTypes({
-		@Type(value = JacksonValueString.class, name = "string"),
-		@Type(value = JacksonValueTime.class, name = "time"),
-		@Type(value = JacksonValueItemId.class, name = "wikibase-entityid"),
-		@Type(value = JacksonValueGlobeCoordinates.class, name = "globecoordinate"),
-		@Type(value = JacksonValueQuantity.class, name = "quantity"),
-		@Type(value = JacksonValueMonolingualText.class, name = "monolingualtext") })
+@JsonDeserialize(using = JacksonValueDeserializer.class)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class JacksonValue implements Value {
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonValueDeserializer.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonValueDeserializer.java
@@ -1,0 +1,114 @@
+package org.wikidata.wdtk.datamodel.json.jackson.datavalues;
+
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+/**
+ * Custom Jackson deserializer that maps the JSON representation of Wikibase
+ * values to WDTK classes. In most cases, the class to use is defined by the
+ * value of the "type" field, but for entities one has to look deeper into the
+ * structure to get the "entity-type" field as well. This is not possible using
+ * simpler mechanisms.
+ *
+ * @author Markus Kroetzsch
+ *
+ */
+public class JacksonValueDeserializer extends StdDeserializer<JacksonValue> {
+
+	/**
+	 *
+	 */
+	private static final long serialVersionUID = -2851517075035995962L;
+
+	/**
+	 * Constructor.
+	 */
+	public JacksonValueDeserializer() {
+		super(JacksonValue.class);
+	}
+
+	@Override
+	public JacksonValue deserialize(JsonParser jsonParser,
+			DeserializationContext ctxt) throws IOException,
+			JsonProcessingException {
+
+		ObjectMapper mapper = (ObjectMapper) jsonParser.getCodec();
+		JsonNode root = mapper.readTree(jsonParser);
+		Class<? extends JacksonValue> valueClass = getValueClass(root);
+
+		return mapper.treeToValue(root, valueClass);
+	}
+
+	/**
+	 * Finds the Java class to use for deserializing the JSON structure
+	 * represented by the given node.
+	 *
+	 * @param jsonNode
+	 *            the JSON node that represents the value to deserialize
+	 * @return the Java class to use for deserialization
+	 * @throws JsonMappingException
+	 *             if we do not have a class for the given JSON
+	 */
+	private Class<? extends JacksonValue> getValueClass(JsonNode jsonNode)
+			throws JsonMappingException {
+		String jsonType = jsonNode.get("type").asText();
+
+		switch (jsonType) {
+		case JacksonValue.JSON_VALUE_TYPE_ENTITY_ID:
+			JsonNode valueNode = jsonNode.get("value");
+			if (valueNode != null) {
+				String entityType = valueNode.get("entity-type").asText();
+				switch (entityType) {
+				case JacksonInnerEntityId.JSON_ENTITY_TYPE_ITEM:
+					return JacksonValueItemId.class;
+				case JacksonInnerEntityId.JSON_ENTITY_TYPE_PROPERTY:
+					return JacksonValuePropertyId.class;
+				default:
+					throw new JsonMappingException("Entities of type \""
+							+ entityType
+							+ "\" are not supported as property values yet.");
+				}
+			}
+		case JacksonValue.JSON_VALUE_TYPE_STRING:
+			return JacksonValueString.class;
+		case JacksonValue.JSON_VALUE_TYPE_TIME:
+			return JacksonValueTime.class;
+		case JacksonValue.JSON_VALUE_TYPE_GLOBE_COORDINATES:
+			return JacksonValueGlobeCoordinates.class;
+		case JacksonValue.JSON_VALUE_TYPE_QUANTITY:
+			return JacksonValueQuantity.class;
+		case JacksonValue.JSON_VALUE_TYPE_MONOLINGUAL_TEXT:
+			return JacksonValueMonolingualText.class;
+		default:
+			throw new JsonMappingException("Property values of type \""
+					+ jsonType + "\" are not supported yet.");
+		}
+	}
+}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonValueEntityId.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonValueEntityId.java
@@ -1,0 +1,121 @@
+package org.wikidata.wdtk.datamodel.json.jackson.datavalues;
+
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
+import org.wikidata.wdtk.datamodel.json.jackson.JacksonTermedStatementDocument;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+/**
+ * Abstract base implementation of {@link EntityIdValue} for Jackson.
+ *
+ * @author Markus Kroetzsch
+ *
+ */
+public abstract class JacksonValueEntityId extends JacksonValue implements
+		EntityIdValue {
+
+	/**
+	 * The parent document that this value is part of. This is needed since the
+	 * site that this value refers to is not part of the JSON serialization of
+	 * value, but is needed in WDTK to build all current types of
+	 * {@link EntityIdValue} objects. Thus, it is necessary to set this
+	 * information after each deserialization using
+	 * {@link JacksonValueEntityId#setParentDocument(JacksonTermedStatementDocument)}
+	 * .
+	 */
+	@JsonIgnore
+	JacksonTermedStatementDocument parentDocument;
+
+	/**
+	 * Inner helper object to store the actual data. Used to get the nested JSON
+	 * structure that is required here.
+	 */
+	protected JacksonInnerEntityId value;
+
+	/**
+	 * Constructor. Creates an empty object that can be populated during JSON
+	 * deserialization. Should only be used by Jackson for this very purpose.
+	 */
+	public JacksonValueEntityId() {
+		super(JSON_VALUE_TYPE_ENTITY_ID);
+	}
+
+	/**
+	 * Returns the inner value helper object. Only for use by Jackson during
+	 * serialization.
+	 *
+	 * @return the inner entity id value
+	 */
+	public JacksonInnerEntityId getValue() {
+		return value;
+	}
+
+	/**
+	 * Sets the inner value helper object to the given value. Only for use by
+	 * Jackson during deserialization.
+	 *
+	 * @param value
+	 *            new value
+	 */
+	public void setValue(JacksonInnerEntityId value) {
+		this.value = value;
+	}
+
+	@JsonIgnore
+	@Override
+	public String getIri() {
+		return this.getSiteIri().concat(this.getId());
+	}
+
+	@JsonIgnore
+	@Override
+	public String getId() {
+		return this.value.getStringId();
+	}
+
+	@JsonIgnore
+	@Override
+	public String getSiteIri() {
+		if (this.parentDocument != null
+				&& this.parentDocument.getSiteIri() != null) {
+			return this.parentDocument.getSiteIri();
+		} else {
+			throw new RuntimeException(
+					"Cannot access the site IRI id of an insufficiently initialised Jackson value.");
+		}
+	}
+
+	/**
+	 * Sets the parent document of this value to the given value. This document
+	 * provides the value with information about its site IRI, which is not part
+	 * of the JSON serialization of values. This method should only be used
+	 * during deserialization.
+	 *
+	 * @param parentDocument
+	 *            new value
+	 */
+	@JsonIgnore
+	public void setParentDocument(JacksonTermedStatementDocument parentDocument) {
+		this.parentDocument = parentDocument;
+	}
+}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonValueGlobeCoordinates.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonValueGlobeCoordinates.java
@@ -28,6 +28,8 @@ import org.wikidata.wdtk.datamodel.interfaces.ValueVisitor;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonDeserializer.None;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Jackson implementation of {@link GlobeCoordinatesValue}.
@@ -36,6 +38,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  *
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonDeserialize(using = None.class)
 public class JacksonValueGlobeCoordinates extends JacksonValue implements
 		GlobeCoordinatesValue {
 
@@ -77,19 +80,19 @@ public class JacksonValueGlobeCoordinates extends JacksonValue implements
 	@JsonIgnore
 	@Override
 	public long getLatitude() {
-		return (long)(this.value.getLatitude() * GlobeCoordinatesValue.PREC_DEGREE);
+		return (long) (this.value.getLatitude() * GlobeCoordinatesValue.PREC_DEGREE);
 	}
 
 	@JsonIgnore
 	@Override
 	public long getLongitude() {
-		return (long)(this.value.getLongitude() * GlobeCoordinatesValue.PREC_DEGREE);
+		return (long) (this.value.getLongitude() * GlobeCoordinatesValue.PREC_DEGREE);
 	}
 
 	@JsonIgnore
 	@Override
 	public long getPrecision() {
-		return (long)(this.value.getPrecision() * GlobeCoordinatesValue.PREC_DEGREE);
+		return (long) (this.value.getPrecision() * GlobeCoordinatesValue.PREC_DEGREE);
 	}
 
 	@JsonIgnore

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonValueItemId.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonValueItemId.java
@@ -7,7 +7,7 @@ import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ValueVisitor;
 import org.wikidata.wdtk.datamodel.json.jackson.JacksonItemDocument;
-import org.wikidata.wdtk.datamodel.json.jackson.JacksonTermedDocument;
+import org.wikidata.wdtk.datamodel.json.jackson.JacksonTermedStatementDocument;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -50,7 +50,7 @@ public class JacksonValueItemId extends JacksonValue implements ItemIdValue {
 	 * {@link JacksonValueItemId#setParentDocument(JacksonItemDocument)}.
 	 */
 	@JsonIgnore
-	JacksonTermedDocument parentDocument;
+	JacksonTermedStatementDocument parentDocument;
 
 	/**
 	 * Inner helper object to store the actual data. Used to get the nested JSON
@@ -96,7 +96,7 @@ public class JacksonValueItemId extends JacksonValue implements ItemIdValue {
 	@JsonIgnore
 	@Override
 	public String getId() {
-		return value.getStringId();
+		return this.value.getStringId();
 	}
 
 	@JsonIgnore
@@ -127,7 +127,7 @@ public class JacksonValueItemId extends JacksonValue implements ItemIdValue {
 	 *            new value
 	 */
 	@JsonIgnore
-	public void setParentDocument(JacksonTermedDocument parentDocument) {
+	public void setParentDocument(JacksonTermedStatementDocument parentDocument) {
 		this.parentDocument = parentDocument;
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonValueItemId.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonValueItemId.java
@@ -6,11 +6,11 @@ import org.wikidata.wdtk.datamodel.helpers.ToString;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ValueVisitor;
-import org.wikidata.wdtk.datamodel.json.jackson.JacksonItemDocument;
-import org.wikidata.wdtk.datamodel.json.jackson.JacksonTermedStatementDocument;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonDeserializer.None;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /*
  * #%L
@@ -33,48 +33,15 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  */
 
 /**
- * Jackson implementation of {@link ItemIdValue}. So far this is the only kind
- * of {@link EntityIdValue} that can occur as a value of properties.
+ * Jackson implementation of {@link ItemIdValue}.
  *
  * @author Fredo Erxleben
  *
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class JacksonValueItemId extends JacksonValue implements ItemIdValue {
-
-	/**
-	 * The parent document that this value is part of. This is needed since the
-	 * site that this value refers to is not part of the JSON serialization of
-	 * value, but is needed in WDTK to build {@link ItemIdValue} objects. Thus,
-	 * it is necessary to set this information after each deserialization using
-	 * {@link JacksonValueItemId#setParentDocument(JacksonItemDocument)}.
-	 */
-	@JsonIgnore
-	JacksonTermedStatementDocument parentDocument;
-
-	/**
-	 * Inner helper object to store the actual data. Used to get the nested JSON
-	 * structure that is required here.
-	 */
-	private JacksonInnerEntityId value;
-
-	/**
-	 * Constructor. Creates an empty object that can be populated during JSON
-	 * deserialization. Should only be used by Jackson for this very purpose.
-	 */
-	public JacksonValueItemId() {
-		super(JSON_VALUE_TYPE_ENTITY_ID);
-	}
-
-	/**
-	 * Returns the inner value helper object. Only for use by Jackson during
-	 * serialization.
-	 *
-	 * @return the inner entity id value
-	 */
-	public JacksonInnerEntityId getValue() {
-		return value;
-	}
+@JsonDeserialize(using = None.class)
+public class JacksonValueItemId extends JacksonValueEntityId implements
+		ItemIdValue {
 
 	/**
 	 * Sets the inner value helper object to the given value. Only for use by
@@ -83,52 +50,20 @@ public class JacksonValueItemId extends JacksonValue implements ItemIdValue {
 	 * @param value
 	 *            new value
 	 */
+	@Override
 	public void setValue(JacksonInnerEntityId value) {
-		this.value = value;
-	}
-
-	@JsonIgnore
-	@Override
-	public String getIri() {
-		return this.getSiteIri().concat(this.getId());
-	}
-
-	@JsonIgnore
-	@Override
-	public String getId() {
-		return this.value.getStringId();
-	}
-
-	@JsonIgnore
-	@Override
-	public String getSiteIri() {
-		if (this.parentDocument != null
-				&& this.parentDocument.getSiteIri() != null) {
-			return this.parentDocument.getSiteIri();
-		} else {
-			throw new RuntimeException(
-					"Cannot access the site IRI id of an insufficiently initialised Jackson value.");
+		if (!JacksonInnerEntityId.JSON_ENTITY_TYPE_ITEM.equals(value
+				.getJsonEntityType())) {
+			throw new RuntimeException("Unexpected inner value type: "
+					+ value.getJsonEntityType());
 		}
+		this.value = value;
 	}
 
 	@JsonIgnore
 	@Override
 	public String getEntityType() {
 		return EntityIdValue.ET_ITEM;
-	}
-
-	/**
-	 * Sets the parent document of this value to the given value. This document
-	 * provides the value with information about its site IRI, which is not part
-	 * of the JSON serialization of values. This method should only be used
-	 * during deserialization.
-	 *
-	 * @param parentDocument
-	 *            new value
-	 */
-	@JsonIgnore
-	public void setParentDocument(JacksonTermedStatementDocument parentDocument) {
-		this.parentDocument = parentDocument;
 	}
 
 	@Override

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonValueMonolingualText.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonValueMonolingualText.java
@@ -28,6 +28,8 @@ import org.wikidata.wdtk.datamodel.interfaces.ValueVisitor;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonDeserializer.None;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Jackson implementation of {@link MonolingualTextValue}. Java attributes are
@@ -42,6 +44,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  *
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonDeserialize(using = None.class)
 public class JacksonValueMonolingualText extends JacksonValue implements
 		MonolingualTextValue {
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonValuePropertyId.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonValuePropertyId.java
@@ -20,12 +20,11 @@ package org.wikidata.wdtk.datamodel.json.jackson.datavalues;
  * #L%
  */
 
-import java.math.BigDecimal;
-
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;
-import org.wikidata.wdtk.datamodel.interfaces.QuantityValue;
+import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ValueVisitor;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -34,28 +33,15 @@ import com.fasterxml.jackson.databind.JsonDeserializer.None;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /**
- * Jackson implementation of {@link QuantityValue}.
+ * Jackson implementation of {@link PropertyIdValue}.
  *
- * @author Fredo Erxleben
+ * @author Markus Kroetzsch
  *
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonDeserialize(using = None.class)
-public class JacksonValueQuantity extends JacksonValue implements QuantityValue {
-
-	/**
-	 * Inner helper object to store the actual data. Used to get the nested JSON
-	 * structure that is required here.
-	 */
-	private JacksonInnerQuantity value;
-
-	/**
-	 * Constructor. Creates an empty object that can be populated during JSON
-	 * deserialization. Should only be used by Jackson for this very purpose.
-	 */
-	public JacksonValueQuantity() {
-		super(JSON_VALUE_TYPE_QUANTITY);
-	}
+public class JacksonValuePropertyId extends JacksonValueEntityId implements
+		PropertyIdValue {
 
 	/**
 	 * Sets the inner value helper object to the given value. Only for use by
@@ -64,36 +50,20 @@ public class JacksonValueQuantity extends JacksonValue implements QuantityValue 
 	 * @param value
 	 *            new value
 	 */
-	public void setValue(JacksonInnerQuantity value) {
+	@Override
+	public void setValue(JacksonInnerEntityId value) {
+		if (!JacksonInnerEntityId.JSON_ENTITY_TYPE_PROPERTY.equals(value
+				.getJsonEntityType())) {
+			throw new RuntimeException("Unexpected inner value type: "
+					+ value.getJsonEntityType());
+		}
 		this.value = value;
 	}
 
-	/**
-	 * Returns the inner value helper object. Only for use by Jackson during
-	 * serialization.
-	 *
-	 * @return the inner quantity value
-	 */
-	public JacksonInnerQuantity getValue() {
-		return this.value;
-	}
-
 	@JsonIgnore
 	@Override
-	public BigDecimal getNumericValue() {
-		return this.value.getAmount();
-	}
-
-	@JsonIgnore
-	@Override
-	public BigDecimal getLowerBound() {
-		return this.value.getLowerBound();
-	}
-
-	@JsonIgnore
-	@Override
-	public BigDecimal getUpperBound() {
-		return this.value.getUpperBound();
+	public String getEntityType() {
+		return EntityIdValue.ET_PROPERTY;
 	}
 
 	@Override
@@ -108,7 +78,7 @@ public class JacksonValueQuantity extends JacksonValue implements QuantityValue 
 
 	@Override
 	public boolean equals(Object obj) {
-		return Equality.equalsQuantityValue(this, obj);
+		return Equality.equalsEntityIdValue(this, obj);
 	}
 
 	@Override

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonValueString.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonValueString.java
@@ -8,6 +8,8 @@ import org.wikidata.wdtk.datamodel.interfaces.ValueVisitor;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonDeserializer.None;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /*
  * #%L
@@ -36,6 +38,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  *
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonDeserialize(using = None.class)
 public class JacksonValueString extends JacksonValue implements StringValue {
 
 	private String value;

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonValueTime.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonValueTime.java
@@ -28,6 +28,8 @@ import org.wikidata.wdtk.datamodel.interfaces.ValueVisitor;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.JsonDeserializer.None;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Jackson implementation of {@link TimeValue}.
@@ -36,6 +38,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
  *
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonDeserialize(using = None.class)
 public class JacksonValueTime extends JacksonValue implements TimeValue {
 
 	/**

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/DumpProcessingTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/DumpProcessingTest.java
@@ -25,7 +25,7 @@ import java.io.IOException;
 
 import javax.swing.JFileChooser;
 
-import org.wikidata.wdtk.datamodel.json.jackson.JacksonTermedDocument;
+import org.wikidata.wdtk.datamodel.json.jackson.JacksonTermedStatementDocument;
 import org.wikidata.wdtk.datamodel.json.jackson.JacksonItemDocument;
 import org.wikidata.wdtk.datamodel.json.jackson.JacksonPropertyDocument;
 
@@ -47,7 +47,7 @@ public class DumpProcessingTest {
 	public static void main(String[] args){
 		
 		ObjectMapper mapper = new ObjectMapper();
-		ObjectReader reader = mapper.reader(JacksonTermedDocument.class);
+		ObjectReader reader = mapper.reader(JacksonTermedStatementDocument.class);
 		//ObjectReader propReader = mapper.reader(PropertyDocumentImpl.class);
 		
 		File dumpFile;
@@ -67,10 +67,10 @@ public class DumpProcessingTest {
 		int props = 0;
 		int lastReport = 0;
 		 try {
-			MappingIterator<JacksonTermedDocument> documentIter = reader.readValues(dumpFile);
+			MappingIterator<JacksonTermedStatementDocument> documentIter = reader.readValues(dumpFile);
 			
 			while(documentIter.hasNextValue()){
-				JacksonTermedDocument document = documentIter.nextValue();
+				JacksonTermedStatementDocument document = documentIter.nextValue();
 				if(document != null){ // TODO do more useful and thorough check here
 					processed++;
 					if(document instanceof JacksonItemDocument){

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImplTest.java
@@ -112,7 +112,8 @@ public class ItemDocumentImplTest {
 				"P42", "foo"), Collections.<MonolingualTextValue> emptyList(),
 				Collections.<MonolingualTextValue> emptyList(),
 				Collections.<MonolingualTextValue> emptyList(),
-				new DatatypeIdImpl(DatatypeIdValue.DT_STRING));
+				Collections.<StatementGroup> emptyList(), new DatatypeIdImpl(
+						DatatypeIdValue.DT_STRING));
 
 		// we need to use empty lists of Statement groups to test inequality
 		// based on different item ids with all other data being equal

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImplTest.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
@@ -54,11 +55,12 @@ public class PropertyDocumentImplTest {
 	List<MonolingualTextValue> labels;
 	List<MonolingualTextValue> descriptions;
 	List<MonolingualTextValue> aliases;
+	List<StatementGroup> statementGroups;
 	DatatypeIdValue datatypeId;
 
 	@Before
 	public void setUp() throws Exception {
-		pid = new PropertyIdValueImpl("P42", "http://wikibase.org/entity/");
+		pid = DataObjectFactoryImplTest.getTestPropertyIdValue(2);
 
 		labelMap = new HashMap<String, MonolingualTextValue>();
 		labelMap.put("en", new MonolingualTextValueImpl("Property 42", "en"));
@@ -90,12 +92,15 @@ public class PropertyDocumentImplTest {
 		aliases.add(alias2);
 		aliases.add(alias3);
 
+		statementGroups = DataObjectFactoryImplTest.getTestStatementGroups(2,
+				10, 3, EntityIdValue.ET_PROPERTY);
+
 		datatypeId = new DatatypeIdImpl(DatatypeIdValue.DT_ITEM);
 
 		pd1 = new PropertyDocumentImpl(pid, labels, descriptions, aliases,
-				datatypeId);
+				statementGroups, datatypeId);
 		pd2 = new PropertyDocumentImpl(pid, labels, descriptions, aliases,
-				datatypeId);
+				statementGroups, datatypeId);
 	}
 
 	@Test
@@ -111,19 +116,24 @@ public class PropertyDocumentImplTest {
 	@Test
 	public void equalityBasedOnContent() {
 		PropertyDocument pdDiffSubject = new PropertyDocumentImpl(
-				new PropertyIdValueImpl("P43", "http://wikibase.org/entity/"),
-				labels, descriptions, aliases, datatypeId);
+				DataObjectFactoryImplTest.getTestPropertyIdValue(3), labels,
+				descriptions, aliases,
+				DataObjectFactoryImplTest.getTestStatementGroups(3, 10, 3,
+						EntityIdValue.ET_PROPERTY), datatypeId);
 		PropertyDocument pdDiffLabels = new PropertyDocumentImpl(pid,
 				Collections.<MonolingualTextValue> emptyList(), descriptions,
-				aliases, datatypeId);
+				aliases, statementGroups, datatypeId);
 		PropertyDocument pdDiffDescriptions = new PropertyDocumentImpl(pid,
 				labels, Collections.<MonolingualTextValue> emptyList(),
-				aliases, datatypeId);
+				aliases, statementGroups, datatypeId);
 		PropertyDocument pdDiffAliases = new PropertyDocumentImpl(pid, labels,
 				descriptions, Collections.<MonolingualTextValue> emptyList(),
-				datatypeId);
+				statementGroups, datatypeId);
+		PropertyDocument pdDiffStatements = new PropertyDocumentImpl(pid,
+				labels, descriptions, aliases,
+				Collections.<StatementGroup> emptyList(), datatypeId);
 		PropertyDocument pdDiffDatatype = new PropertyDocumentImpl(pid, labels,
-				descriptions, aliases, new DatatypeIdImpl(
+				descriptions, aliases, statementGroups, new DatatypeIdImpl(
 						DatatypeIdValue.DT_STRING));
 
 		ItemDocument id = new ItemDocumentImpl(
@@ -137,6 +147,7 @@ public class PropertyDocumentImplTest {
 		assertThat(pd1, not(equalTo(pdDiffLabels)));
 		assertThat(pd1, not(equalTo(pdDiffDescriptions)));
 		assertThat(pd1, not(equalTo(pdDiffAliases)));
+		assertThat(pd1, not(equalTo(pdDiffStatements)));
 		assertThat(pd1, not(equalTo(pdDiffDatatype)));
 		assertFalse(pd1.equals(id));
 		assertThat(pd1, not(equalTo(null)));
@@ -151,27 +162,37 @@ public class PropertyDocumentImplTest {
 	@Test(expected = NullPointerException.class)
 	public void idNotNull() {
 		new PropertyDocumentImpl(null, labels, descriptions, aliases,
-				datatypeId);
+				statementGroups, datatypeId);
 	}
 
 	@Test(expected = NullPointerException.class)
 	public void labelsNotNull() {
-		new PropertyDocumentImpl(pid, null, descriptions, aliases, datatypeId);
+		new PropertyDocumentImpl(pid, null, descriptions, aliases,
+				statementGroups, datatypeId);
 	}
 
 	@Test(expected = NullPointerException.class)
 	public void descriptionsNotNull() {
-		new PropertyDocumentImpl(pid, labels, null, aliases, datatypeId);
+		new PropertyDocumentImpl(pid, labels, null, aliases, statementGroups,
+				datatypeId);
 	}
 
 	@Test(expected = NullPointerException.class)
 	public void aliasesNotNull() {
-		new PropertyDocumentImpl(pid, labels, descriptions, null, datatypeId);
+		new PropertyDocumentImpl(pid, labels, descriptions, null,
+				statementGroups, datatypeId);
+	}
+
+	@Test(expected = NullPointerException.class)
+	public void statementGroupsNotNull() {
+		new PropertyDocumentImpl(pid, labels, descriptions, aliases, null,
+				datatypeId);
 	}
 
 	@Test(expected = NullPointerException.class)
 	public void datatypeNotNull() {
-		new PropertyDocumentImpl(pid, labels, descriptions, aliases, null);
+		new PropertyDocumentImpl(pid, labels, descriptions, aliases,
+				statementGroups, null);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
@@ -181,7 +202,8 @@ public class PropertyDocumentImplTest {
 		labels2.add(new MonolingualTextValueImpl("Property 42 label duplicate",
 				"en"));
 
-		new PropertyDocumentImpl(pid, labels2, descriptions, aliases, null);
+		new PropertyDocumentImpl(pid, labels2, descriptions, aliases,
+				statementGroups, null);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
@@ -191,7 +213,8 @@ public class PropertyDocumentImplTest {
 		descriptions2.add(new MonolingualTextValueImpl(
 				"Noch eine Beschreibung fuer P42", "de"));
 
-		new PropertyDocumentImpl(pid, labels, descriptions2, aliases, null);
+		new PropertyDocumentImpl(pid, labels, descriptions2, aliases,
+				statementGroups, null);
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/json/jackson/JsonTestData.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/json/jackson/JsonTestData.java
@@ -37,6 +37,7 @@ import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValue;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueGlobeCoordinates;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueItemId;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueMonolingualText;
+import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValuePropertyId;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueQuantity;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueString;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueTime;
@@ -52,14 +53,13 @@ public class JsonTestData {
 
 	public static final DataObjectFactory JACKSON_OBJECT_FACTORY = new JacksonObjectFactory();
 
-	// TODO maybe decompose the time a bit to have less magic strings in it
+	// TODO maybe decompose the time a bit to have fewer magic strings in it
 
 	public static final String JSON_ENTITY_TYPE_ITEM = "item";
+	public static final String JSON_ENTITY_TYPE_PROPERTY = "property";
 
 	// the id's used in the tests
 	public static final String TEST_PROPERTY_ID = "P1";
-	public static final PropertyIdValue TEST_PROPERTY_ID_VALUE = Datamodel
-			.makeWikidataPropertyIdValue(TEST_PROPERTY_ID);
 	public static final String TEST_ITEM_ID = "Q1";
 	public static final int TEST_NUMERIC_ID = 1;
 	public static final String TEST_STATEMENT_ID = "statement_foobar";
@@ -71,9 +71,13 @@ public class JsonTestData {
 	// stand-alone descriptions of Value-parts
 	public static final String JSON_STRING_VALUE = "{\"type\":\""
 			+ JacksonValue.JSON_VALUE_TYPE_STRING + "\",\"value\":\"foobar\"}";
-	public static final String JSON_ENTITY_ID_VALUE = "{\"type\":\""
+	public static final String JSON_ITEM_ID_VALUE = "{\"type\":\""
 			+ JacksonValue.JSON_VALUE_TYPE_ENTITY_ID
 			+ "\",\"value\":{\"entity-type\":\"" + JSON_ENTITY_TYPE_ITEM
+			+ "\",\"numeric-id\":" + TEST_NUMERIC_ID + "}}";
+	public static final String JSON_PROPERTY_ID_VALUE = "{\"type\":\""
+			+ JacksonValue.JSON_VALUE_TYPE_ENTITY_ID
+			+ "\",\"value\":{\"entity-type\":\"" + JSON_ENTITY_TYPE_PROPERTY
 			+ "\",\"numeric-id\":" + TEST_NUMERIC_ID + "}}";
 	public static final String JSON_TIME_VALUE = "{\"type\":\""
 			+ JacksonValue.JSON_VALUE_TYPE_TIME
@@ -130,8 +134,10 @@ public class JsonTestData {
 
 	public static final JacksonValueString TEST_STRING_VALUE = (JacksonValueString) JACKSON_OBJECT_FACTORY
 			.getStringValue("foobar");
-	public static final JacksonValueItemId TEST_ENTITY_ID_VALUE = (JacksonValueItemId) JACKSON_OBJECT_FACTORY
+	public static final JacksonValueItemId TEST_ITEM_ID_VALUE = (JacksonValueItemId) JACKSON_OBJECT_FACTORY
 			.getItemIdValue("Q1", Datamodel.SITE_WIKIDATA);
+	public static final JacksonValuePropertyId TEST_PROPERTY_ID_VALUE = (JacksonValuePropertyId) JACKSON_OBJECT_FACTORY
+			.getPropertyIdValue("P1", Datamodel.SITE_WIKIDATA);
 	public static final JacksonValueTime TEST_TIME_VALUE = (JacksonValueTime) JACKSON_OBJECT_FACTORY
 			.getTimeValue(2013, (byte) 10, (byte) 28, (byte) 0, (byte) 0,
 					(byte) 0, (byte) 11, 0, 0, 0, TimeValue.CM_GREGORIAN_PRO);

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/json/jackson/TestInnerValueObjects.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/json/jackson/TestInnerValueObjects.java
@@ -28,6 +28,8 @@ import org.junit.Test;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonInnerEntityId;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonInnerMonolingualText;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
+
 /**
  * This class tests the inner objects lying behind the …ValueImpl-classes.
  *
@@ -43,7 +45,7 @@ public class TestInnerValueObjects {
 	private JacksonInnerMonolingualText testMonolingualText;
 
 	@Before
-	public void setupTestEntityIds() {
+	public void setupTestEntityIds() throws JsonMappingException {
 		this.testEntityId = new JacksonInnerEntityId(itemType, 1);
 	}
 
@@ -53,21 +55,22 @@ public class TestInnerValueObjects {
 				"foobar");
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testEntityIdConstructor() {
-		new JacksonInnerEntityId(wrongType, 1);
+	@Test(expected = JsonMappingException.class)
+	public void testEntityIdConstructor() throws JsonMappingException {
+		JacksonInnerEntityId testId = new JacksonInnerEntityId(wrongType, 1);
+		testId.getStringId(); // should fail
 	}
 
-	@Test(expected = IllegalArgumentException.class)
-	public void testEntityIdSetter() {
-		JacksonInnerEntityId emptyId = new JacksonInnerEntityId();
-		emptyId.setNumericId(1);
-		emptyId.setEntityType(itemType); // should work
-		emptyId.setEntityType(wrongType); // should fail
+	@Test(expected = JsonMappingException.class)
+	public void testEntityIdSetter() throws JsonMappingException {
+		JacksonInnerEntityId testId = new JacksonInnerEntityId();
+		testId.setNumericId(1);
+		testId.setJsonEntityType(wrongType);
+		testId.getStringId(); // should fail
 	}
 
 	@Test
-	public void testEntityIdMethods() {
+	public void testEntityIdMethods() throws JsonMappingException {
 		assertEquals("Q1", this.testEntityId.getStringId());
 		assertEquals(this.testEntityId.getNumericId(), 1);
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/json/jackson/TestInnerValueObjects.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/json/jackson/TestInnerValueObjects.java
@@ -55,13 +55,13 @@ public class TestInnerValueObjects {
 				"foobar");
 	}
 
-	@Test(expected = JsonMappingException.class)
+	@Test(expected = IllegalArgumentException.class)
 	public void testEntityIdConstructor() throws JsonMappingException {
 		JacksonInnerEntityId testId = new JacksonInnerEntityId(wrongType, 1);
 		testId.getStringId(); // should fail
 	}
 
-	@Test(expected = JsonMappingException.class)
+	@Test(expected = IllegalArgumentException.class)
 	public void testEntityIdSetter() throws JsonMappingException {
 		JacksonInnerEntityId testId = new JacksonInnerEntityId();
 		testId.setNumericId(1);

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/json/jackson/TestValue.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/json/jackson/TestValue.java
@@ -29,9 +29,10 @@ import java.io.IOException;
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonInnerTime;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValue;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueItemId;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueGlobeCoordinates;
+import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueItemId;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueMonolingualText;
+import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValuePropertyId;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueQuantity;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueString;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueTime;
@@ -67,25 +68,47 @@ public class TestValue {
 	}
 
 	@Test
-	public void testEntityIdValueToJson() throws JsonProcessingException {
+	public void testItemIdValueToJson() throws JsonProcessingException {
 		String result = mapper
-				.writeValueAsString(JsonTestData.TEST_ENTITY_ID_VALUE);
-		JsonComparator.compareJsonStrings(JsonTestData.JSON_ENTITY_ID_VALUE,
+				.writeValueAsString(JsonTestData.TEST_ITEM_ID_VALUE);
+		JsonComparator.compareJsonStrings(JsonTestData.JSON_ITEM_ID_VALUE,
 				result);
 	}
 
 	@Test
-	public void testEntityIdValueToJava() throws JsonParseException,
+	public void testItemIdValueToJava() throws JsonParseException,
 			JsonMappingException, IOException {
-		JacksonValue result = mapper.readValue(
-				JsonTestData.JSON_ENTITY_ID_VALUE, JacksonValue.class);
+		JacksonValue result = mapper.readValue(JsonTestData.JSON_ITEM_ID_VALUE,
+				JacksonValue.class);
 
 		assertNotNull(result);
 		assertTrue(result instanceof JacksonValueItemId);
 		assertEquals(result.getType(),
-				JsonTestData.TEST_ENTITY_ID_VALUE.getType());
+				JsonTestData.TEST_ITEM_ID_VALUE.getType());
 		assertEquals(((JacksonValueItemId) result).getValue(),
-				JsonTestData.TEST_ENTITY_ID_VALUE.getValue());
+				JsonTestData.TEST_ITEM_ID_VALUE.getValue());
+	}
+
+	@Test
+	public void testPropertyIdValueToJson() throws JsonProcessingException {
+		String result = mapper
+				.writeValueAsString(JsonTestData.TEST_PROPERTY_ID_VALUE);
+		JsonComparator.compareJsonStrings(JsonTestData.JSON_PROPERTY_ID_VALUE,
+				result);
+	}
+
+	@Test
+	public void testPropertyIdValueToJava() throws JsonParseException,
+			JsonMappingException, IOException {
+		JacksonValue result = mapper.readValue(
+				JsonTestData.JSON_PROPERTY_ID_VALUE, JacksonValue.class);
+
+		assertNotNull(result);
+		assertTrue(result instanceof JacksonValuePropertyId);
+		assertEquals(result.getType(),
+				JsonTestData.TEST_PROPERTY_ID_VALUE.getType());
+		assertEquals(((JacksonValuePropertyId) result).getValue(),
+				JsonTestData.TEST_PROPERTY_ID_VALUE.getValue());
 	}
 
 	@Test

--- a/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/DumpProcessingController.java
+++ b/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/DumpProcessingController.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.dumpfiles;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/JsonDumpFileProcessor.java
+++ b/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/JsonDumpFileProcessor.java
@@ -173,10 +173,12 @@ public class JsonDumpFileProcessor implements MwDumpFileProcessor {
 				handleDocument(document);
 			} catch (JsonProcessingException e) {
 				logJsonProcessingException(e);
+				JsonDumpFileProcessor.logger.error("Problematic line was: "
+						+ line.substring(0, Math.min(50, line.length()))
+						+ "...");
 			}
 
 			line = br.readLine();
 		}
 	}
-
 }

--- a/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/JsonDumpFileProcessor.java
+++ b/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/JsonDumpFileProcessor.java
@@ -20,14 +20,19 @@ package org.wikidata.wdtk.dumpfiles;
  * #L%
  */
 
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocumentProcessor;
 import org.wikidata.wdtk.datamodel.json.jackson.JacksonItemDocument;
 import org.wikidata.wdtk.datamodel.json.jackson.JacksonPropertyDocument;
-import org.wikidata.wdtk.datamodel.json.jackson.JacksonTermedDocument;
+import org.wikidata.wdtk.datamodel.json.jackson.JacksonTermedStatementDocument;
 
+import com.fasterxml.jackson.core.JsonParser.Feature;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -41,9 +46,12 @@ import com.fasterxml.jackson.databind.ObjectReader;
  */
 public class JsonDumpFileProcessor implements MwDumpFileProcessor {
 
+	static final Logger logger = LoggerFactory
+			.getLogger(JsonDumpFileProcessor.class);
+
 	private final ObjectMapper mapper = new ObjectMapper();
 	private final ObjectReader documentReader = mapper
-			.reader(JacksonTermedDocument.class);
+			.reader(JacksonTermedStatementDocument.class);
 
 	private final EntityDocumentProcessor entityDocumentProcessor;
 	private final String siteIri;
@@ -54,40 +62,116 @@ public class JsonDumpFileProcessor implements MwDumpFileProcessor {
 		this.siteIri = siteIri;
 	}
 
+	/**
+	 * Process dump file data from the given input stream. This method uses the
+	 * efficient Jackson {@link MappingIterator}. However, this class cannot
+	 * recover from processing errors. If an error occurs in one entity, the
+	 * (presumably) less efficient processing method
+	 * {@link #processDumpFileContentsRecovery(InputStream)} is used instead.
+	 *
+	 * @see MwDumpFileProcessor#processDumpFileContents(InputStream, MwDumpFile)
+	 */
 	@Override
 	public void processDumpFileContents(InputStream inputStream,
 			MwDumpFile dumpFile) {
 
 		try {
-			MappingIterator<JacksonTermedDocument> documentIterator = documentReader
-					.readValues(inputStream);
+			try {
+				MappingIterator<JacksonTermedStatementDocument> documentIterator = documentReader
+						.readValues(inputStream);
+				documentIterator.getParser().disable(Feature.AUTO_CLOSE_SOURCE);
 
-			while (documentIterator.hasNextValue()) {
-				JacksonTermedDocument document = documentIterator.nextValue();
-				document.setSiteIri(siteIri);
-				if (document != null) {
-					if (document instanceof JacksonItemDocument) {
-						this.handleItemDocument((JacksonItemDocument) document);
-					} else if (document instanceof JacksonPropertyDocument) {
-						this.handlePropertyDocument((JacksonPropertyDocument) document);
-					}
+				while (documentIterator.hasNextValue()) {
+					JacksonTermedStatementDocument document = documentIterator
+							.nextValue();
+					handleDocument(document);
 				}
+				documentIterator.close();
+			} catch (JsonProcessingException e) {
+				logJsonProcessingException(e);
+				processDumpFileContentsRecovery(inputStream);
 			}
-
-		} catch (JsonProcessingException e) {
-			e.printStackTrace();
 		} catch (IOException e) {
-			e.printStackTrace();
+			throw new RuntimeException("Cannot read JSON input: "
+					+ e.getMessage(), e);
 		}
 
 	}
 
-	private void handleItemDocument(JacksonItemDocument document) {
-		this.entityDocumentProcessor.processItemDocument(document);
+	/**
+	 * Reports the error of a JSON processing exception that was caught when
+	 * trying to read an entity.
+	 *
+	 * @param exception
+	 *            the exception to log
+	 */
+	private void logJsonProcessingException(JsonProcessingException exception) {
+		JsonDumpFileProcessor.logger
+				.error("Error when reading JSON for entity: "
+						+ exception.getMessage());
 	}
 
-	private void handlePropertyDocument(JacksonPropertyDocument document) {
-		this.entityDocumentProcessor.processPropertyDocument(document);
+	/**
+	 * Handles a {@link JacksonTermedStatementDocument} that was retrieved by
+	 * parsing the JSON input. It will call appropriate processing methods
+	 * depending on the type of document.
+	 *
+	 * @param document
+	 *            the document to process
+	 */
+	private void handleDocument(JacksonTermedStatementDocument document) {
+		document.setSiteIri(siteIri);
+		if (document != null) {
+			if (document instanceof JacksonItemDocument) {
+				this.entityDocumentProcessor
+						.processItemDocument((JacksonItemDocument) document);
+			} else if (document instanceof JacksonPropertyDocument) {
+				this.entityDocumentProcessor
+						.processPropertyDocument((JacksonPropertyDocument) document);
+			}
+		}
+	}
+
+	/**
+	 * Process dump file data from the given input stream. The method can
+	 * recover from an errors that occurred while processing an input stream,
+	 * which is assumed to contain the JSON serialization of a list of JSON
+	 * entities, with each entity serialization in one line. To recover from the
+	 * previous error, the first line is skipped.
+	 *
+	 * @param inputStream
+	 *            the stream to read from
+	 * @throws IOException
+	 *             if there is a problem reading the stream
+	 */
+	private void processDumpFileContentsRecovery(InputStream inputStream)
+			throws IOException {
+		JsonDumpFileProcessor.logger
+				.warn("Entering recovery mode to parse rest of file. This might be slightly slower.");
+
+		BufferedReader br = new BufferedReader(new InputStreamReader(
+				inputStream));
+
+		String line = br.readLine();
+		if (line.length() >= 100) {
+			line = line.substring(0, 100) + "[...]"
+					+ line.substring(line.length() - 50);
+		}
+		JsonDumpFileProcessor.logger.warn("Skipping rest of current line: "
+				+ line);
+
+		line = br.readLine();
+		while (line.length() > 1 && line != null) {
+			try {
+				JacksonTermedStatementDocument document = documentReader
+						.readValue(line.substring(0, line.length() - 1));
+				handleDocument(document);
+			} catch (JsonProcessingException e) {
+				logJsonProcessingException(e);
+			}
+
+			line = br.readLine();
+		}
 	}
 
 }

--- a/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/JsonDumpFileProcessor.java
+++ b/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/JsonDumpFileProcessor.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.dumpfiles;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -161,10 +161,15 @@ public class JsonDumpFileProcessor implements MwDumpFileProcessor {
 				+ line);
 
 		line = br.readLine();
-		while (line.length() > 1 && line != null) {
+		while (line != null && line.length() > 1) {
 			try {
-				JacksonTermedStatementDocument document = documentReader
-						.readValue(line.substring(0, line.length() - 1));
+				JacksonTermedStatementDocument document;
+				if (line.charAt(line.length() - 1) == ',') {
+					document = documentReader.readValue(line.substring(0,
+							line.length() - 1));
+				} else {
+					document = documentReader.readValue(line);
+				}
 				handleDocument(document);
 			} catch (JsonProcessingException e) {
 				logJsonProcessingException(e);

--- a/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/JsonDumpFileProcessor.java
+++ b/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/JsonDumpFileProcessor.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.dumpfiles;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -50,7 +50,7 @@ public class JsonDumpFileProcessor implements MwDumpFileProcessor {
 			.getLogger(JsonDumpFileProcessor.class);
 
 	private final ObjectMapper mapper = new ObjectMapper();
-	private final ObjectReader documentReader = mapper
+	private final ObjectReader documentReader = this.mapper
 			.reader(JacksonTermedStatementDocument.class);
 
 	private final EntityDocumentProcessor entityDocumentProcessor;

--- a/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/MwSitesDumpFileProcessor.java
+++ b/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/MwSitesDumpFileProcessor.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.dumpfiles;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/ExampleHelpers.java
+++ b/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/ExampleHelpers.java
@@ -49,7 +49,7 @@ public class ExampleHelpers {
 	 * If set to true, all example programs will run in offline mode. Only data
 	 * dumps that have been downloaded in previous runs will be used.
 	 */
-	public static final boolean OFFLINE_MODE = false;
+	public static final boolean OFFLINE_MODE = !false;
 
 	/**
 	 * Enum to say which dumps should be downloaded and processed. Used as

--- a/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/ExampleHelpers.java
+++ b/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/ExampleHelpers.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.examples;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -49,7 +49,7 @@ public class ExampleHelpers {
 	 * If set to true, all example programs will run in offline mode. Only data
 	 * dumps that have been downloaded in previous runs will be used.
 	 */
-	public static final boolean OFFLINE_MODE = !false;
+	public static final boolean OFFLINE_MODE = false;
 
 	/**
 	 * Enum to say which dumps should be downloaded and processed. Used as

--- a/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/RdfSerializationExample.java
+++ b/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/RdfSerializationExample.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.examples;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/OwlDeclarationBuffer.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/OwlDeclarationBuffer.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.rdf;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/RdfConverter.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/RdfConverter.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.rdf;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -41,6 +41,7 @@ import org.wikidata.wdtk.datamodel.interfaces.Sites;
 import org.wikidata.wdtk.datamodel.interfaces.Snak;
 import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
+import org.wikidata.wdtk.datamodel.interfaces.StatementDocument;
 import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
 import org.wikidata.wdtk.datamodel.interfaces.TermedDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ValueSnak;
@@ -201,17 +202,21 @@ public class RdfConverter {
 					this.rdfWriter.getUri(document.getDatatype().getIri()));
 		}
 
-		// Not needed for properties -- might change in future:
-		// this.snakRdfConverter.writeAuxiliaryTriples();
-		// this.owlDeclarationBuffer.writePropertyDeclarations(this.rdfWriter,
-		// hasTask(RdfSerializer.TASK_STATEMENTS),
-		// hasTask(RdfSerializer.TASK_SIMPLE_STATEMENTS));
-		// this.referenceRdfConverter.writeReferences();
+		if (hasTask(RdfSerializer.TASK_STATEMENTS)) {
+			writeStatements(subject, document);
+		}
+
+		this.snakRdfConverter.writeAuxiliaryTriples();
+		this.owlDeclarationBuffer.writePropertyDeclarations(this.rdfWriter,
+				hasTask(RdfSerializer.TASK_STATEMENTS),
+				hasTask(RdfSerializer.TASK_SIMPLE_STATEMENTS));
+		this.referenceRdfConverter.writeReferences();
 	}
 
-	void writeStatements(Resource subject, ItemDocument itemDocument)
+	void writeStatements(Resource subject, StatementDocument statementDocument)
 			throws RDFHandlerException {
-		for (StatementGroup statementGroup : itemDocument.getStatementGroups()) {
+		for (StatementGroup statementGroup : statementDocument
+				.getStatementGroups()) {
 			URI property = this.rdfWriter.getUri(Vocabulary.getPropertyUri(
 					statementGroup.getProperty(), PropertyContext.STATEMENT));
 			for (Statement statement : statementGroup.getStatements()) {
@@ -220,15 +225,18 @@ public class RdfConverter {
 			}
 		}
 
-		for (StatementGroup statementGroup : itemDocument.getStatementGroups()) {
+		for (StatementGroup statementGroup : statementDocument
+				.getStatementGroups()) {
 			for (Statement statement : statementGroup.getStatements()) {
 				writeStatement(statement);
 			}
 		}
 	}
 
-	void writeSimpleStatements(Resource subject, ItemDocument itemDocument) {
-		for (StatementGroup statementGroup : itemDocument.getStatementGroups()) {
+	void writeSimpleStatements(Resource subject,
+			StatementDocument statementDocument) {
+		for (StatementGroup statementGroup : statementDocument
+				.getStatementGroups()) {
 			for (Statement statement : statementGroup.getStatements()) {
 				if (statement.getClaim().getQualifiers().size() == 0) {
 					this.snakRdfConverter.setSnakContext(subject,
@@ -273,8 +281,8 @@ public class RdfConverter {
 
 	void writeSubclassOfStatements(Resource subject, ItemDocument itemDocument) {
 		for (StatementGroup statementGroup : itemDocument.getStatementGroups()) {
-			boolean isSubClassOf = "P279".equals(statementGroup
-					.getProperty().getId());
+			boolean isSubClassOf = "P279".equals(statementGroup.getProperty()
+					.getId());
 			boolean isInstanceOf = "P31".equals(statementGroup.getProperty()
 					.getId());
 			if (!isInstanceOf && !isSubClassOf) {

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/Vocabulary.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/Vocabulary.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.rdf;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/WikidataPropertyTypes.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/WikidataPropertyTypes.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.rdf;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
Support property statements; more robust JSON parsing

* Statements on property documents now supported in datamodel
* Parsing property statements from JSON supported
* more robust JSON dump parsing: recover from broken entities

This addresses issue #106.