### PR TITLE
Adapt ExampleHelpers createDirection()

### DIFF
--- a/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/ExampleHelpers.java
+++ b/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/ExampleHelpers.java
@@ -216,7 +216,9 @@ public class ExampleHelpers {
 		if ("".equals(lastDumpFileName)) {
 			directoryPath = Paths.get(EXAMPLE_OUTPUT_DIRECTORY);
 		} else {
-			directoryPath = Paths.get(EXAMPLE_OUTPUT_DIRECTORY).resolve(
+			directoryPath = Paths.get(EXAMPLE_OUTPUT_DIRECTORY);
+			createDirectory(directoryPath);
+			directoryPath = directoryPath.resolve(
 					lastDumpFileName);
 		}
 


### PR DESCRIPTION
Files.createDirectory() throws a NoSuchFileException on Windows if the parent directory does not exist. This solution creates each part of a path separately.