### PR TITLE
change http to https in the api url

### DIFF
--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/WikidataPropertyTypes.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/WikidataPropertyTypes.java
@@ -60,7 +60,7 @@ public class WikidataPropertyTypes implements PropertyTypes {
 	static final Logger logger = LoggerFactory
 			.getLogger(WikidataPropertyTypes.class);
 
-	final String WEB_API_URL = "http://www.wikidata.org/w/api.php";
+	final String WEB_API_URL = "https://www.wikidata.org/w/api.php";
 
 	final Map<String, String> propertyTypes;
 

--- a/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/WikidataPropertyTypesTest.java
+++ b/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/WikidataPropertyTypesTest.java
@@ -48,10 +48,10 @@ public class WikidataPropertyTypesTest {
 		MockWebResourceFetcher wrf = new MockWebResourceFetcher();
 		propertyTypes.webResourceFetcher = wrf;
 		wrf.setWebResourceContents(
-				"http://www.wikidata.org/w/api.php?action=wbgetentities&ids=P10&format=json&props=datatype",
+				"https://www.wikidata.org/w/api.php?action=wbgetentities&ids=P10&format=json&props=datatype",
 				"{\"entities\":{\"P10\":{\"id\":\"P10\",\"type\":\"property\",\"datatype\":\"commonsMedia\"}},\"success\":1}");
 		wrf.setWebResourceContents(
-				"http://www.wikidata.org/w/api.php?action=wbgetentities&ids=P1245&format=json&props=datatype",
+				"https://www.wikidata.org/w/api.php?action=wbgetentities&ids=P1245&format=json&props=datatype",
 				"{\"entities\":{\"P1245\":{\"id\":\"P1245\",\"type\":\"property\",\"datatype\":\"string\"}},\"success\":1}");
 	}
 


### PR DESCRIPTION
The Wikidata API only supports access over SSL (https) since recently. Since the DataResourceFetcher does not support redirects it is necessary to change http to https in the base URL.