### PR TITLE
Ignore null property types when generating RDF.

### DIFF
--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/SnakRdfConverter.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/SnakRdfConverter.java
@@ -304,8 +304,9 @@ public class SnakRdfConverter implements SnakVisitor<Void> {
 		String datatype = this.propertyRegister
 				.getPropertyType(propertyIdValue);
 
-        if (datatype == null)
-            return null;
+		if (datatype == null)
+			return null;
+
 		switch (datatype) {
 		case DatatypeIdValue.DT_STRING:
 		case DatatypeIdValue.DT_EXTERNAL_ID:

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/SnakRdfConverter.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/SnakRdfConverter.java
@@ -304,6 +304,8 @@ public class SnakRdfConverter implements SnakVisitor<Void> {
 		String datatype = this.propertyRegister
 				.getPropertyType(propertyIdValue);
 
+        if (datatype == null)
+            return null;
 		switch (datatype) {
 		case DatatypeIdValue.DT_STRING:
 		case DatatypeIdValue.DT_EXTERNAL_ID:

--- a/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/MockPropertyRegister.java
+++ b/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/MockPropertyRegister.java
@@ -47,10 +47,11 @@ public class MockPropertyRegister extends PropertyRegister {
 
 	}
 
-    public MockPropertyRegister (String uriPatternPropertyId,
-                                                 ApiConnection apiConnection, String siteUri) {
-        super(uriPatternPropertyId, apiConnection, siteUri);
-    }
+	public MockPropertyRegister (String uriPatternPropertyId,
+								 ApiConnection apiConnection, String siteUri) {
+		super(uriPatternPropertyId, apiConnection, siteUri);
+	}
+
 
 	@Override
 	protected void fetchPropertyInformation(PropertyIdValue startProperty) {
@@ -705,21 +706,20 @@ public class MockPropertyRegister extends PropertyRegister {
 		KNOWN_PROPERTY_TYPES.put("P996", DatatypeIdValue.DT_COMMONS_MEDIA);
 		KNOWN_PROPERTY_TYPES.put("P998", DatatypeIdValue.DT_STRING);
 		KNOWN_PROPERTY_TYPES.put("P1647", DatatypeIdValue.DT_PROPERTY);
-        KNOWN_PROPERTY_TYPES.put("P1291", null);
 	}
 
-    public static class WithNullPropertyTypes extends MockPropertyRegister {
+	public static class WithNullPropertyTypes extends MockPropertyRegister {
 
-        public WithNullPropertyTypes() {
-            super("P1921", ApiConnection.getWikidataApiConnection(),
-                    Datamodel.SITE_WIKIDATA);
-            Map<String, String> NULL_PROPERTY_TYPES = new HashMap<>();
-            for (Map.Entry<String, String> e : KNOWN_PROPERTY_TYPES.entrySet()) {
-                NULL_PROPERTY_TYPES.put(e.getKey(), null);
-            }
-            this.datatypes.putAll(NULL_PROPERTY_TYPES);
-            this.uriPatterns.putAll(KNOWN_URI_PATTERNS);
+		public WithNullPropertyTypes() {
+			super("P1921", ApiConnection.getWikidataApiConnection(),
+					Datamodel.SITE_WIKIDATA);
+			Map<String, String> NULL_PROPERTY_TYPES = new HashMap<>();
+			for (Map.Entry<String, String> e : KNOWN_PROPERTY_TYPES.entrySet()) {
+				NULL_PROPERTY_TYPES.put(e.getKey(), null);
+			}
+			this.datatypes.putAll(NULL_PROPERTY_TYPES);
+			this.uriPatterns.putAll(KNOWN_URI_PATTERNS);
 
-        }
-    }
+		}
+	}
 }

--- a/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/MockPropertyRegister.java
+++ b/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/MockPropertyRegister.java
@@ -47,6 +47,11 @@ public class MockPropertyRegister extends PropertyRegister {
 
 	}
 
+    public MockPropertyRegister (String uriPatternPropertyId,
+                                                 ApiConnection apiConnection, String siteUri) {
+        super(uriPatternPropertyId, apiConnection, siteUri);
+    }
+
 	@Override
 	protected void fetchPropertyInformation(PropertyIdValue startProperty) {
 		Assert.fail("Please add " + startProperty
@@ -700,5 +705,21 @@ public class MockPropertyRegister extends PropertyRegister {
 		KNOWN_PROPERTY_TYPES.put("P996", DatatypeIdValue.DT_COMMONS_MEDIA);
 		KNOWN_PROPERTY_TYPES.put("P998", DatatypeIdValue.DT_STRING);
 		KNOWN_PROPERTY_TYPES.put("P1647", DatatypeIdValue.DT_PROPERTY);
+        KNOWN_PROPERTY_TYPES.put("P1291", null);
 	}
+
+    public static class WithNullPropertyTypes extends MockPropertyRegister {
+
+        public WithNullPropertyTypes() {
+            super("P1921", ApiConnection.getWikidataApiConnection(),
+                    Datamodel.SITE_WIKIDATA);
+            Map<String, String> NULL_PROPERTY_TYPES = new HashMap<>();
+            for (Map.Entry<String, String> e : KNOWN_PROPERTY_TYPES.entrySet()) {
+                NULL_PROPERTY_TYPES.put(e.getKey(), null);
+            }
+            this.datatypes.putAll(NULL_PROPERTY_TYPES);
+            this.uriPatterns.putAll(KNOWN_URI_PATTERNS);
+
+        }
+    }
 }

--- a/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/RdfConverterTest.java
+++ b/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/RdfConverterTest.java
@@ -24,10 +24,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.junit.After;
 import org.junit.Before;
@@ -96,7 +93,22 @@ public class RdfConverterTest {
 				.getResourceFromFile("ItemDocument.rdf")));
 	}
 
-	@Test
+    @Test
+    public void testWriteItemDocumentWithNullPropertyTypes() throws RDFHandlerException,
+            IOException, RDFParseException {
+        this.rdfConverter = new RdfConverter(this.rdfWriter, this.sites,
+                new MockPropertyRegister.WithNullPropertyTypes());
+
+        ItemDocument document = this.objectFactory.createItemDocument();
+        this.rdfConverter.writeItemDocument(document);
+        this.rdfWriter.finish();
+        Model model = RdfTestHelpers.parseRdf(out.toString());
+        Model expected = RdfTestHelpers.parseRdf(RdfTestHelpers
+                .getResourceFromFile("ItemDocumentUnknownPropertyTypes.rdf"));
+        assertEquals(model, expected);
+    }
+
+    @Test
 	public void testWritePropertyDocument() throws RDFHandlerException,
 			RDFParseException, IOException {
 		PropertyDocument document = this.objectFactory
@@ -224,7 +236,7 @@ public class RdfConverterTest {
 		ItemIdValue value1 = dataObjectFactory.getItemIdValue("Q10",
 				"http://www.wikidata.org/");
 		ItemIdValue value2 = dataObjectFactory.getItemIdValue("Q11",
-				"http://www.wikidata.org/");
+                "http://www.wikidata.org/");
 		PropertyIdValue propertyIdValueP31 = dataObjectFactory
 				.getPropertyIdValue("P31", "http://www.wikidata.org/");
 		PropertyIdValue propertyIdValueP279 = dataObjectFactory

--- a/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/RdfConverterTest.java
+++ b/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/RdfConverterTest.java
@@ -24,7 +24,10 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.After;
 import org.junit.Before;
@@ -93,20 +96,20 @@ public class RdfConverterTest {
 				.getResourceFromFile("ItemDocument.rdf")));
 	}
 
-    @Test
-    public void testWriteItemDocumentWithNullPropertyTypes() throws RDFHandlerException,
-            IOException, RDFParseException {
-        this.rdfConverter = new RdfConverter(this.rdfWriter, this.sites,
-                new MockPropertyRegister.WithNullPropertyTypes());
+	@Test
+	public void testWriteItemDocumentWithNullPropertyTypes() throws RDFHandlerException,
+			IOException, RDFParseException {
+		this.rdfConverter = new RdfConverter(this.rdfWriter, this.sites,
+				new MockPropertyRegister.WithNullPropertyTypes());
 
-        ItemDocument document = this.objectFactory.createItemDocument();
-        this.rdfConverter.writeItemDocument(document);
-        this.rdfWriter.finish();
-        Model model = RdfTestHelpers.parseRdf(out.toString());
-        Model expected = RdfTestHelpers.parseRdf(RdfTestHelpers
-                .getResourceFromFile("ItemDocumentUnknownPropertyTypes.rdf"));
-        assertEquals(model, expected);
-    }
+		ItemDocument document = this.objectFactory.createItemDocument();
+		this.rdfConverter.writeItemDocument(document);
+		this.rdfWriter.finish();
+		Model model = RdfTestHelpers.parseRdf(out.toString());
+		assertEquals(model, RdfTestHelpers.parseRdf(RdfTestHelpers
+				.getResourceFromFile("ItemDocumentUnknownPropertyTypes.rdf")));
+	}
+
 
     @Test
 	public void testWritePropertyDocument() throws RDFHandlerException,
@@ -236,7 +239,7 @@ public class RdfConverterTest {
 		ItemIdValue value1 = dataObjectFactory.getItemIdValue("Q10",
 				"http://www.wikidata.org/");
 		ItemIdValue value2 = dataObjectFactory.getItemIdValue("Q11",
-                "http://www.wikidata.org/");
+				"http://www.wikidata.org/");
 		PropertyIdValue propertyIdValueP31 = dataObjectFactory
 				.getPropertyIdValue("P31", "http://www.wikidata.org/");
 		PropertyIdValue propertyIdValueP279 = dataObjectFactory

--- a/wdtk-rdf/src/test/resources/ItemDocumentUnknownPropertyTypes.rdf
+++ b/wdtk-rdf/src/test/resources/ItemDocumentUnknownPropertyTypes.rdf
@@ -1,0 +1,53 @@
+
+<http://www.wikidata.org/Q10> a <http://www.wikidata.org/ontology#Item> ;
+	<http://www.w3.org/2000/01/rdf-schema#label> "bar"@lc2 , "foo"@lc ;
+	<http://schema.org/description> "it's bar"@lc2 , "it's foo"@lc ;
+	<http://www.w3.org/2004/02/skos/core#altLabel> "foo"@lc , "bar"@lc ;
+	<http://www.wikidata.org/P10s> <http://www.wikidata.org/Q10Snone> ;
+	<http://www.wikidata.org/P569s> <http://www.wikidata.org/Q10Snone2> ;
+	<http://www.wikidata.org/P549s> <http://www.wikidata.org/Q10Snone> .
+
+<http://www.wikidata.org/Q10Snone> a <http://www.wikidata.org/ontology#Statement> ;
+	<http://www.wikidata.org/ontology#rank> <http://www.wikidata.org/ontology#NormalRank> .
+
+<http://www.wikidata.org/Q10Snone2> a <http://www.wikidata.org/ontology#Statement> ;
+	<http://www.wikidata.org/P569v> <http://www.wikidata.org/entity/VTec11d94e4f5bb7b00a79196734f49066> ;
+	<http://www.wikidata.org/P15q> <http://www.wikidata.org/entity/VTec11d94e4f5bb7b00a79196734f49066> ;
+	<http://www.w3.org/ns/prov#wasDerivedFrom> <http://www.wikidata.org/entity/R29b7008efe33a96335e456305edfb481> ;
+	<http://www.wikidata.org/ontology#rank> <http://www.wikidata.org/ontology#NormalRank> .
+
+<http://www.wikidata.org/Q10Snone> a <http://www.wikidata.org/ontology#Statement> ;
+	<http://www.wikidata.org/P549v> "TestString" ;
+	<http://www.wikidata.org/ontology#rank> <http://www.wikidata.org/ontology#NormalRank> .
+
+<http://www.wikidata.org/entity/VTec11d94e4f5bb7b00a79196734f49066> a <http://www.wikidata.org/ontology#TimeValue> ;
+	<http://www.wikidata.org/ontology#time> "0306-11-03"^^<http://www.w3.org/2001/XMLSchema#date> ;
+	<http://www.wikidata.org/ontology#timePrecision> "32"^^<http://www.w3.org/2001/XMLSchema#int> ;
+	<http://www.wikidata.org/ontology#preferredCalendar> <http://www.wikidata.org/entity/Q1985727> .
+
+<http://www.wikidata.org/P569s> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://www.wikidata.org/P569v> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://www.wikidata.org/P569q> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://www.wikidata.org/P569r> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://www.wikidata.org/P15s> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://www.wikidata.org/P15v> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://www.wikidata.org/P15q> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://www.wikidata.org/P15r> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://www.wikidata.org/P549s> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://www.wikidata.org/P549v> a <http://www.w3.org/2002/07/owl#DatatypeProperty> .
+
+<http://www.wikidata.org/P549q> a <http://www.w3.org/2002/07/owl#DatatypeProperty> .
+
+<http://www.wikidata.org/P549r> a <http://www.w3.org/2002/07/owl#DatatypeProperty> .
+
+<http://www.wikidata.org/entity/R29b7008efe33a96335e456305edfb481> a <http://www.wikidata.org/ontology#Reference> ;
+	<http://www.wikidata.org/P112r> <http://www.wikidata.org/entity/VTec11d94e4f5bb7b00a79196734f49066> .


### PR DESCRIPTION
This fixes an issue I found after applying the changes to make QuantityValue bounds optional (https://github.com/Wikidata/Wikidata-Toolkit/pull/247).

Exporting a wikidata dump as rdf triggered a null pointer exception:

Exception in thread "main" java.lang.NullPointerException
        at org.wikidata.wdtk.rdf.SnakRdfConverter.getRangeUri(SnakRdfConverter.java:307)

It looks like the intention of the code was to return null in the case of an unknown property type, this informed my fix.