### PR TITLE
Adds "id" field to entity id JSON serialization

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonObjectFactory.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/JacksonObjectFactory.java
@@ -20,52 +20,13 @@ package org.wikidata.wdtk.datamodel.json.jackson;
  * #L%
  */
 
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelConverter;
-import org.wikidata.wdtk.datamodel.interfaces.Claim;
-import org.wikidata.wdtk.datamodel.interfaces.DataObjectFactory;
-import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.GlobeCoordinatesValue;
-import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
-import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
-import org.wikidata.wdtk.datamodel.interfaces.NoValueSnak;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.QuantityValue;
-import org.wikidata.wdtk.datamodel.interfaces.Reference;
-import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
-import org.wikidata.wdtk.datamodel.interfaces.Snak;
-import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
-import org.wikidata.wdtk.datamodel.interfaces.SomeValueSnak;
-import org.wikidata.wdtk.datamodel.interfaces.Statement;
-import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
-import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
-import org.wikidata.wdtk.datamodel.interfaces.StringValue;
-import org.wikidata.wdtk.datamodel.interfaces.TimeValue;
-import org.wikidata.wdtk.datamodel.interfaces.Value;
-import org.wikidata.wdtk.datamodel.interfaces.ValueSnak;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonInnerEntityId;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonInnerGlobeCoordinates;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonInnerMonolingualText;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonInnerQuantity;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonInnerTime;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValue;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueGlobeCoordinates;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueItemId;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueMonolingualText;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValuePropertyId;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueQuantity;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueString;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueTime;
+import org.wikidata.wdtk.datamodel.interfaces.*;
+import org.wikidata.wdtk.datamodel.json.jackson.datavalues.*;
+
+import java.math.BigDecimal;
+import java.util.*;
 
 /**
  * Factory implementation to create Jackson versions of the datamodel objects,
@@ -81,36 +42,18 @@ public class JacksonObjectFactory implements DataObjectFactory {
 
 	@Override
 	public ItemIdValue getItemIdValue(String id, String siteIri) {
-		if (id.length() > 0 && id.charAt(0) == 'Q') {
-			Integer numericId = Integer.valueOf(id.substring(1));
-			JacksonInnerEntityId innerEntity;
-			innerEntity = new JacksonInnerEntityId(
-					JacksonInnerEntityId.JSON_ENTITY_TYPE_ITEM, numericId);
-
-			JacksonValueItemId result = new JacksonValueItemId();
-			result.setValue(innerEntity);
-			result.setSiteIri(siteIri);
-			return result;
-		} else {
-			throw new IllegalArgumentException("Illegal item id: " + id);
-		}
+		JacksonValueItemId result = new JacksonValueItemId();
+		result.setValue(new JacksonInnerEntityId(id));
+		result.setSiteIri(siteIri);
+		return result;
 	}
 
 	@Override
 	public PropertyIdValue getPropertyIdValue(String id, String siteIri) {
-		if (id.length() > 0 && id.charAt(0) == 'P') {
-			Integer numericId = Integer.valueOf(id.substring(1));
-			JacksonInnerEntityId innerEntity;
-			innerEntity = new JacksonInnerEntityId(
-					JacksonInnerEntityId.JSON_ENTITY_TYPE_PROPERTY, numericId);
-
-			JacksonValuePropertyId result = new JacksonValuePropertyId();
-			result.setValue(innerEntity);
-			result.setSiteIri(siteIri);
-			return result;
-		} else {
-			throw new IllegalArgumentException("Illegal property id: " + id);
-		}
+		JacksonValuePropertyId result = new JacksonValuePropertyId();
+		result.setValue(new JacksonInnerEntityId(id));
+		result.setSiteIri(siteIri);
+		return result;
 	}
 
 	@Override

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonInnerEntityId.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/json/jackson/datavalues/JacksonInnerEntityId.java
@@ -20,7 +20,6 @@ package org.wikidata.wdtk.datamodel.json.jackson.datavalues;
  * #L%
  */
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -30,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * document.
  *
  * @author Fredo Erxleben
+ * @author Thomas Pellissier Tanon
  *
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -49,10 +49,13 @@ public class JacksonInnerEntityId {
 	public final static String JSON_ENTITY_TYPE_PROPERTY = "property";
 
 	@JsonProperty("entity-type")
-	private String entityType;
+	private String entityType = null;
 
 	@JsonProperty("numeric-id")
-	private int numericId;
+	private int numericId = 0;
+
+	@JsonProperty("id")
+	private String id = null;
 
 	/**
 	 * Constructor. Creates an empty object that can be populated during JSON
@@ -67,10 +70,22 @@ public class JacksonInnerEntityId {
 	 * @param entityType
 	 *            (case-sensitive)
 	 * @param numericId
+	 *
+	 * @deprecated You should input the entity Id
 	 */
+	@Deprecated
 	public JacksonInnerEntityId(String entityType, int numericId) {
-		setJsonEntityType(entityType);
+		this.entityType = entityType;
 		this.numericId = numericId;
+		checkAndFillFields();
+	}
+
+	/**
+	 * Constructor.
+	 */
+	public JacksonInnerEntityId(String id) {
+		this.id = id;
+		checkAndFillFields();
 	}
 
 	/**
@@ -94,6 +109,7 @@ public class JacksonInnerEntityId {
 	@JsonProperty("entity-type")
 	public void setJsonEntityType(String entityType) {
 		this.entityType = entityType;
+		checkAndFillFields();
 	}
 
 	/**
@@ -117,6 +133,7 @@ public class JacksonInnerEntityId {
 	@JsonProperty("numeric-id")
 	public void setNumericId(int numericId) {
 		this.numericId = numericId;
+		checkAndFillFields();
 	}
 
 	/**
@@ -129,17 +146,22 @@ public class JacksonInnerEntityId {
 	 *             if the entity type of this value is unknown and can thus not
 	 *             be mapped to a string id
 	 */
-	@JsonIgnore
+	@JsonProperty("id")
 	public String getStringId() throws IllegalArgumentException {
-		switch (entityType) {
-		case JSON_ENTITY_TYPE_ITEM:
-			return "Q" + this.numericId;
-		case JSON_ENTITY_TYPE_PROPERTY:
-			return "P" + this.numericId;
-		default:
-			throw new IllegalArgumentException("Entities of type \""
-					+ entityType + "\" are not supported in property values.");
-		}
+		return id;
+	}
+
+	/**
+	 * Sets the string entity id to the given value. Only for use by Jackson
+	 * during deserialization.
+	 *
+	 * @param id
+	 *            new value
+	 */
+	@JsonProperty("id")
+	public void setStringId(String id) {
+		this.id = id;
+		checkAndFillFields();
 	}
 
 	@Override
@@ -156,4 +178,48 @@ public class JacksonInnerEntityId {
 						.equals(((JacksonInnerEntityId) o).entityType));
 	}
 
+	private void checkAndFillFields() {
+		if(entityType != null && numericId != 0) {
+			if(id == null) {
+				id = buildIdFromNumericId();
+			} else if(!id.equals(buildIdFromNumericId())) {
+				throw new IllegalArgumentException("Numerical id is different from the string id");
+			}
+		} else if(id != null) {
+			if (id.length() <= 1) {
+				throw new IllegalArgumentException(
+						"Wikibase entity ids must have the form \"(Q|P)<positive integer>\". Given id was \""
+								+ id + "\"");
+			}
+			switch (id.charAt(0)) {
+			case 'Q':
+				entityType = JacksonInnerEntityId.JSON_ENTITY_TYPE_ITEM;
+				break;
+			case 'P':
+				entityType = JacksonInnerEntityId.JSON_ENTITY_TYPE_PROPERTY;
+				break;
+			default:
+				throw new IllegalArgumentException("Unrecognized entity id: \"" + id + "\"");
+			}
+			try {
+				numericId = new Integer(id.substring(1));
+			} catch (NumberFormatException e) {
+				throw new IllegalArgumentException(
+						"Wikibase entity ids must have the form \"(Q|P)<positive integer>\". Given id was \""
+								+ id + "\"");
+			}
+		}
+	}
+
+	private String buildIdFromNumericId() {
+		switch (entityType) {
+		case JSON_ENTITY_TYPE_ITEM:
+			return  "Q" + this.numericId;
+		case JSON_ENTITY_TYPE_PROPERTY:
+			return "P" + this.numericId;
+		default:
+			throw new IllegalArgumentException("Entities of type \""
+					+ entityType + "\" are not supported in property values.");
+		}
+	}
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/json/jackson/JsonTestData.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/json/jackson/JsonTestData.java
@@ -20,27 +20,12 @@ package org.wikidata.wdtk.datamodel.json.jackson;
  * #L%
  */
 
-import java.math.BigDecimal;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
-import org.wikidata.wdtk.datamodel.interfaces.DataObjectFactory;
-import org.wikidata.wdtk.datamodel.interfaces.GlobeCoordinatesValue;
-import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.TimeValue;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValue;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueGlobeCoordinates;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueItemId;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueMonolingualText;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValuePropertyId;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueQuantity;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueString;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueTime;
+import org.wikidata.wdtk.datamodel.interfaces.*;
+import org.wikidata.wdtk.datamodel.json.jackson.datavalues.*;
+
+import java.math.BigDecimal;
+import java.util.*;
 
 /**
  * Class that provides objects and strings for testing the conversion between
@@ -74,11 +59,18 @@ public class JsonTestData {
 	public static final String JSON_ITEM_ID_VALUE = "{\"type\":\""
 			+ JacksonValue.JSON_VALUE_TYPE_ENTITY_ID
 			+ "\",\"value\":{\"entity-type\":\"" + JSON_ENTITY_TYPE_ITEM
-			+ "\",\"numeric-id\":" + TEST_NUMERIC_ID + "}}";
+			+ "\",\"numeric-id\":" + TEST_NUMERIC_ID + ",\"id\":\"" + TEST_ITEM_ID + "\"}}";
+    public static final String JSON_ITEM_ID_VALUE_WITHOUT_ID = "{\"type\":\""
+            + JacksonValue.JSON_VALUE_TYPE_ENTITY_ID
+            + "\",\"value\":{\"entity-type\":\"" + JSON_ENTITY_TYPE_ITEM
+            + "\",\"numeric-id\":\"" + TEST_NUMERIC_ID + "\"}}";
+    public static final String JSON_ITEM_ID_VALUE_WITHOUT_NUMERICAL_ID = "{\"type\":\""
+            + JacksonValue.JSON_VALUE_TYPE_ENTITY_ID
+            + "\",\"value\":{\"id\":\"" + TEST_ITEM_ID + "\"}}";
 	public static final String JSON_PROPERTY_ID_VALUE = "{\"type\":\""
 			+ JacksonValue.JSON_VALUE_TYPE_ENTITY_ID
 			+ "\",\"value\":{\"entity-type\":\"" + JSON_ENTITY_TYPE_PROPERTY
-			+ "\",\"numeric-id\":" + TEST_NUMERIC_ID + "}}";
+			+ "\",\"numeric-id\":" + TEST_NUMERIC_ID + ",\"id\":\"" + TEST_PROPERTY_ID + "\"}}";
 	public static final String JSON_TIME_VALUE = "{\"type\":\""
 			+ JacksonValue.JSON_VALUE_TYPE_TIME
 			+ "\", \"value\":{\"time\":\"+00000002013-10-28T00:00:00Z\",\"timezone\":0,\"before\":0,\"after\":0,\"precision\":11,\"calendarmodel\":\"http://www.wikidata.org/entity/Q1985727\"}}";

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/json/jackson/TestInnerValueObjects.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/json/jackson/TestInnerValueObjects.java
@@ -20,15 +20,14 @@ package org.wikidata.wdtk.datamodel.json.jackson;
  * #L%
  */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-
+import com.fasterxml.jackson.databind.JsonMappingException;
 import org.junit.Before;
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonInnerEntityId;
 import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonInnerMonolingualText;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 /**
  * This class tests the inner objects lying behind the …ValueImpl-classes.
@@ -38,15 +37,12 @@ import com.fasterxml.jackson.databind.JsonMappingException;
  */
 public class TestInnerValueObjects {
 
-	private static String itemType = "item";
-	private static String wrongType = "wrongType";
-
 	private JacksonInnerEntityId testEntityId;
 	private JacksonInnerMonolingualText testMonolingualText;
 
 	@Before
 	public void setupTestEntityIds() throws JsonMappingException {
-		this.testEntityId = new JacksonInnerEntityId(itemType, 1);
+		this.testEntityId = new JacksonInnerEntityId("Q1");
 	}
 
 	@Before
@@ -57,16 +53,21 @@ public class TestInnerValueObjects {
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testEntityIdConstructor() throws JsonMappingException {
-		JacksonInnerEntityId testId = new JacksonInnerEntityId(wrongType, 1);
+		JacksonInnerEntityId testId = new JacksonInnerEntityId("W1");
 		testId.getStringId(); // should fail
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testEntityIdSetterLegacy() throws JsonMappingException {
+		JacksonInnerEntityId testId = new JacksonInnerEntityId();
+		testId.setNumericId(1);
+		testId.setJsonEntityType("wrongType"); // should fail
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testEntityIdSetter() throws JsonMappingException {
 		JacksonInnerEntityId testId = new JacksonInnerEntityId();
-		testId.setNumericId(1);
-		testId.setJsonEntityType(wrongType);
-		testId.getStringId(); // should fail
+		testId.setStringId("W1"); // should fail
 	}
 
 	@Test
@@ -75,11 +76,11 @@ public class TestInnerValueObjects {
 		assertEquals(this.testEntityId.getNumericId(), 1);
 
 		// test equals
-		assertEquals(this.testEntityId, new JacksonInnerEntityId("item", 1));
+		assertEquals(this.testEntityId, new JacksonInnerEntityId("Q1"));
 		assertEquals(this.testEntityId, this.testEntityId);
 		assertFalse(this.testEntityId.equals(new Object()));
 		assertFalse(this.testEntityId
-				.equals(new JacksonInnerEntityId("item", 2)));
+				.equals(new JacksonInnerEntityId("Q2")));
 
 	}
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/json/jackson/TestValue.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/json/jackson/TestValue.java
@@ -20,26 +20,15 @@ package org.wikidata.wdtk.datamodel.json.jackson;
  * #L%
  */
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.json.jackson.datavalues.*;
 
 import java.io.IOException;
 
-import org.junit.Test;
-import org.wikidata.wdtk.datamodel.helpers.Datamodel;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonInnerTime;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValue;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueGlobeCoordinates;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueItemId;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueMonolingualText;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValuePropertyId;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueQuantity;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueString;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonValueTime;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.junit.Assert.*;
 
 public class TestValue {
 
@@ -77,9 +66,25 @@ public class TestValue {
 	@Test
 	public void testItemIdValueToJava() throws
 			IOException {
-		JacksonValue result = mapper.readValue(JsonTestData.JSON_ITEM_ID_VALUE,
-				JacksonValue.class);
+		assertItemIdValue(mapper.readValue(JsonTestData.JSON_ITEM_ID_VALUE,
+				JacksonValue.class));
+	}
 
+	@Test
+	public void testItemIdValueToJavaWithoutId() throws
+			IOException {
+		assertItemIdValue(mapper.readValue(JsonTestData.JSON_ITEM_ID_VALUE_WITHOUT_ID,
+				JacksonValue.class));
+	}
+
+	@Test
+	public void testItemIdValueToJavaWithoutNumericalId() throws
+			IOException {
+		assertItemIdValue(mapper.readValue(JsonTestData.JSON_ITEM_ID_VALUE_WITHOUT_NUMERICAL_ID,
+				JacksonValue.class));
+	}
+
+	private void assertItemIdValue(JacksonValue result) {
 		assertTrue(result instanceof JacksonValueItemId);
 		((JacksonValueItemId) result).setSiteIri(Datamodel.SITE_WIKIDATA);
 


### PR DESCRIPTION
Not sure if it is the best implementation as it forces to make sure that the internal state of JacksonInnerEntityId is always consistent. But it has the advantage of being both backward and maybe forward compatible (if the "numerical-id" and "entity-type" fields are removed).

Closes #252