### PR TITLE
Do not fail when descriptions/sitelinks are serialized as "[]" (empty array)

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonItemDocument.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonItemDocument.java
@@ -87,7 +87,11 @@ public class JacksonItemDocument extends JacksonTermedStatementDocument
 	 */
 	@JsonProperty("sitelinks")
 	public void setSiteLinks(Map<String, JacksonSiteLink> sitelinks) {
-		this.sitelinks = sitelinks;
+		if (sitelinks == null) {
+			this.sitelinks = Collections.emptyMap();
+		} else {
+			this.sitelinks = sitelinks;
+		}
 	}
 
 	@JsonProperty("sitelinks")

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonTermedStatementDocument.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonTermedStatementDocument.java
@@ -130,7 +130,11 @@ public abstract class JacksonTermedStatementDocument extends
 	 */
 	public void setAliases(
 			Map<String, List<JacksonMonolingualTextValue>> aliases) {
-		this.aliases = aliases;
+		if (aliases == null) {
+			this.aliases = Collections.emptyMap();
+		} else {
+			this.aliases = aliases;
+		}
 	}
 
 	@Override
@@ -157,7 +161,11 @@ public abstract class JacksonTermedStatementDocument extends
 	 */
 	public void setDescriptions(
 			Map<String, JacksonMonolingualTextValue> descriptions) {
-		this.descriptions = descriptions;
+		if (descriptions == null) {
+			this.descriptions = Collections.emptyMap();
+		} else {
+			this.descriptions = descriptions;
+		}
 	}
 
 	@Override
@@ -174,7 +182,11 @@ public abstract class JacksonTermedStatementDocument extends
 	 *            new value
 	 */
 	public void setLabels(Map<String, JacksonMonolingualTextValue> labels) {
-		this.labels = labels;
+		if (labels == null) {
+			this.labels = Collections.emptyMap();
+		} else {
+			this.labels = labels;
+		}
 	}
 
 	@Override
@@ -265,7 +277,11 @@ public abstract class JacksonTermedStatementDocument extends
 	 */
 	@JsonProperty("claims")
 	public void setJsonClaims(Map<String, List<JacksonStatement>> claims) {
-		this.claims = claims;
+		if (claims == null) {
+			this.claims = Collections.emptyMap();
+		} else {
+			this.claims = claims;
+		}
 		this.statementGroups = null; // clear cache
 	}
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/json/jackson/JsonTestData.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/json/jackson/JsonTestData.java
@@ -126,6 +126,10 @@ public class JsonTestData {
 			+ TEST_ITEM_ID
 			+ "\",\"aliases\":{},\"labels\":{},\"descriptions\":{},\"claims\":{},\"sitelinks\":{\"enwiki\":"
 			+ JSON_SITE_LINK + "}," + JSON_ITEM_TYPE + "}";
+	public static final String JSON_EMPTY_ARRAY_AS_CONTAINER = "{\"id\":\""
+			+ TEST_ITEM_ID
+			+ "\",\"aliases\":[],\"labels\":[],\"descriptions\":[],\"claims\":[],\"sitelinks\":[],"
+			+ JSON_ITEM_TYPE + "}";
 
 	public static final String JSON_NOVALUE_STATEMENT = "{\"type\":\"statement\",\"id\":\""
 			+ TEST_STATEMENT_ID

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/json/jackson/TestItemDocument.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/json/jackson/TestItemDocument.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertNotNull;
 
 import java.io.IOException;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelConverter;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
@@ -179,6 +180,20 @@ public class TestItemDocument {
 
 		assertNotNull(result);
 		assertEquals(JsonTestData.getTestSiteLinkMap(), result.getSiteLinks());
+	}
+
+	@Test
+	public void testEmptyArraysForTerms() throws IOException {
+		JacksonItemDocument result = mapper.reader(JacksonItemDocument.class)
+			.with(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT)
+			.readValue(JsonTestData.JSON_EMPTY_ARRAY_AS_CONTAINER);
+
+		assertNotNull(result);
+		assertNotNull(result.getLabels());
+		assertNotNull(result.getDescriptions());
+		assertNotNull(result.getAliases());
+		assertNotNull(result.getAllStatements());
+		assertNotNull(result.getSiteLinks());
 	}
 
 	@Test

--- a/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/JsonDumpFileProcessor.java
+++ b/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/JsonDumpFileProcessor.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocumentProcessor;
@@ -51,7 +52,8 @@ public class JsonDumpFileProcessor implements MwDumpFileProcessor {
 
 	private final ObjectMapper mapper = new ObjectMapper();
 	private final ObjectReader documentReader = this.mapper
-			.reader(JacksonTermedStatementDocument.class);
+			.reader(JacksonTermedStatementDocument.class)
+			.with(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT);
 
 	private final EntityDocumentProcessor entityDocumentProcessor;
 	private final String siteIri;

--- a/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/WikibaseRevisionProcessor.java
+++ b/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/WikibaseRevisionProcessor.java
@@ -23,6 +23,7 @@ package org.wikidata.wdtk.dumpfiles;
 import java.io.IOException;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocumentProcessor;
@@ -93,8 +94,7 @@ public class WikibaseRevisionProcessor implements MwRevisionProcessor {
 
 	public void processItemRevision(MwRevision mwRevision) {
 		try {
-			JacksonItemDocument document = mapper.readValue(
-					mwRevision.getText(), JacksonItemDocument.class);
+			JacksonItemDocument document = readValue(mwRevision.getText(), JacksonItemDocument.class);
 			document.setSiteIri(this.siteIri);
 			this.entityDocumentProcessor.processItemDocument(document);
 		} catch (JsonParseException e1) {
@@ -124,8 +124,7 @@ public class WikibaseRevisionProcessor implements MwRevisionProcessor {
 
 	public void processPropertyRevision(MwRevision mwRevision) {
 		try {
-			JacksonPropertyDocument document = mapper.readValue(
-					mwRevision.getText(), JacksonPropertyDocument.class);
+			JacksonPropertyDocument document = readValue(mwRevision.getText(), JacksonPropertyDocument.class);
 			document.setSiteIri(this.siteIri);
 			this.entityDocumentProcessor.processPropertyDocument(document);
 		} catch (JsonParseException e1) {
@@ -153,6 +152,12 @@ public class WikibaseRevisionProcessor implements MwRevisionProcessor {
 		// + mwRevision.toString() + " (" + e.toString() + ")");
 		// }
 
+	}
+
+	public <T> T readValue(String content, Class<T> valueType) throws IOException {
+		return mapper.reader(valueType)
+				.with(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT)
+				.readValue(content);
 	}
 
 	@Override


### PR DESCRIPTION
Based on the DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT option of Jackson

Tries to work around #234