### PR TITLE
Moves Travis to Trusty and enables oraclejdk9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 jdk:
   - openjdk7
-  - openjdk7
+  - openjdk8
   - oraclejdk8
   - oraclejdk9
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: java
 jdk:
-  - oraclejdk7
+  - openjdk7
   - openjdk7
   - oraclejdk8
+  - oraclejdk9
 
 after_success:
   - mvn clean cobertura:cobertura coveralls:cobertura
 
+dist: trusty
 sudo: false
 
 cache:


### PR DESCRIPTION
Drops oraclejdk7 that does not seems to be supported anymore