### PR TITLE
Remove null check after method call on the object

### DIFF
--- a/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/JsonDumpFileProcessor.java
+++ b/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/JsonDumpFileProcessor.java
@@ -123,14 +123,12 @@ public class JsonDumpFileProcessor implements MwDumpFileProcessor {
 	 */
 	private void handleDocument(JacksonTermedStatementDocument document) {
 		document.setSiteIri(siteIri);
-		if (document != null) {
-			if (document instanceof JacksonItemDocument) {
-				this.entityDocumentProcessor
-						.processItemDocument((JacksonItemDocument) document);
-			} else if (document instanceof JacksonPropertyDocument) {
-				this.entityDocumentProcessor
-						.processPropertyDocument((JacksonPropertyDocument) document);
-			}
+		if (document instanceof JacksonItemDocument) {
+			this.entityDocumentProcessor
+					.processItemDocument((JacksonItemDocument) document);
+		} else if (document instanceof JacksonPropertyDocument) {
+			this.entityDocumentProcessor
+					.processPropertyDocument((JacksonPropertyDocument) document);
 		}
 	}
 


### PR DESCRIPTION
Perhaps a null check at the start of the method is needed (though not tested for)?