### PR TITLE
Make bit vector more flexible

### DIFF
--- a/wdtk-storage/src/main/java/org/wikidata/wdtk/storage/datastructures/BitVectorImpl.java
+++ b/wdtk-storage/src/main/java/org/wikidata/wdtk/storage/datastructures/BitVectorImpl.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.storage.datastructures;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/wdtk-storage/src/main/java/org/wikidata/wdtk/storage/datastructures/BitVectorImpl.java
+++ b/wdtk-storage/src/main/java/org/wikidata/wdtk/storage/datastructures/BitVectorImpl.java
@@ -121,8 +121,7 @@ public class BitVectorImpl implements BitVector, Iterable<Boolean> {
 	 * @return the minimum array size for a bit vector of <i>bitVectorSize</i>
 	 */
 	static int getMinimumArraySize(long bitVectorSize) {
-		return Math.max(MINIMUM_ARRAY_SIZE,
-				(int) (bitVectorSize >> LG_WORD_SIZE) + 1);
+		return Math.max(MINIMUM_ARRAY_SIZE, getSizeInWords(bitVectorSize));
 	}
 
 	/**
@@ -156,22 +155,19 @@ public class BitVectorImpl implements BitVector, Iterable<Boolean> {
 	}
 
 	/**
-	 * @param newSize
-	 *            new size
-	 * @param arrayOfBitsLength
-	 *            length of the array of bits
-	 * @return <code>true</code> if and only if the new size would require to
-	 *         resize the array of bits
+	 * @param sizeInBits
+	 *            size in bits
+	 * @return the size in words
 	 */
-	boolean isResizeNeeded(long newSize, int arrayOfBitsLength) {
-		return (((newSize >> LG_WORD_SIZE) + 1) > arrayOfBitsLength);
+	static int getSizeInWords(long sizeInBits) {
+		return (int) ((sizeInBits >> LG_WORD_SIZE) + 1);
 	}
 
 	@Override
 	public boolean addBit(boolean bit) {
 		this.validHashCode = false;
 		this.size++;
-		if (isResizeNeeded(this.size, this.arrayOfBits.length)) {
+		if (getSizeInWords(this.size) > this.arrayOfBits.length) {
 			resizeArray(GROWTH_FACTOR * this.arrayOfBits.length);
 		}
 		setBit(this.size - 1, bit);
@@ -206,7 +202,8 @@ public class BitVectorImpl implements BitVector, Iterable<Boolean> {
 			this.validHashCode = false;
 			long newSize = position + 1;
 			int arrayOfBitsLength = this.arrayOfBits.length;
-			while (isResizeNeeded(newSize, arrayOfBitsLength)) {
+			int sizeInWords = getSizeInWords(newSize);
+			while (sizeInWords > arrayOfBitsLength) {
 				arrayOfBitsLength = GROWTH_FACTOR * arrayOfBitsLength;
 			}
 			resizeArray(arrayOfBitsLength);

--- a/wdtk-storage/src/main/java/org/wikidata/wdtk/storage/datastructures/BitVectorImpl.java
+++ b/wdtk-storage/src/main/java/org/wikidata/wdtk/storage/datastructures/BitVectorImpl.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.storage.datastructures;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,9 +35,9 @@ import org.apache.commons.lang3.Validate;
  * <li>any non-negative position outside the bit vector can be retrieved and
  * contains a <code>false</code>.</li>
  * </ol>
- * 
+ *
  * @author Julian Mendez
- * 
+ *
  */
 public class BitVectorImpl implements BitVector, Iterable<Boolean> {
 
@@ -54,7 +54,7 @@ public class BitVectorImpl implements BitVector, Iterable<Boolean> {
 
 	/**
 	 * Constructor of a bit vector of size 0.
-	 * 
+	 *
 	 */
 	public BitVectorImpl() {
 		this.arrayOfBits = new long[MINIMUM_ARRAY_SIZE];
@@ -62,7 +62,7 @@ public class BitVectorImpl implements BitVector, Iterable<Boolean> {
 
 	/**
 	 * Copy constructor of a bit vector.
-	 * 
+	 *
 	 * @param bitVector
 	 *            bit vector
 	 */
@@ -86,10 +86,10 @@ public class BitVectorImpl implements BitVector, Iterable<Boolean> {
 	/**
 	 * Constructor of a bit vector of size <i>initialSize</i>. The bit vector
 	 * contains <code>false</code> at all indexes.
-	 * 
+	 *
 	 * @param initialSize
 	 *            initial size of this bit vector
-	 * 
+	 *
 	 */
 	public BitVectorImpl(long initialSize) {
 		if (initialSize < 0) {
@@ -158,18 +158,20 @@ public class BitVectorImpl implements BitVector, Iterable<Boolean> {
 	/**
 	 * @param newSize
 	 *            new size
+	 * @param arrayOfBitsLength
+	 *            length of the array of bits
 	 * @return <code>true</code> if and only if the new size would require to
 	 *         resize the array of bits
 	 */
-	boolean isResizeNeeded(long newSize) {
-		return (((newSize >> LG_WORD_SIZE) + 1) > this.arrayOfBits.length);
+	boolean isResizeNeeded(long newSize, int arrayOfBitsLength) {
+		return (((newSize >> LG_WORD_SIZE) + 1) > arrayOfBitsLength);
 	}
 
 	@Override
 	public boolean addBit(boolean bit) {
 		this.validHashCode = false;
 		this.size++;
-		if (isResizeNeeded(this.size)) {
+		if (isResizeNeeded(this.size, this.arrayOfBits.length)) {
 			resizeArray(GROWTH_FACTOR * this.arrayOfBits.length);
 		}
 		setBit(this.size - 1, bit);
@@ -194,7 +196,7 @@ public class BitVectorImpl implements BitVector, Iterable<Boolean> {
 	 * Ensures that the bit vector is large enough to contain an element at the
 	 * given position. If the bit vector needs to be enlarged, new
 	 * <code>false</code> elements are added.
-	 * 
+	 *
 	 * @param position
 	 *            position
 	 */
@@ -203,9 +205,11 @@ public class BitVectorImpl implements BitVector, Iterable<Boolean> {
 		if (position >= this.size) {
 			this.validHashCode = false;
 			long newSize = position + 1;
-			while (isResizeNeeded(newSize)) {
-				resizeArray(GROWTH_FACTOR * this.arrayOfBits.length);
+			int arrayOfBitsLength = this.arrayOfBits.length;
+			while (isResizeNeeded(newSize, arrayOfBitsLength)) {
+				arrayOfBitsLength = GROWTH_FACTOR * arrayOfBitsLength;
 			}
+			resizeArray(arrayOfBitsLength);
 			this.size = newSize;
 		}
 	}
@@ -302,7 +306,7 @@ public class BitVectorImpl implements BitVector, Iterable<Boolean> {
 
 	/**
 	 * Resizes the array that represents this bit vector.
-	 * 
+	 *
 	 * @param newArraySize
 	 *            new array size
 	 */

--- a/wdtk-storage/src/main/java/org/wikidata/wdtk/storage/datastructures/BitVectorImpl.java
+++ b/wdtk-storage/src/main/java/org/wikidata/wdtk/storage/datastructures/BitVectorImpl.java
@@ -155,11 +155,21 @@ public class BitVectorImpl implements BitVector, Iterable<Boolean> {
 		return (new StringBuilder(binaryDigits)).reverse().toString();
 	}
 
+	/**
+	 * @param newSize
+	 *            new size
+	 * @return <code>true</code> if and only if the new size would require to
+	 *         resize the array of bits
+	 */
+	boolean isResizeNeeded(long newSize) {
+		return (((newSize >> LG_WORD_SIZE) + 1) > this.arrayOfBits.length);
+	}
+
 	@Override
 	public boolean addBit(boolean bit) {
 		this.validHashCode = false;
 		this.size++;
-		if (((this.size >> LG_WORD_SIZE) + 1) > this.arrayOfBits.length) {
+		if (isResizeNeeded(this.size)) {
 			resizeArray(GROWTH_FACTOR * this.arrayOfBits.length);
 		}
 		setBit(this.size - 1, bit);
@@ -190,8 +200,13 @@ public class BitVectorImpl implements BitVector, Iterable<Boolean> {
 	 */
 	void ensureSize(long position) {
 		assertNonNegativePosition(position);
-		while (position >= this.size) {
-			addBit(false);
+		if (position >= this.size) {
+			this.validHashCode = false;
+			long newSize = position + 1;
+			while (isResizeNeeded(newSize)) {
+				resizeArray(GROWTH_FACTOR * this.arrayOfBits.length);
+			}
+			this.size = newSize;
 		}
 	}
 

--- a/wdtk-storage/src/test/java/org/wikidata/wdtk/storage/datastructures/BitVectorImplTest.java
+++ b/wdtk-storage/src/test/java/org/wikidata/wdtk/storage/datastructures/BitVectorImplTest.java
@@ -22,9 +22,6 @@ package org.wikidata.wdtk.storage.datastructures;
 
 import org.junit.Assert;
 import org.junit.Test;
-import org.wikidata.wdtk.storage.datastructures.BitVector;
-import org.wikidata.wdtk.storage.datastructures.BitVectorImpl;
-import org.wikidata.wdtk.storage.datastructures.RankedBitVectorImpl;
 
 /**
  * Test class for {@link BitVectorImpl}.
@@ -163,6 +160,24 @@ public class BitVectorImplTest {
 		}
 	}
 
+	@Test
+	public void testGetOutOfRange() {
+		Assert.assertEquals(false, new BitVectorImpl().getBit(1));
+		Assert.assertEquals(false, new BitVectorImpl().getBit(Long.MAX_VALUE));
+	}
+
+	@Test
+	public void testSetOutOfRange() {
+		BitVectorImpl bv = new BitVectorImpl();
+		Assert.assertEquals(0, bv.size());
+		bv.setBit(41, true);
+		Assert.assertEquals(42, bv.size());
+		Assert.assertEquals(false, bv.getBit(40));
+		Assert.assertEquals(true, bv.getBit(41));
+		Assert.assertEquals(false, bv.getBit(42));
+		Assert.assertEquals(false, bv.getBit(43));
+	}
+
 	@Test(expected = IllegalArgumentException.class)
 	public void testInvalidInitialSize() {
 		new BitVectorImpl(-1);
@@ -175,16 +190,11 @@ public class BitVectorImplTest {
 
 	@Test(expected = IndexOutOfBoundsException.class)
 	public void testInvalidPositionSizeGet01() {
-		(new BitVectorImpl()).getBit(1);
-	}
-
-	@Test(expected = IndexOutOfBoundsException.class)
-	public void testInvalidPositionSizeGet02() {
 		BitVectorImpl.getBitInWord((byte) -1, 0);
 	}
 
 	@Test(expected = IndexOutOfBoundsException.class)
-	public void testInvalidPositionSizeGet03() {
+	public void testInvalidPositionSizeGet02() {
 		BitVectorImpl.getBitInWord((byte) 0x40, 0);
 	}
 


### PR DESCRIPTION
The purpose of these changes is to have a more flexible implementation of bit vector. This means that elements in non-negative positions outside the bit vector are considered 'false', and a bit can be directly stored at any non-negative position without the need of resizing the vector ( issue #125 ).