### PR TITLE
add null check for headerCookies in fillCookies

### DIFF
--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/ApiConnection.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/ApiConnection.java
@@ -540,15 +540,17 @@ public class ApiConnection {
 	void fillCookies(Map<String, List<String>> headerFields) {
 		List<String> headerCookies = headerFields
 				.get(ApiConnection.HEADER_FIELD_SET_COOKIE);
-		for (String cookie : headerCookies) {
-			String[] cookieResponse = cookie.split(";\\p{Space}??");
-			for (String cookieLine : cookieResponse) {
-				String[] entry = cookieLine.split("=");
-				if (entry.length == 2) {
-					this.cookies.put(entry[0], entry[1]);
-				}
-				if (entry.length == 1) {
-					this.cookies.put(entry[0], "");
+		if (headerCookies != null) {
+			for (String cookie : headerCookies) {
+				String[] cookieResponse = cookie.split(";\\p{Space}??");
+				for (String cookieLine : cookieResponse) {
+					String[] entry = cookieLine.split("=");
+					if (entry.length == 2) {
+						this.cookies.put(entry[0], entry[1]);
+					}
+					if (entry.length == 1) {
+						this.cookies.put(entry[0], "");
+					}
 				}
 			}
 		}


### PR DESCRIPTION
This should fix the bug according to issue #217. If the header field Set-Cookie was not used headerCookies got null which caused a NullPointerException.