### PR TITLE
Wbsearchentities

### DIFF
--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/JacksonWbSearchEntitiesResult.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/JacksonWbSearchEntitiesResult.java
@@ -1,0 +1,380 @@
+package org.wikidata.wdtk.wikibaseapi;
+
+/*
+ * #%L
+ * Wikidata Toolkit Wikibase API
+ * %%
+ * Copyright (C) 2014 - 2016 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Jackson implementation of {@link WbSearchEntitiesResult}
+ *
+ * @author Sören Brunk
+ *
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class JacksonWbSearchEntitiesResult implements WbSearchEntitiesResult {
+	
+	/**
+	 * Jackson implementation of {@link Match}
+	 */
+	public static class JacksonMatch implements Match {
+		
+		public JacksonMatch() {}
+		
+		public JacksonMatch(String type, String language, String text) {
+			this.type = type;
+			this.language = language;
+			this.text = text;
+		}
+		/**
+		 * The type (field) of the matching term
+		 * e.g "entityId", "label" or "alias".
+		 */
+		@JsonProperty("type")
+		protected String type;
+		/**
+		 * Language of the matching term field.
+		 */
+		@JsonProperty("language")
+		protected String language;
+		/**
+		 * Text of the matching term.
+		 */
+		@JsonProperty("text")
+		protected String text;
+		
+		public String getType() {
+			return type;
+		}
+		
+		public void setType(String type) {
+			this.type = type;
+		}
+		
+		public String getLanguage() {
+			return language;
+		}
+		
+		public void setLanguage(String language) {
+			this.language = language;
+		}
+		
+		public String getText() {
+			return text;
+		}
+		
+		public void setText(String text) {
+			this.text = text;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result
+					+ ((language == null) ? 0 : language.hashCode());
+			result = prime * result + ((text == null) ? 0 : text.hashCode());
+			result = prime * result + ((type == null) ? 0 : type.hashCode());
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			JacksonMatch other = (JacksonMatch) obj;
+			if (language == null) {
+				if (other.language != null)
+					return false;
+			} else if (!language.equals(other.language))
+				return false;
+			if (text == null) {
+				if (other.text != null)
+					return false;
+			} else if (!text.equals(other.text))
+				return false;
+			if (type == null) {
+				if (other.type != null)
+					return false;
+			} else if (!type.equals(other.type))
+				return false;
+			return true;
+		}
+	}
+	
+	/**
+	 * Constructor. Creates an empty object that can be populated during JSON
+	 * deserialization. Should only be used by Jackson for this very purpose.
+	 */
+	public JacksonWbSearchEntitiesResult() {}
+	
+	/**
+	 * The id of the entity that the document refers to.
+	 */
+	@JsonProperty("id")
+	protected String entityId;
+	
+	/** 
+	 * The full concept URI (the site IRI with entity ID).
+	 */
+	@JsonProperty("concepturi")
+	protected String conceptUri;
+	
+	/** 
+	 * The URL of the wiki site that shows the concept.
+	 */
+	@JsonProperty("url")
+	protected String url;
+	
+	/**
+	 * Title of the entity (currently is the same as the entity ID).
+	 */
+	@JsonProperty("title")
+	protected String title;
+	
+	/**
+	 * The internal Mediawiki pageid of the entity.
+	 */
+	@JsonProperty("pageid")
+	protected long pageId;
+	
+	/**
+	 * Label of the entity
+	 * 
+	 * The language of the returned label depends on the HTTP
+	 * <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4">
+	 * Accept-Language header or the uselang URL parameter.
+	 */
+	@JsonProperty("label")
+	protected String label;
+	
+	/**
+	 * Description of the entity
+	 * 
+	 * The language of the returned description depends on the HTTP
+	 * <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4">
+	 * Accept-Language header or the uselang URL parameter.
+	 */
+	@JsonProperty("description")
+	protected String description;
+	
+	/**
+	 * Detailed information about how a document matched the query
+	 */
+	@JsonProperty("match")
+	protected JacksonMatch match;
+	
+	/**
+	 * A list of alias labels (returned only when an alias matched the query)
+	 */
+	@JsonProperty("aliases")
+	protected List<String> aliases;
+	
+	public void setEntityId(String id) {
+		this.entityId = id;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.wikidata.wdtk.wikibaseapi.IWbSearchInterfaceResult#getEntityId()
+	 */
+	@Override
+	public String getEntityId() {
+		return this.entityId;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.wikidata.wdtk.wikibaseapi.IWbSearchInterfaceResult#getConceptUri()
+	 */
+	@Override
+	public String getConceptUri() {
+		return conceptUri;
+	}
+
+	public void setConceptUri(String conceptUri) {
+		this.conceptUri = conceptUri;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.wikidata.wdtk.wikibaseapi.IWbSearchInterfaceResult#getUrl()
+	 */
+	@Override
+	public String getUrl() {
+		return url;
+	}
+
+	public void setUrl(String url) {
+		this.url = url;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.wikidata.wdtk.wikibaseapi.IWbSearchInterfaceResult#getTitle()
+	 */
+	@Override
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.wikidata.wdtk.wikibaseapi.IWbSearchInterfaceResult#getPageId()
+	 */
+	@Override
+	public long getPageId() {
+		return pageId;
+	}
+
+	public void setPageId(long pageId) {
+		this.pageId = pageId;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.wikidata.wdtk.wikibaseapi.IWbSearchInterfaceResult#getLabel()
+	 */
+	@Override
+	public String getLabel() {
+		return label;
+	}
+
+	public void setLabel(String label) {
+		this.label = label;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.wikidata.wdtk.wikibaseapi.IWbSearchInterfaceResult#getDescription()
+	 */
+	@Override
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+	
+	/* (non-Javadoc)
+	 * @see org.wikidata.wdtk.wikibaseapi.IWbSearchInterfaceResult#getMatch()
+	 */
+	@Override
+	public JacksonMatch getMatch() {
+		return match;
+	}
+
+	public void setMatch(JacksonMatch match) {
+		this.match = match;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.wikidata.wdtk.wikibaseapi.IWbSearchInterfaceResult#getAliases()
+	 */
+	@Override
+	public List<String> getAliases() {
+		return aliases;
+	}
+
+	public void setAliases(List<String> aliases) {
+		this.aliases = aliases;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((aliases == null) ? 0 : aliases.hashCode());
+		result = prime * result
+				+ ((conceptUri == null) ? 0 : conceptUri.hashCode());
+		result = prime * result
+				+ ((description == null) ? 0 : description.hashCode());
+		result = prime * result
+				+ ((entityId == null) ? 0 : entityId.hashCode());
+		result = prime * result + ((label == null) ? 0 : label.hashCode());
+		result = prime * result + ((match == null) ? 0 : match.hashCode());
+		result = prime * result + (int) (pageId ^ (pageId >>> 32));
+		result = prime * result + ((title == null) ? 0 : title.hashCode());
+		result = prime * result + ((url == null) ? 0 : url.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		JacksonWbSearchEntitiesResult other = (JacksonWbSearchEntitiesResult) obj;
+		if (aliases == null) {
+			if (other.aliases != null)
+				return false;
+		} else if (!aliases.equals(other.aliases))
+			return false;
+		if (conceptUri == null) {
+			if (other.conceptUri != null)
+				return false;
+		} else if (!conceptUri.equals(other.conceptUri))
+			return false;
+		if (description == null) {
+			if (other.description != null)
+				return false;
+		} else if (!description.equals(other.description))
+			return false;
+		if (entityId == null) {
+			if (other.entityId != null)
+				return false;
+		} else if (!entityId.equals(other.entityId))
+			return false;
+		if (label == null) {
+			if (other.label != null)
+				return false;
+		} else if (!label.equals(other.label))
+			return false;
+		if (match == null) {
+			if (other.match != null)
+				return false;
+		} else if (!match.equals(other.match))
+			return false;
+		if (pageId != other.pageId)
+			return false;
+		if (title == null) {
+			if (other.title != null)
+				return false;
+		} else if (!title.equals(other.title))
+			return false;
+		if (url == null) {
+			if (other.url != null)
+				return false;
+		} else if (!url.equals(other.url))
+			return false;
+		return true;
+	}
+
+
+}

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesAction.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesAction.java
@@ -1,0 +1,185 @@
+package org.wikidata.wdtk.wikibaseapi;
+
+/*
+ * #%L
+ * Wikidata Toolkit Wikibase API
+ * %%
+ * Copyright (C) 2014 - 2015 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Java implementation of the wbsearchentities action.
+ *
+ * @author Sören Brunk
+ *
+ */
+public class WbSearchEntitiesAction {
+
+	static final Logger logger = LoggerFactory
+			.getLogger(WbSearchEntitiesAction.class);
+
+	/**
+	 * Connection to a Wikibase API.
+	 */
+	final ApiConnection connection;
+
+	/**
+	 * The IRI that identifies the site that the data is from.
+	 */
+	final String siteIri;
+
+	/**
+	 * Mapper object used for deserializing JSON data.
+	 */
+	final ObjectMapper mapper = new ObjectMapper();
+
+	/**
+	 * Creates an object to fetch data from the given ApiConnection. The site
+	 * URI is necessary since it is not contained in the data retrieved from the
+	 * API.
+	 *
+	 * @param connection
+	 *            {@link ApiConnection} Object to send the requests
+	 * @param siteUri
+	 *            the URI identifying the site that is accessed (usually the
+	 *            prefix of entity URIs), e.g.,
+	 *            "http://www.wikidata.org/entity/"
+	 */
+	public WbSearchEntitiesAction(ApiConnection connection, String siteUri) {
+		this.connection = connection;
+		this.siteIri = siteUri;
+	}
+
+	/**
+	 * Executes the API action "wbsearchentity" for the given parameters.
+	 * Searches for entities using labels and aliases. Returns a label and
+	 * description for the entity in the user language if possible. Returns
+	 * details of the matched term. The matched term text is also present in the
+	 * aliases key if different from the display label.
+	 * 
+	 * <p>
+	 * See the <a href=
+	 * "https://www.wikidata.org/w/api.php?action=help&modules=wbsearchentity"
+	 * >online API documentation</a> for further information.
+	 * <p>
+	 * 
+	 * @param search
+	 *            (required) search for this text
+	 * @param language
+	 *            (required) search in this language
+	 * @param strictlanguage
+	 *            (optional) whether to disable language fallback
+	 * @param type
+	 *            (optional) search for this type of entity
+	 *            One of the following values: item, property
+	 *            Default: item
+	 * @param limit
+	 *            (optional) maximal number of results
+	 *            no more than 50 (500 for bots) allowed
+	 *            Default: 7
+	 * @param offset
+	 *            (optional) offset where to continue a search
+	 *            Default: 0
+	 *            this parameter is called "continue" in the API (which is a Java keyword)
+	 *
+	 * @return list of matching entities retrieved via the API URL
+	 * @throws MediaWikiApiErrorException
+	 *             if the API returns an error
+	 * @throws IllegalArgumentException
+	 *             if the given combination of parameters does not make sense
+	 */
+	public List<WbSearchEntitiesResult> wbSearchEntities(String search, String language,
+			Boolean strictLanguage, String type, Long limit, Long offset)
+			throws MediaWikiApiErrorException {
+
+		Map<String, String> parameters = new HashMap<String, String>();
+		parameters.put(ApiConnection.PARAM_ACTION, "wbsearchentities");
+		parameters.put(ApiConnection.PARAM_FORMAT, "json");
+
+		if (search != null) {
+			parameters.put("search", search);
+		} else {
+			throw new IllegalArgumentException(
+					"Search parameter must be specified for this action.");
+		}
+		
+		if (language != null) {
+			parameters.put("language", language);
+		} else {
+			throw new IllegalArgumentException(
+					"Language parameter must be specified for this action.");
+		}
+		if (strictLanguage != null) {
+			parameters.put("strictlanguage", Boolean.toString(strictLanguage));
+		}
+		
+		if (type != null) {
+			parameters.put("type", type);
+		}
+		
+		if (limit != null) {
+			parameters.put("limit", Long.toString(limit));
+		}
+		
+		if (offset != null) {
+			parameters.put("continue", Long.toString(offset));
+		}
+
+//		Map<String, EntityDocument> result = new HashMap<String, EntityDocument>();
+		List<WbSearchEntitiesResult> results = new ArrayList<>();
+
+		try (InputStream response = this.connection.sendRequest("POST",
+				parameters)) {
+			JsonNode root = mapper.readTree(response);
+
+			this.connection.checkErrors(root);
+			this.connection.logWarnings(root);
+
+			JsonNode entities = root.path("search");
+			for (JsonNode entityNode : entities) {
+				try {
+					WbSearchEntitiesResult ed = mapper.treeToValue(entityNode,
+							WbSearchEntitiesResult.class);
+					results.add(ed);
+				} catch (JsonProcessingException e) {
+					logger.error("Error when reading JSON for entity "
+							+ entityNode.path("id").asText("UNKNOWN") + ": "
+							+ e.toString());
+				}
+			}
+		} catch (IOException e) {
+			logger.error("Could not retrive data: " + e.toString());
+		}
+
+		return results;
+	}
+
+}

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesAction.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesAction.java
@@ -153,7 +153,6 @@ public class WbSearchEntitiesAction {
 			parameters.put("continue", Long.toString(offset));
 		}
 
-//		Map<String, EntityDocument> result = new HashMap<String, EntityDocument>();
 		List<WbSearchEntitiesResult> results = new ArrayList<>();
 
 		try (InputStream response = this.connection.sendRequest("POST",
@@ -166,8 +165,8 @@ public class WbSearchEntitiesAction {
 			JsonNode entities = root.path("search");
 			for (JsonNode entityNode : entities) {
 				try {
-					WbSearchEntitiesResult ed = mapper.treeToValue(entityNode,
-							WbSearchEntitiesResult.class);
+					JacksonWbSearchEntitiesResult ed = mapper.treeToValue(entityNode,
+							JacksonWbSearchEntitiesResult.class);
 					results.add(ed);
 				} catch (JsonProcessingException e) {
 					logger.error("Error when reading JSON for entity "

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesResult.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesResult.java
@@ -1,340 +1,109 @@
 package org.wikidata.wdtk.wikibaseapi;
 
-/*
- * #%L
- * Wikidata Toolkit Wikibase API
- * %%
- * Copyright (C) 2014 - 2016 Wikidata Toolkit Developers
- * %%
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * 
- *      http://www.apache.org/licenses/LICENSE-2.0
- * 
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * #L%
- */
-
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import org.wikidata.wdtk.wikibaseapi.JacksonWbSearchEntitiesResult.JacksonMatch;
 
 /**
- * Value class representing the result of a wbsearchentities action.
+ * Represents the result of a wbsearchentities action.
  *
  * @author Sören Brunk
- *
  */
-@JsonIgnoreProperties(ignoreUnknown = true)
-public class WbSearchEntitiesResult {
+public interface WbSearchEntitiesResult {
 	
 	/**
-	 * Class representing information about how a document matched the query
+	 * Represents information about how a document matched the query
 	 */
-	public static class Match  {
-		
-		public Match() {}
-		
-		public Match(String type, String language, String text) {
-			this.type = type;
-			this.language = language;
-			this.text = text;
-		}
+	public  interface Match  {	
 		/**
-		 * The type (field) of the matching term
-		 * e.g "entityId", "label" or "alias"
+		 * Returns the type (field) of the matching term
+		 * e.g "entityId", "label" or "alias".
+		 * 
+		 * @return type (field) of the match
 		 */
-		@JsonProperty("type")
-		protected String type = "";
-		/**
-		 * Language of the matching term field
-		 */
-		@JsonProperty("language")
-		protected String language = "";
-		/**
-		 * Text of the matching term
-		 */
-		@JsonProperty("text")
-		protected String text = "";
+		public String getType();
 		
-		public String getType() {
-			return type;
-		}
-		public void setType(String type) {
-			this.type = type;
-		}
-		public String getLanguage() {
-			return language;
-		}
-		public void setLanguage(String language) {
-			this.language = language;
-		}
-		public String getText() {
-			return text;
-		}
-		public void setText(String text) {
-			this.text = text;
-		}
-
-		@Override
-		public int hashCode() {
-			final int prime = 31;
-			int result = 1;
-			result = prime * result
-					+ ((language == null) ? 0 : language.hashCode());
-			result = prime * result + ((text == null) ? 0 : text.hashCode());
-			result = prime * result + ((type == null) ? 0 : type.hashCode());
-			return result;
-		}
-
-		@Override
-		public boolean equals(Object obj) {
-			if (this == obj)
-				return true;
-			if (obj == null)
-				return false;
-			if (getClass() != obj.getClass())
-				return false;
-			Match other = (Match) obj;
-			if (language == null) {
-				if (other.language != null)
-					return false;
-			} else if (!language.equals(other.language))
-				return false;
-			if (text == null) {
-				if (other.text != null)
-					return false;
-			} else if (!text.equals(other.text))
-				return false;
-			if (type == null) {
-				if (other.type != null)
-					return false;
-			} else if (!type.equals(other.type))
-				return false;
-			return true;
-		}
+		/**
+		 * Returns the language of the matching term field.
+		 * 
+		 * @return language of the match
+		 */
+		public String getLanguage();
+		/**
+		 * Returns the text of the matching term.
+		 * 
+		 * @return text of the match
+		 */
+		public String getText();
 	}
-	
+
 	/**
-	 * Constructor. Creates an empty object that can be populated during JSON
-	 * deserialization. Should only be used by Jackson for this very purpose.
+	 * Returns the id of the entity that the document refers to.
+	 * 
+	 * @return the entity ID
 	 */
-	public WbSearchEntitiesResult() {
-	}
-	
-	/**
-	 * The id of the entity that the document refers to.
-	 */
-	@JsonProperty("id")
-	protected String entityId = "";
-	
+	public abstract String getEntityId();
+
 	/** 
-	 * The full concept URI (the site IRI with entity ID) 
+	 * Returns the full concept URI (the site IRI with entity ID).
+	 * 
+	 * @return full concept URI
 	 */
-	@JsonProperty("concepturi")
-	protected String conceptUri = "";
-	
+	public abstract String getConceptUri();
+
 	/** 
-	 * The URL of the wiki site that shows the concept
+	 * The URL of the wiki site that shows the concept.
+	 * 
+	 * @return wiki site URL
 	 */
-	@JsonProperty("url")
-	protected String url = "";
-	
+	public abstract String getUrl();
+
 	/**
-	 * Title of the entity (currently is the same as the entity ID)
+	 * Returns the title of the entity (currently the same as the entity ID).
 	 */
-	@JsonProperty("title")
-	protected String title = "";
-	
+	public abstract String getTitle();
+
 	/**
-	 * The internal Mediawiki pageid of the entity
+	 * Returns the internal Mediawiki pageid of the entity.
+	 * 
+	 * @return internal pageid
 	 */
-	@JsonProperty("pageid")
-	protected long pageId = 0;
-	
+	public abstract long getPageId();
+
 	/**
-	 * Label of the entity
+	 * Returns the label of the entity.
 	 * 
 	 * The language of the returned label depends on the HTTP
 	 * <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4">
 	 * Accept-Language header or the uselang URL parameter.
+	 * 
+	 * @return the label of the entity
 	 */
-	@JsonProperty("label")
-	protected String label = "";
-	
+	public abstract String getLabel();
+
 	/**
-	 * Description of the entity
+	 * Returns the description of the entity
 	 * 
 	 * The language of the returned description depends on the HTTP
 	 * <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4">
 	 * Accept-Language header or the uselang URL parameter.
+	 * 
+	 * @return the description
 	 */
-	@JsonProperty("description")
-	protected String description = "";
-	
+	public abstract String getDescription();
+
 	/**
-	 * Detailed information about how a document matched the query
+	 * Returns detailed information about how a document matched the query.
+	 * 
+	 * @return match information
 	 */
-	@JsonProperty("match")
-	protected Match match;
-	
+	public abstract JacksonMatch getMatch();
+
 	/**
-	 * A list of alias labels (returned only when an alias matched the query)
+	 * A list of alias labels (returned only when an alias matched the query).
+	 * 
+	 * @ return a list of aliases
 	 */
-	@JsonProperty("aliases")
-	protected List<String> aliases;
-	
-	public void setEntityId(String id) {
-		this.entityId = id;
-	}
-
-	public String getEntityId() {
-		return this.entityId;
-	}
-
-	public String getConceptUri() {
-		return conceptUri;
-	}
-
-	public void setConceptUri(String conceptUri) {
-		this.conceptUri = conceptUri;
-	}
-
-	public String getUrl() {
-		return url;
-	}
-
-	public void setUrl(String url) {
-		this.url = url;
-	}
-
-	public String getTitle() {
-		return title;
-	}
-
-	public void setTitle(String title) {
-		this.title = title;
-	}
-
-	public long getPageId() {
-		return pageId;
-	}
-
-	public void setPageId(long pageId) {
-		this.pageId = pageId;
-	}
-
-	public String getLabel() {
-		return label;
-	}
-
-	public void setLabel(String label) {
-		this.label = label;
-	}
-
-	public String getDescription() {
-		return description;
-	}
-
-	public void setDescription(String description) {
-		this.description = description;
-	}
-	
-	public Match getMatch() {
-		return match;
-	}
-
-	
-	public void setMatch(Match match) {
-		this.match = match;
-	}
-
-	public List<String> getAliases() {
-		return aliases;
-	}
-
-	public void setAliases(List<String> aliases) {
-		this.aliases = aliases;
-	}
-
-	@Override
-	public int hashCode() {
-		final int prime = 31;
-		int result = 1;
-		result = prime * result + ((aliases == null) ? 0 : aliases.hashCode());
-		result = prime * result
-				+ ((conceptUri == null) ? 0 : conceptUri.hashCode());
-		result = prime * result
-				+ ((description == null) ? 0 : description.hashCode());
-		result = prime * result
-				+ ((entityId == null) ? 0 : entityId.hashCode());
-		result = prime * result + ((label == null) ? 0 : label.hashCode());
-		result = prime * result + ((match == null) ? 0 : match.hashCode());
-		result = prime * result + (int) (pageId ^ (pageId >>> 32));
-		result = prime * result + ((title == null) ? 0 : title.hashCode());
-		result = prime * result + ((url == null) ? 0 : url.hashCode());
-		return result;
-	}
-
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj)
-			return true;
-		if (obj == null)
-			return false;
-		if (getClass() != obj.getClass())
-			return false;
-		WbSearchEntitiesResult other = (WbSearchEntitiesResult) obj;
-		if (aliases == null) {
-			if (other.aliases != null)
-				return false;
-		} else if (!aliases.equals(other.aliases))
-			return false;
-		if (conceptUri == null) {
-			if (other.conceptUri != null)
-				return false;
-		} else if (!conceptUri.equals(other.conceptUri))
-			return false;
-		if (description == null) {
-			if (other.description != null)
-				return false;
-		} else if (!description.equals(other.description))
-			return false;
-		if (entityId == null) {
-			if (other.entityId != null)
-				return false;
-		} else if (!entityId.equals(other.entityId))
-			return false;
-		if (label == null) {
-			if (other.label != null)
-				return false;
-		} else if (!label.equals(other.label))
-			return false;
-		if (match == null) {
-			if (other.match != null)
-				return false;
-		} else if (!match.equals(other.match))
-			return false;
-		if (pageId != other.pageId)
-			return false;
-		if (title == null) {
-			if (other.title != null)
-				return false;
-		} else if (!title.equals(other.title))
-			return false;
-		if (url == null) {
-			if (other.url != null)
-				return false;
-		} else if (!url.equals(other.url))
-			return false;
-		return true;
-	}
-
+	public abstract List<String> getAliases();
 
 }

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesResult.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesResult.java
@@ -1,0 +1,340 @@
+package org.wikidata.wdtk.wikibaseapi;
+
+/*
+ * #%L
+ * Wikidata Toolkit Wikibase API
+ * %%
+ * Copyright (C) 2014 - 2016 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Value class representing the result of a wbsearchentities action.
+ *
+ * @author Sören Brunk
+ *
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class WbSearchEntitiesResult {
+	
+	/**
+	 * Class representing information about how a document matched the query
+	 */
+	public static class Match  {
+		
+		public Match() {}
+		
+		public Match(String type, String language, String text) {
+			this.type = type;
+			this.language = language;
+			this.text = text;
+		}
+		/**
+		 * The type (field) of the matching term
+		 * e.g "entityId", "label" or "alias"
+		 */
+		@JsonProperty("type")
+		protected String type = "";
+		/**
+		 * Language of the matching term field
+		 */
+		@JsonProperty("language")
+		protected String language = "";
+		/**
+		 * Text of the matching term
+		 */
+		@JsonProperty("text")
+		protected String text = "";
+		
+		public String getType() {
+			return type;
+		}
+		public void setType(String type) {
+			this.type = type;
+		}
+		public String getLanguage() {
+			return language;
+		}
+		public void setLanguage(String language) {
+			this.language = language;
+		}
+		public String getText() {
+			return text;
+		}
+		public void setText(String text) {
+			this.text = text;
+		}
+
+		@Override
+		public int hashCode() {
+			final int prime = 31;
+			int result = 1;
+			result = prime * result
+					+ ((language == null) ? 0 : language.hashCode());
+			result = prime * result + ((text == null) ? 0 : text.hashCode());
+			result = prime * result + ((type == null) ? 0 : type.hashCode());
+			return result;
+		}
+
+		@Override
+		public boolean equals(Object obj) {
+			if (this == obj)
+				return true;
+			if (obj == null)
+				return false;
+			if (getClass() != obj.getClass())
+				return false;
+			Match other = (Match) obj;
+			if (language == null) {
+				if (other.language != null)
+					return false;
+			} else if (!language.equals(other.language))
+				return false;
+			if (text == null) {
+				if (other.text != null)
+					return false;
+			} else if (!text.equals(other.text))
+				return false;
+			if (type == null) {
+				if (other.type != null)
+					return false;
+			} else if (!type.equals(other.type))
+				return false;
+			return true;
+		}
+	}
+	
+	/**
+	 * Constructor. Creates an empty object that can be populated during JSON
+	 * deserialization. Should only be used by Jackson for this very purpose.
+	 */
+	public WbSearchEntitiesResult() {
+	}
+	
+	/**
+	 * The id of the entity that the document refers to.
+	 */
+	@JsonProperty("id")
+	protected String entityId = "";
+	
+	/** 
+	 * The full concept URI (the site IRI with entity ID) 
+	 */
+	@JsonProperty("concepturi")
+	protected String conceptUri = "";
+	
+	/** 
+	 * The URL of the wiki site that shows the concept
+	 */
+	@JsonProperty("url")
+	protected String url = "";
+	
+	/**
+	 * Title of the entity (currently is the same as the entity ID)
+	 */
+	@JsonProperty("title")
+	protected String title = "";
+	
+	/**
+	 * The internal Mediawiki pageid of the entity
+	 */
+	@JsonProperty("pageid")
+	protected long pageId = 0;
+	
+	/**
+	 * Label of the entity
+	 * 
+	 * The language of the returned label depends on the HTTP
+	 * <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4">
+	 * Accept-Language header or the uselang URL parameter.
+	 */
+	@JsonProperty("label")
+	protected String label = "";
+	
+	/**
+	 * Description of the entity
+	 * 
+	 * The language of the returned description depends on the HTTP
+	 * <a href="https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.4">
+	 * Accept-Language header or the uselang URL parameter.
+	 */
+	@JsonProperty("description")
+	protected String description = "";
+	
+	/**
+	 * Detailed information about how a document matched the query
+	 */
+	@JsonProperty("match")
+	protected Match match;
+	
+	/**
+	 * A list of alias labels (returned only when an alias matched the query)
+	 */
+	@JsonProperty("aliases")
+	protected List<String> aliases;
+	
+	public void setEntityId(String id) {
+		this.entityId = id;
+	}
+
+	public String getEntityId() {
+		return this.entityId;
+	}
+
+	public String getConceptUri() {
+		return conceptUri;
+	}
+
+	public void setConceptUri(String conceptUri) {
+		this.conceptUri = conceptUri;
+	}
+
+	public String getUrl() {
+		return url;
+	}
+
+	public void setUrl(String url) {
+		this.url = url;
+	}
+
+	public String getTitle() {
+		return title;
+	}
+
+	public void setTitle(String title) {
+		this.title = title;
+	}
+
+	public long getPageId() {
+		return pageId;
+	}
+
+	public void setPageId(long pageId) {
+		this.pageId = pageId;
+	}
+
+	public String getLabel() {
+		return label;
+	}
+
+	public void setLabel(String label) {
+		this.label = label;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+	
+	public Match getMatch() {
+		return match;
+	}
+
+	
+	public void setMatch(Match match) {
+		this.match = match;
+	}
+
+	public List<String> getAliases() {
+		return aliases;
+	}
+
+	public void setAliases(List<String> aliases) {
+		this.aliases = aliases;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((aliases == null) ? 0 : aliases.hashCode());
+		result = prime * result
+				+ ((conceptUri == null) ? 0 : conceptUri.hashCode());
+		result = prime * result
+				+ ((description == null) ? 0 : description.hashCode());
+		result = prime * result
+				+ ((entityId == null) ? 0 : entityId.hashCode());
+		result = prime * result + ((label == null) ? 0 : label.hashCode());
+		result = prime * result + ((match == null) ? 0 : match.hashCode());
+		result = prime * result + (int) (pageId ^ (pageId >>> 32));
+		result = prime * result + ((title == null) ? 0 : title.hashCode());
+		result = prime * result + ((url == null) ? 0 : url.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		WbSearchEntitiesResult other = (WbSearchEntitiesResult) obj;
+		if (aliases == null) {
+			if (other.aliases != null)
+				return false;
+		} else if (!aliases.equals(other.aliases))
+			return false;
+		if (conceptUri == null) {
+			if (other.conceptUri != null)
+				return false;
+		} else if (!conceptUri.equals(other.conceptUri))
+			return false;
+		if (description == null) {
+			if (other.description != null)
+				return false;
+		} else if (!description.equals(other.description))
+			return false;
+		if (entityId == null) {
+			if (other.entityId != null)
+				return false;
+		} else if (!entityId.equals(other.entityId))
+			return false;
+		if (label == null) {
+			if (other.label != null)
+				return false;
+		} else if (!label.equals(other.label))
+			return false;
+		if (match == null) {
+			if (other.match != null)
+				return false;
+		} else if (!match.equals(other.match))
+			return false;
+		if (pageId != other.pageId)
+			return false;
+		if (title == null) {
+			if (other.title != null)
+				return false;
+		} else if (!title.equals(other.title))
+			return false;
+		if (url == null) {
+			if (other.url != null)
+				return false;
+		} else if (!url.equals(other.url))
+			return false;
+		return true;
+	}
+
+
+}

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesActionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesActionTest.java
@@ -63,26 +63,27 @@ public class WbSearchEntitiesActionTest {
 	public void testWbSearchEntities() throws MediaWikiApiErrorException {
 		List<WbSearchEntitiesResult> results = action.wbSearchEntities("abc",
 				"en", null, null, null, null);
-		
-		assertEquals(results.size(), 7);
-		
-		WbSearchEntitiesResult firstMatch = results.get(0);
-		assertEquals(firstMatch.getEntityId(), "Q169889");
-		assertEquals(firstMatch.getConceptUri(),
+
+		assertEquals(7, results.size());
+
+		WbSearchEntitiesResult firstResult = results.get(0);
+		assertEquals("Q169889", firstResult.getEntityId());
+		assertEquals(firstResult.getConceptUri(),
 				"http://www.wikidata.org/entity/Q169889");
-		assertEquals(firstMatch.getUrl(), "//www.wikidata.org/wiki/Q169889");
-		assertEquals(firstMatch.getTitle(), "Q169889");
-		assertEquals(firstMatch.getPageId(), 170288);
-		assertEquals(firstMatch.getLabel(), "American Broadcasting Company");
-		assertEquals(firstMatch.getDescription(),
-				"American broadcast television network");
-		assertEquals(firstMatch.getMatch(), new WbSearchEntitiesResult.Match(
-				"alias", "en", "ABC"));
+		assertEquals(firstResult.getUrl(), "//www.wikidata.org/wiki/Q169889");
+		assertEquals("Q169889", firstResult.getTitle());
+		assertEquals(170288, firstResult.getPageId());
+		assertEquals("American Broadcasting Company", firstResult.getLabel());
+		assertEquals("American broadcast television network",
+				firstResult.getDescription());
+		WbSearchEntitiesResult.Match match = new JacksonWbSearchEntitiesResult.JacksonMatch(
+				"alias", "en", "ABC");
+		assertEquals(match, firstResult.getMatch());
 		List<String> aliases = new ArrayList<>();
 		aliases.add("ABC");
-		assertEquals(firstMatch.getAliases(), aliases);
+		assertEquals(aliases, firstResult.getAliases());
 	}
-	
+
 	@Test
 	public void testWbSearchEntitiesEmpty() throws MediaWikiApiErrorException {
 		List<WbSearchEntitiesResult> results = action.wbSearchEntities(

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesActionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesActionTest.java
@@ -1,0 +1,104 @@
+package org.wikidata.wdtk.wikibaseapi;
+
+/*
+ * #%L
+ * Wikidata Toolkit Wikibase API
+ * %%
+ * Copyright (C) 2014 - 2015 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.util.CompressionType;
+import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
+
+public class WbSearchEntitiesActionTest {
+
+	MockApiConnection con;
+	WbSearchEntitiesAction action;
+
+	@Before
+	public void setUp() throws Exception {
+
+		this.con = new MockApiConnection();
+		Map<String, String> params = new HashMap<String, String>();
+		params.put(ApiConnection.PARAM_ACTION, "wbsearchentities");
+		params.put(ApiConnection.PARAM_FORMAT, "json");
+		params.put("search", "abc");
+		params.put("language", "en");
+		this.con.setWebResourceFromPath(params, getClass(),
+				"/wbsearchentities-abc.json", CompressionType.NONE);
+		
+		params.put("search", "some search string with no results");
+		this.con.setWebResourceFromPath(params, getClass(),
+				"/wbsearchentities-empty.json", CompressionType.NONE);
+
+		this.action = new WbSearchEntitiesAction(this.con, Datamodel.SITE_WIKIDATA);
+
+	}
+
+	@Test
+	public void testWbSearchEntities() throws MediaWikiApiErrorException {
+		List<WbSearchEntitiesResult> results = action.wbSearchEntities("abc",
+				"en", null, null, null, null);
+		
+		assertEquals(results.size(), 7);
+		
+		WbSearchEntitiesResult firstMatch = results.get(0);
+		assertEquals(firstMatch.getEntityId(), "Q169889");
+		assertEquals(firstMatch.getConceptUri(),
+				"http://www.wikidata.org/entity/Q169889");
+		assertEquals(firstMatch.getUrl(), "//www.wikidata.org/wiki/Q169889");
+		assertEquals(firstMatch.getTitle(), "Q169889");
+		assertEquals(firstMatch.getPageId(), 170288);
+		assertEquals(firstMatch.getLabel(), "American Broadcasting Company");
+		assertEquals(firstMatch.getDescription(),
+				"American broadcast television network");
+		assertEquals(firstMatch.getMatch(), new WbSearchEntitiesResult.Match(
+				"alias", "en", "ABC"));
+		List<String> aliases = new ArrayList<>();
+		aliases.add("ABC");
+		assertEquals(firstMatch.getAliases(), aliases);
+	}
+	
+	@Test
+	public void testWbSearchEntitiesEmpty() throws MediaWikiApiErrorException {
+		List<WbSearchEntitiesResult> results = action.wbSearchEntities(
+				"some search string with no results", "en", null, null, null,
+				null);
+
+		assertTrue(results.isEmpty());
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testIdsAndTitles() throws MediaWikiApiErrorException {
+		action.wbSearchEntities(null, "en", null, null, null, null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testIdsAndSites() throws MediaWikiApiErrorException {
+		action.wbSearchEntities("abc", null, null, null, null, null);
+	}
+}

--- a/wdtk-wikibaseapi/src/test/resources/wbsearchentities-abc.json
+++ b/wdtk-wikibaseapi/src/test/resources/wbsearchentities-abc.json
@@ -1,0 +1,119 @@
+{
+    "searchinfo": {
+        "search": "abc"
+    },
+    "search": [
+        {
+            "id": "Q169889",
+            "concepturi": "http://www.wikidata.org/entity/Q169889",
+            "url": "//www.wikidata.org/wiki/Q169889",
+            "title": "Q169889",
+            "pageid": 170288,
+            "label": "American Broadcasting Company",
+            "description": "American broadcast television network",
+            "match": {
+                "type": "alias",
+                "language": "en",
+                "text": "ABC"
+            },
+            "aliases": [
+                "ABC"
+            ]
+        },
+        {
+            "id": "Q286874",
+            "concepturi": "http://www.wikidata.org/entity/Q286874",
+            "url": "//www.wikidata.org/wiki/Q286874",
+            "title": "Q286874",
+            "pageid": 277328,
+            "label": "ABC",
+            "description": "Wikimedia disambiguation page",
+            "match": {
+                "type": "label",
+                "language": "en",
+                "text": "ABC"
+            }
+        },
+        {
+            "id": "Q781365",
+            "concepturi": "http://www.wikidata.org/entity/Q781365",
+            "url": "//www.wikidata.org/wiki/Q781365",
+            "title": "Q781365",
+            "pageid": 734387,
+            "label": "Australian Broadcasting Corporation",
+            "description": "Australia's state-owned and funded national public broadcaster",
+            "match": {
+                "type": "alias",
+                "language": "en",
+                "text": "ABC"
+            },
+            "aliases": [
+                "ABC"
+            ]
+        },
+        {
+            "id": "Q287076",
+            "concepturi": "http://www.wikidata.org/entity/Q287076",
+            "url": "//www.wikidata.org/wiki/Q287076",
+            "title": "Q287076",
+            "pageid": 277519,
+            "label": "ABC",
+            "description": "Spanish newspaper",
+            "match": {
+                "type": "label",
+                "language": "en",
+                "text": "ABC"
+            }
+        },
+        {
+            "id": "Q304330",
+            "concepturi": "http://www.wikidata.org/entity/Q304330",
+            "url": "//www.wikidata.org/wiki/Q304330",
+            "title": "Q304330",
+            "pageid": 293199,
+            "label": "Abacavir",
+            "description": "pharmaceutical drug",
+            "match": {
+                "type": "alias",
+                "language": "en",
+                "text": "ABC"
+            },
+            "aliases": [
+                "ABC"
+            ]
+        },
+        {
+            "id": "Q1057802",
+            "concepturi": "http://www.wikidata.org/entity/Q1057802",
+            "url": "//www.wikidata.org/wiki/Q1057802",
+            "title": "Q1057802",
+            "pageid": 1006628,
+            "label": "ABC",
+            "description": "programming language",
+            "match": {
+                "type": "label",
+                "language": "en",
+                "text": "ABC"
+            }
+        },
+        {
+            "id": "Q26298",
+            "concepturi": "http://www.wikidata.org/entity/Q26298",
+            "url": "//www.wikidata.org/wiki/Q26298",
+            "title": "Q26298",
+            "pageid": 29721,
+            "label": "Agricultural Bank of China",
+            "description": "major bank in the People's Republic of China",
+            "match": {
+                "type": "alias",
+                "language": "en",
+                "text": "ABC"
+            },
+            "aliases": [
+                "ABC"
+            ]
+        }
+    ],
+    "search-continue": 7,
+    "success": 1
+}

--- a/wdtk-wikibaseapi/src/test/resources/wbsearchentities-empty.json
+++ b/wdtk-wikibaseapi/src/test/resources/wbsearchentities-empty.json
@@ -1,0 +1,7 @@
+{
+    "searchinfo": {
+        "search": "some search string with no results"
+    },
+    "search": [],
+    "success": 1
+}


### PR DESCRIPTION
I did an implementation of the [wbsearchentities](https://www.wikidata.org/w/api.php?action=help&modules=wbsearchentities) API call as discussed #228.
I wasn't sure about the best place to put the search result structure (WbSearchEntitiesResult) and its implementation for deserialization (JacksonWbSearchEntitiesResult) since it is not really part of the coredatamodel. So for now it's in the wikibaseapi package.
No integration in WikibaseDataFetcher yet.
