### PR TITLE
Remove redundant modifiers

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DataObjectFactory.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DataObjectFactory.java
@@ -178,8 +178,8 @@ public interface DataObjectFactory {
 	 *            unit
 	 * @return a {@link QuantityValue} corresponding to the input
 	 */
-	public QuantityValue getQuantityValue(BigDecimal numericValue,
-			BigDecimal lowerBound, BigDecimal upperBound, String unit);
+	QuantityValue getQuantityValue(BigDecimal numericValue,
+								   BigDecimal lowerBound, BigDecimal upperBound, String unit);
 
 	/**
 	 * Creates a {@link ValueSnak}.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DataObjectFactory.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DataObjectFactory.java
@@ -161,7 +161,7 @@ public interface DataObjectFactory {
 	 *            the upper bound of the numeric value of this quantity
 	 * @return a {@link QuantityValue} corresponding to the input
 	 */
-	public QuantityValue getQuantityValue(BigDecimal numericValue,
+	QuantityValue getQuantityValue(BigDecimal numericValue,
 			BigDecimal lowerBound, BigDecimal upperBound);
 
 	/**
@@ -179,7 +179,7 @@ public interface DataObjectFactory {
 	 * @return a {@link QuantityValue} corresponding to the input
 	 */
 	QuantityValue getQuantityValue(BigDecimal numericValue,
-								   BigDecimal lowerBound, BigDecimal upperBound, String unit);
+			BigDecimal lowerBound, BigDecimal upperBound, String unit);
 
 	/**
 	 * Creates a {@link ValueSnak}.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DatatypeIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DatatypeIdValue.java
@@ -32,38 +32,38 @@ public interface DatatypeIdValue extends IriIdentifiedValue {
 	/**
 	 * IRI of the item datatype in Wikibase.
 	 */
-	static final String DT_ITEM = "http://www.wikidata.org/ontology#propertyTypeItem";
+	String DT_ITEM = "http://www.wikidata.org/ontology#propertyTypeItem";
 	/**
 	 * IRI of the property datatype in Wikibase.
 	 */
-	static final String DT_PROPERTY = "http://www.wikidata.org/ontology#propertyTypeProperty";
+	String DT_PROPERTY = "http://www.wikidata.org/ontology#propertyTypeProperty";
 	/**
 	 * IRI of the string datatype in Wikibase.
 	 */
-	static final String DT_STRING = "http://www.wikidata.org/ontology#propertyTypeString";
+	String DT_STRING = "http://www.wikidata.org/ontology#propertyTypeString";
 	/**
 	 * IRI of the URL datatype in Wikibase.
 	 */
-	static final String DT_URL = "http://www.wikidata.org/ontology#propertyTypeUrl";
+	String DT_URL = "http://www.wikidata.org/ontology#propertyTypeUrl";
 	/**
 	 * IRI of the Commons media datatype in Wikibase.
 	 */
-	static final String DT_COMMONS_MEDIA = "http://www.wikidata.org/ontology#propertyTypeCommonsMedia";
+	String DT_COMMONS_MEDIA = "http://www.wikidata.org/ontology#propertyTypeCommonsMedia";
 	/**
 	 * IRI of the time datatype in Wikibase.
 	 */
-	static final String DT_TIME = "http://www.wikidata.org/ontology#propertyTypeTime";
+	String DT_TIME = "http://www.wikidata.org/ontology#propertyTypeTime";
 	/**
 	 * IRI of the globe coordinates datatype in Wikibase.
 	 */
-	static final String DT_GLOBE_COORDINATES = "http://www.wikidata.org/ontology#propertyTypeGlobeCoordinates";
+	String DT_GLOBE_COORDINATES = "http://www.wikidata.org/ontology#propertyTypeGlobeCoordinates";
 	/**
 	 * IRI of the quantity datatype in Wikibase.
 	 */
-	static final String DT_QUANTITY = "http://www.wikidata.org/ontology#propertyTypeQuantity";
+	String DT_QUANTITY = "http://www.wikidata.org/ontology#propertyTypeQuantity";
 	/**
 	 * IRI of the monolingual text datatype in Wikibase.
 	 */
-	static final String DT_MONOLINGUAL_TEXT = "http://www.wikidata.org/ontology#propertyTypeMonolingualText";
+	String DT_MONOLINGUAL_TEXT = "http://www.wikidata.org/ontology#propertyTypeMonolingualText";
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/EntityIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/EntityIdValue.java
@@ -47,18 +47,18 @@ public interface EntityIdValue extends IriIdentifiedValue {
 	/**
 	 * IRI of the type of an entity that is an item.
 	 */
-	static final String ET_ITEM = "http://www.wikidata.org/ontology#Item";
+	String ET_ITEM = "http://www.wikidata.org/ontology#Item";
 	/**
 	 * IRI of the type of an entity that is a property.
 	 */
-	static final String ET_PROPERTY = "http://www.wikidata.org/ontology#Property";
+	String ET_PROPERTY = "http://www.wikidata.org/ontology#Property";
 	/**
 	 * The site IRI of "local" identifiers. These are used to mark internal ids
 	 * that are not found on any external site. Components that send data to
 	 * external services or that create data exports should omit such ids, if
 	 * possible.
 	 */
-	static public String SITE_LOCAL = "http://localhost/entity/";
+	String SITE_LOCAL = "http://localhost/entity/";
 
 	/**
 	 * Returns the type of this entity. This should be an IRI that identifies an

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/GlobeCoordinatesValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/GlobeCoordinatesValue.java
@@ -41,75 +41,75 @@ public interface GlobeCoordinatesValue extends Value {
 	/**
 	 * Precision constant for globe coordinates that are precise to ten degrees.
 	 */
-	static final double PREC_TEN_DEGREE = 10.0;
+	double PREC_TEN_DEGREE = 10.0;
 	/**
 	 * Precision constant for globe coordinates that are precise to the degree.
 	 */
-	static final double PREC_DEGREE = 1.0;
+	double PREC_DEGREE = 1.0;
 	/**
 	 * Precision constant for globe coordinates that are precise to the tenth of
 	 * a degree.
 	 */
-	static final double PREC_DECI_DEGREE = 0.1;
+	double PREC_DECI_DEGREE = 0.1;
 	/**
 	 * Precision constant for globe coordinates that are precise to the
 	 * arcminute.
 	 */
-	static final double PREC_ARCMINUTE = 1.0 / 60;
+	double PREC_ARCMINUTE = 1.0 / 60;
 	/**
 	 * Precision constant for globe coordinates that are precise to the
 	 * hundredth of a degree.
 	 */
-	static final double PREC_CENTI_DEGREE = 0.01;
+	double PREC_CENTI_DEGREE = 0.01;
 	/**
 	 * Precision constant for globe coordinates that are precise to the
 	 * thousandth of a degree.
 	 */
-	static final double PREC_MILLI_DEGREE = 0.001;
+	double PREC_MILLI_DEGREE = 0.001;
 	/**
 	 * Precision constant for globe coordinates that are precise to the
 	 * arcsecond.
 	 */
-	static final double PREC_ARCSECOND = 1.0 / 3600;
+	double PREC_ARCSECOND = 1.0 / 3600;
 	/**
 	 * Precision constant for globe coordinates that are precise to the
 	 * ten-thousandth of a degree.
 	 */
-	static final double PREC_HUNDRED_MICRO_DEGREE = 0.0001;
+	double PREC_HUNDRED_MICRO_DEGREE = 0.0001;
 	/**
 	 * Precision constant for globe coordinates that are precise to the tenth of
 	 * an arcsecond.
 	 */
-	static final double PREC_DECI_ARCSECOND = 1.0 / 36000;
+	double PREC_DECI_ARCSECOND = 1.0 / 36000;
 	/**
 	 * Precision constant for globe coordinates that are precise to the
 	 * hundred-thousandth of a degree.
 	 */
-	static final double PREC_TEN_MICRO_DEGREE = 0.00001;
+	double PREC_TEN_MICRO_DEGREE = 0.00001;
 	/**
 	 * Precision constant for globe coordinates that are precise to the
 	 * hundredth of an arcsecond.
 	 */
-	static final double PREC_CENTI_ARCSECOND = 1.0 / 360000;
+	double PREC_CENTI_ARCSECOND = 1.0 / 360000;
 	/**
 	 * Precision constant for globe coordinates that are precise to the
 	 * millionth of a degree.
 	 */
-	static final double PREC_MICRO_DEGREE = 0.000001;
+	double PREC_MICRO_DEGREE = 0.000001;
 	/**
 	 * Precision constant for globe coordinates that are precise to the
 	 * thousandth of an arcsecond.
 	 */
-	static final double PREC_MILLI_ARCSECOND = 1.0 / 3600000;
+	double PREC_MILLI_ARCSECOND = 1.0 / 3600000;
 
 	/**
 	 * IRI of the Earth. Used frequently to specify the globe.
 	 */
-	static final String GLOBE_EARTH = "http://www.wikidata.org/entity/Q2";
+	String GLOBE_EARTH = "http://www.wikidata.org/entity/Q2";
 	/**
 	 * IRI of the the Earth's Moon.
 	 */
-	static final String GLOBE_MOON = "http://www.wikidata.org/entity/Q405";
+	String GLOBE_MOON = "http://www.wikidata.org/entity/Q405";
 
 	/**
 	 * Get the latitude of this value in degrees. For Earth, the latitude value

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/ItemIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/ItemIdValue.java
@@ -34,7 +34,7 @@ public interface ItemIdValue extends EntityIdValue {
 	 * Fixed {@link ItemIdValue} that refers to a non-existing item. Can be used
 	 * as a placeholder object in situations where the entity id is irrelevant.
 	 */
-	static final ItemIdValue NULL = new ItemIdValue() {
+	ItemIdValue NULL = new ItemIdValue() {
 
 		@Override
 		public String getIri() {

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/PropertyIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/PropertyIdValue.java
@@ -34,7 +34,7 @@ public interface PropertyIdValue extends EntityIdValue {
 	 * be used as a placeholder object in situations where the entity id is
 	 * irrelevant.
 	 */
-	static final PropertyIdValue NULL = new PropertyIdValue() {
+	PropertyIdValue NULL = new PropertyIdValue() {
 
 		@Override
 		public String getIri() {

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/TimeValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/TimeValue.java
@@ -66,73 +66,73 @@ public interface TimeValue extends Value {
 	 * IRI of the proleptic Gregorian calendar; often used to specify the
 	 * calendar model
 	 */
-	static final String CM_GREGORIAN_PRO = "http://www.wikidata.org/entity/Q1985727";
+	String CM_GREGORIAN_PRO = "http://www.wikidata.org/entity/Q1985727";
 	/**
 	 * IRI of the proleptic Julian calendar; often used to specify the calendar
 	 * model
 	 */
-	static final String CM_JULIAN_PRO = "http://www.wikidata.org/entity/Q1985786";
+	String CM_JULIAN_PRO = "http://www.wikidata.org/entity/Q1985786";
 
 	/**
 	 * Precision constant for dates that are precise to the second.
 	 */
-	static final byte PREC_SECOND = 14;
+	byte PREC_SECOND = 14;
 	/**
 	 * Precision constant for dates that are precise to the minute.
 	 */
-	static final byte PREC_MINUTE = 13;
+	byte PREC_MINUTE = 13;
 	/**
 	 * Precision constant for dates that are precise to the hour.
 	 */
-	static final byte PREC_HOUR = 12;
+	byte PREC_HOUR = 12;
 	/**
 	 * Precision constant for dates that are precise to the day.
 	 */
-	static final byte PREC_DAY = 11;
+	byte PREC_DAY = 11;
 	/**
 	 * Precision constant for dates that are precise to the month.
 	 */
-	static final byte PREC_MONTH = 10;
+	byte PREC_MONTH = 10;
 	/**
 	 * Precision constant for dates that are precise to the year.
 	 */
-	static final byte PREC_YEAR = 9;
+	byte PREC_YEAR = 9;
 	/**
 	 * Precision constant for dates that are precise to the decade.
 	 */
-	static final byte PREC_DECADE = 8;
+	byte PREC_DECADE = 8;
 	/**
 	 * Precision constant for dates that are precise to 100 years.
 	 */
-	static final byte PREC_100Y = 7;
+	byte PREC_100Y = 7;
 	/**
 	 * Precision constant for dates that are precise to 1,000 years.
 	 */
-	static final byte PREC_1KY = 6;
+	byte PREC_1KY = 6;
 	/**
 	 * Precision constant for dates that are precise to 10,000 years.
 	 */
-	static final byte PREC_10KY = 5;
+	byte PREC_10KY = 5;
 	/**
 	 * Precision constant for dates that are precise to 100,000 years.
 	 */
-	static final byte PREC_100KY = 4;
+	byte PREC_100KY = 4;
 	/**
 	 * Precision constant for dates that are precise to 1 million years.
 	 */
-	static final byte PREC_1MY = 3;
+	byte PREC_1MY = 3;
 	/**
 	 * Precision constant for dates that are precise to 10 million years.
 	 */
-	static final byte PREC_10MY = 2;
+	byte PREC_10MY = 2;
 	/**
 	 * Precision constant for dates that are precise to 100 million years.
 	 */
-	static final byte PREC_100MY = 1;
+	byte PREC_100MY = 1;
 	/**
 	 * Precision constant for dates that are precise to 10^9 years.
 	 */
-	static final byte PREC_1GY = 0;
+	byte PREC_1GY = 0;
 
 	/**
 	 * Get the year stored for this date. Years in Wikibase can be 0; see "Y0K"

--- a/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/MwRevision.java
+++ b/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/MwRevision.java
@@ -32,19 +32,19 @@ public interface MwRevision {
 	 * The model used for MediaWiki revisions in traditional Wikitext. Revisions
 	 * with this format should always use "text/x-wiki" as their format.
 	 */
-	static final String MODEL_WIKITEXT = "wikitext";
+	String MODEL_WIKITEXT = "wikitext";
 	/**
 	 * The model used for MediaWiki revisions representing Wikibase items.
 	 * Revisions with this format should always use "application/json" as their
 	 * format.
 	 */
-	static final String MODEL_WIKIBASE_ITEM = "wikibase-item";
+	String MODEL_WIKIBASE_ITEM = "wikibase-item";
 	/**
 	 * The model used for MediaWiki revisions representing Wikibase properties.
 	 * Revisions with this format should always use "application/json" as their
 	 * format.
 	 */
-	static final String MODEL_WIKIBASE_PROPERTY = "wikibase-property";
+	String MODEL_WIKIBASE_PROPERTY = "wikibase-property";
 
 	/**
 	 * Returns the title string of the revised page, including namespace

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/extensions/ValueExportExtension.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/extensions/ValueExportExtension.java
@@ -30,15 +30,15 @@ import org.wikidata.wdtk.rdf.RdfWriter;
 /**
  * Classes that implement this interface export additional data for snaks with
  * certain values.
- * 
+ *
  * @author Markus Kroetzsch
- * 
+ *
  */
 public interface ValueExportExtension<V extends Value> {
 
 	/**
 	 * Writes additional RDF data for the given data.
-	 * 
+	 *
 	 * @param resource
 	 *            the subject for which to write the data
 	 * @param propertyIdValue
@@ -52,8 +52,8 @@ public interface ValueExportExtension<V extends Value> {
 	 * @throws RDFHandlerException
 	 *             if the data could not be written
 	 */
-	void writeExtensionData(Resource resource,
-							PropertyIdValue propertyIdValue, V value, RdfWriter rdfWriter,
-							OwlDeclarationBuffer owlDeclarationBuffer)
+	void writeExtensionData(Resource resource, PropertyIdValue propertyIdValue,
+			V value, RdfWriter rdfWriter,
+			OwlDeclarationBuffer owlDeclarationBuffer)
 			throws RDFHandlerException;
 }

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/extensions/ValueExportExtension.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/extensions/ValueExportExtension.java
@@ -52,8 +52,8 @@ public interface ValueExportExtension<V extends Value> {
 	 * @throws RDFHandlerException
 	 *             if the data could not be written
 	 */
-	public void writeExtensionData(Resource resource,
-			PropertyIdValue propertyIdValue, V value, RdfWriter rdfWriter,
-			OwlDeclarationBuffer owlDeclarationBuffer)
+	void writeExtensionData(Resource resource,
+							PropertyIdValue propertyIdValue, V value, RdfWriter rdfWriter,
+							OwlDeclarationBuffer owlDeclarationBuffer)
 			throws RDFHandlerException;
 }


### PR DESCRIPTION
Interface members can only be public, so specifying they are public is not needed.
Same for static and final.