### PR TITLE
Add support for updating terms on items.

### DIFF
--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/StatementUpdate.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/StatementUpdate.java
@@ -42,6 +42,8 @@ import org.wikidata.wdtk.datamodel.json.jackson.JacksonObjectFactory;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -168,6 +170,7 @@ public class StatementUpdate {
 	}
 	
 	@JsonProperty("claims")
+	@JsonInclude(Include.NON_EMPTY)
 	public List<Statement> getUpdatedStatements() {
 		DatamodelConverter datamodelConverter = new DatamodelConverter(
 				new JacksonObjectFactory());

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdate.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdate.java
@@ -1,0 +1,310 @@
+package org.wikidata.wdtk.wikibaseapi;
+
+/*
+ * #%L
+ * Wikidata Toolkit Wikibase API
+ * %%
+ * Copyright (C) 2014 - 2015 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Collection;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
+import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonInnerMonolingualText;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+
+/**
+ * This class extends StatementUpdate to support update to terms (labels,
+ * descriptions and aliases).
+ * 
+ * Various safeguards are implemented in this interface:
+ * - aliases are added and deleted independently
+ * - duplicate aliases cannot be added
+ * - adding an alias in a language that does not have a label sets the label instead
+ * 
+ * @author antonin
+ */
+public class TermStatementUpdate extends StatementUpdate {
+	static final Logger logger = LoggerFactory.getLogger(TermStatementUpdate.class);
+    
+    /**
+     * Just adding a "write" field to keep track of whether
+     * we have changed this value. That helps keep the edit cleaner.
+     * 
+     * @author antonin
+     */
+    private class NameWithUpdate {
+        public MonolingualTextValue value;
+        public boolean write;
+        
+        public NameWithUpdate(MonolingualTextValue value, boolean write) {
+            this.value = value;
+            this.write = write;
+        }
+    }
+    
+    /**
+     * Keeps track of the current state of aliases after updates.
+     * 
+     * @author antonin
+     */
+    private class AliasesWithUpdate {
+        public List<MonolingualTextValue> aliases;
+        public boolean write;
+        
+        public AliasesWithUpdate(List<MonolingualTextValue> aliases, boolean write) {
+            this.aliases = aliases;
+            this.write = write;
+        }
+    }
+    
+    @JsonIgnore
+    final Map<String, NameWithUpdate> newLabels;
+    @JsonIgnore
+    final Map<String, NameWithUpdate> newDescriptions;
+    @JsonIgnore
+    final Map<String, AliasesWithUpdate> newAliases;
+    
+    /**
+     * Constructor. Plans an update on the statements and terms of a document.
+     * Statements are merged according to StatementUpdate's logic. Labels and
+     * descriptions will overwrite any existing values. The first aliases added 
+     * on a language where no label is available yet will be treated as a label
+     * instead. Duplicate aliases are ignored.
+     * 
+     * @param currentDocument
+     * 			the current state of the entity
+     * @param addStatements
+     * 			the statements to be added to the entity.
+     * @param deleteStatements
+     *          the statements to be removed from the entity
+     * @param addLabels
+     *          the labels to be added to the entity
+     * @param addDescriptions
+     * 			the descriptions to be added to the entity
+     * @param addAliases
+     *          the aliases to be added to the entity
+     * @param deleteAliases
+     *          the aliases to be removed from the entity
+     */
+    public TermStatementUpdate(ItemDocument currentDocument,
+            List<Statement> addStatements,
+            List<Statement> deleteStatements,
+            List<MonolingualTextValue> addLabels,
+            List<MonolingualTextValue> addDescriptions,
+            List<MonolingualTextValue> addAliases,
+            List<MonolingualTextValue> deleteAliases) {
+        super(currentDocument, addStatements, deleteStatements);
+        
+        // Fill the terms with their current values
+        newLabels = initUpdatesFromCurrentValues(currentDocument.getLabels().values());
+        newDescriptions = initUpdatesFromCurrentValues(currentDocument.getLabels().values());
+        newAliases = new HashMap<>();
+        for(Map.Entry<String, List<MonolingualTextValue>> entry : currentDocument.getAliases().entrySet()) {
+            newAliases.put(entry.getKey(),
+                    new AliasesWithUpdate(
+                    		new ArrayList<>(entry.getValue()), false));
+        }
+        
+        // Add changes
+        processLabels(addLabels);
+        processDescriptions(addDescriptions);
+        processAliases(addAliases, deleteAliases);
+    }
+    
+    /**
+     * Initializes the list of current values for a type of terms (label or description).
+     * 
+     * @param currentValues
+     *      current values for the type of terms
+     * @return a map of updates (where all terms are marked as not for write)
+     */
+    protected Map<String, NameWithUpdate> initUpdatesFromCurrentValues(Collection<MonolingualTextValue> currentValues) {
+    	Map<String, NameWithUpdate> updates = new HashMap<>();
+        for(MonolingualTextValue label: currentValues) {
+            updates.put(label.getLanguageCode(),
+                    new NameWithUpdate(label, false));
+        }
+        return updates;
+    }
+
+    /**
+     * Processes changes on aliases, updating the planned state of the item.
+     * 
+     * @param addAliases
+     * 		aliases that should be added to the document
+     * @param deleteAliases
+     * 		aliases that should be removed from the document
+     */
+    protected void processAliases(List<MonolingualTextValue> addAliases, List<MonolingualTextValue> deleteAliases) {
+        for(MonolingualTextValue val : addAliases) {
+            addAlias(val);
+        }
+        for(MonolingualTextValue val : deleteAliases) {
+            deleteAlias(val);
+        }
+    }
+
+    /**
+     * Deletes an individual alias
+     * 
+     * @param alias
+     * 		the alias to delete
+     */
+    protected void deleteAlias(MonolingualTextValue alias) {
+        String lang = alias.getLanguageCode();
+        AliasesWithUpdate currentAliases = newAliases.get(lang);
+        if (currentAliases != null) {
+            currentAliases.aliases.remove(alias);
+            currentAliases.write = true;
+        }
+    }
+
+    /**
+     * Adds an individual alias. It will be merged with the current
+     * list of aliases, or added as a label if there is no label for
+     * this item in this language yet.
+     * 
+     * @param alias
+     * 		the alias to add
+     */
+    protected void addAlias(MonolingualTextValue alias) {
+        String lang = alias.getLanguageCode();
+        AliasesWithUpdate currentAliasesUpdate = newAliases.get(lang);
+        
+        // If there isn't any label for that language, put the alias there
+        if (!newLabels.containsKey(lang)) {
+            newLabels.put(lang, new NameWithUpdate(alias, true));
+        } else {
+        	if (currentAliasesUpdate == null) {
+        		currentAliasesUpdate = new AliasesWithUpdate(new ArrayList<MonolingualTextValue>(), true);
+        	}
+        	List<MonolingualTextValue> currentAliases = currentAliasesUpdate.aliases;
+        	if(!currentAliases.contains(alias)) {
+        		currentAliases.add(alias);
+        		currentAliasesUpdate.write = true;
+        	}
+        	newAliases.put(lang, currentAliasesUpdate);
+        }
+    }
+
+    /**
+     * Adds descriptions to the item.
+     * 
+     * @param descriptions
+     * 		the descriptions to add
+     */
+    protected void processDescriptions(List<MonolingualTextValue> descriptions) {
+        for(MonolingualTextValue description : descriptions) {
+            newDescriptions.put(description.getLanguageCode(),
+                    new NameWithUpdate(description, true));
+        }
+    }
+
+    /**
+     * Adds labels to the item
+     * 
+     * @param labels
+     * 		the labels to add
+     */
+    protected void processLabels(List<MonolingualTextValue> labels) {
+        for(MonolingualTextValue label : labels) {
+            newLabels.put(label.getLanguageCode(),
+                    new NameWithUpdate(label, true));
+        }
+        
+    }
+    
+    /**
+     * Label accessor provided for JSON serialization only.
+     */
+    @JsonProperty("labels")
+    @JsonInclude(Include.NON_EMPTY)
+    public Map<String, JacksonInnerMonolingualText> getLabelUpdates() {
+    	return getMonolingualUpdatedValues(newLabels);
+    }
+    
+    /**
+     * Description accessor provided for JSON serialization only.
+     */
+    @JsonProperty("descriptions")
+    @JsonInclude(Include.NON_EMPTY)
+    public Map<String, JacksonInnerMonolingualText> getDescriptionUpdates() {
+    	return getMonolingualUpdatedValues(newDescriptions);
+    }
+    
+    /**
+     * Alias accessor provided for JSON serialization only
+     */
+    @JsonProperty("aliases")
+    @JsonInclude(Include.NON_EMPTY)
+    public Map<String, List<JacksonInnerMonolingualText> > getAliasUpdates() {
+    	
+    	Map<String, List<JacksonInnerMonolingualText>> updatedValues = new HashMap<>();
+    	for(Entry<String,AliasesWithUpdate> entry : newAliases.entrySet()) {
+    		AliasesWithUpdate update = entry.getValue();
+    		if (!update.write) {
+    			continue;
+    		}
+    		List<JacksonInnerMonolingualText> convertedAliases = new ArrayList<>();
+    		for(MonolingualTextValue alias : update.aliases) {
+    			convertedAliases.add(monolingualToJackson(alias));
+    		}
+    		updatedValues.put(entry.getKey(), convertedAliases);
+    	}
+    	return updatedValues;
+    }
+    
+    /**
+     * Helper to format term updates as expected by the Wikibase API
+     * @param updates
+     * 		planned updates for the type of term
+     * @return map ready to be serialized as JSON by Jackson
+     */
+    protected Map<String, JacksonInnerMonolingualText> getMonolingualUpdatedValues(Map<String, NameWithUpdate> updates) {
+    	Map<String, JacksonInnerMonolingualText> updatedValues = new HashMap<>();
+    	for(NameWithUpdate update : updates.values()) {
+            if (!update.write) {
+                continue;
+            }
+            updatedValues.put(update.value.getLanguageCode(), monolingualToJackson(update.value));
+    	}
+    	return updatedValues;
+    }
+    
+    /**
+     * Creates a monolingual value that is suitable for JSON serialization.
+     * @param monolingualTextValue
+     * 		target monolingual value for serialization
+     * @return Jackson implementation that is serialized appropriately
+     */
+    protected JacksonInnerMonolingualText monolingualToJackson(MonolingualTextValue monolingualTextValue) {
+    	return new JacksonInnerMonolingualText(monolingualTextValue.getLanguageCode(), monolingualTextValue.getText());
+    }
+}

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdateTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdateTest.java
@@ -1,0 +1,226 @@
+package org.wikidata.wdtk.wikibaseapi;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Collections;
+import java.util.List;
+import java.util.ArrayList;
+
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.helpers.DatamodelConverter;
+import org.wikidata.wdtk.datamodel.helpers.ItemDocumentBuilder;
+import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
+import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+import org.wikidata.wdtk.datamodel.json.jackson.JacksonObjectFactory;
+import org.wikidata.wdtk.datamodel.json.jackson.JsonSerializer;
+import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonInnerMonolingualText;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+/*
+ * #%L
+ * Wikidata Toolkit Wikibase API
+ * %%
+ * Copyright (C) 2014 - 2015 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+public class TermStatementUpdateTest {
+	final static ItemIdValue Q1 = Datamodel.makeWikidataItemIdValue("Q1");
+	
+	protected TermStatementUpdate makeUpdate(ItemDocument doc, List<MonolingualTextValue> labels,
+			List<MonolingualTextValue> descriptions,
+			List<MonolingualTextValue> addedLabels,
+			List<MonolingualTextValue> deletedLabels) {
+		return new TermStatementUpdate(
+				doc,
+				Collections.<Statement> emptyList(),
+				Collections.<Statement> emptyList(),
+				labels, descriptions, addedLabels, deletedLabels);
+	}
+	
+	/**
+	 * Adding a label on an empty item.
+	 */
+	@Test
+	public void testAddLabel() throws JsonProcessingException {
+		ItemDocument currentDocument = ItemDocumentBuilder.forItemId(Q1).build();
+		
+		MonolingualTextValue label = Datamodel.makeMonolingualTextValue("Apfelstrudel", "de");
+		
+		TermStatementUpdate su = makeUpdate(currentDocument,
+				Collections.singletonList(label),
+				Collections.<MonolingualTextValue> emptyList(),
+				Collections.<MonolingualTextValue> emptyList(),
+				Collections.<MonolingualTextValue> emptyList());
+		
+		// Check model
+		
+		assertEquals(Collections.singleton("de"), su.getLabelUpdates().keySet());
+		assertEquals(label.getText(), su.getLabelUpdates().get("de").getText());
+		assertTrue(su.getAliasUpdates().isEmpty());
+		assertTrue(su.getDescriptionUpdates().isEmpty());
+		
+		// Check JSON output
+		assertEquals("{\"labels\":{\"de\":{\"language\":\"de\",\"text\":\"Apfelstrudel\"}}}",
+				su.getJsonUpdateString());
+	}
+	
+	/**
+	 * When trying to add an alias for a language that does not have
+	 * any label yet, add as label instead.
+	 */
+	@Test
+	public void testAddAliasWithoutLabel() {
+		ItemDocument currentDocument = ItemDocumentBuilder.forItemId(Q1).build();
+		
+		MonolingualTextValue alias = Datamodel.makeMonolingualTextValue("Apfelstrudel", "de");
+		TermStatementUpdate su = makeUpdate(currentDocument,
+				Collections.<MonolingualTextValue> emptyList(),
+				Collections.<MonolingualTextValue> emptyList(),
+				Collections.singletonList(alias),
+				Collections.<MonolingualTextValue> emptyList());
+		
+		
+		assertEquals(su.getLabelUpdates().keySet(), Collections.singleton("de"));
+		assertEquals(su.getLabelUpdates().get("de").getText(), alias.getText());
+		assertTrue(su.getAliasUpdates().isEmpty());
+		assertTrue(su.getDescriptionUpdates().isEmpty());
+	}
+	
+	/**
+	 * Adding a label and an alias at the same time.
+	 */
+	@Test
+	public void testAddLabelAndAlias() throws JsonProcessingException {
+		ItemDocument currentDocument = ItemDocumentBuilder.forItemId(Q1).build();
+		MonolingualTextValue label = Datamodel.makeMonolingualTextValue("strudel aux pommes", "fr");
+		MonolingualTextValue alias = Datamodel.makeMonolingualTextValue("Apfelstrudel", "fr");
+		TermStatementUpdate su = makeUpdate(currentDocument,
+				Collections.singletonList(label),
+				Collections.<MonolingualTextValue> emptyList(),
+				Collections.singletonList(alias),
+				Collections.<MonolingualTextValue> emptyList());
+		
+		assertEquals(Collections.singleton("fr"), su.getLabelUpdates().keySet());
+		assertEquals(label.getText(), su.getLabelUpdates().get("fr").getText());
+		assertEquals(Collections.singleton("fr"), su.getAliasUpdates().keySet());
+		assertEquals(alias.getText(), su.getAliasUpdates().get("fr").get(0).getText());
+		assertTrue(su.getDescriptionUpdates().isEmpty());
+	}
+	
+	/**
+	 * Adding the same alias twice.
+	 */
+	@Test
+	public void testAliasTwice() throws JsonProcessingException {
+		MonolingualTextValue label = Datamodel.makeMonolingualTextValue("strudel aux pommes", "fr");
+		ItemDocument currentDocument = ItemDocumentBuilder.forItemId(Q1).withLabel(label).build();
+		MonolingualTextValue alias = Datamodel.makeMonolingualTextValue("Apfelstrudel", "fr");
+		List<MonolingualTextValue> newAliases = new ArrayList<>();
+		newAliases.add(alias);
+		newAliases.add(alias);
+		TermStatementUpdate su = makeUpdate(currentDocument,
+				Collections.<MonolingualTextValue> emptyList(),
+				Collections.<MonolingualTextValue> emptyList(),
+				newAliases,
+				Collections.<MonolingualTextValue> emptyList());
+		
+		assertTrue(su.getLabelUpdates().isEmpty());
+		assertEquals(su.getAliasUpdates().size(), 1);
+		assertEquals("{\"aliases\":{\"fr\":[{\"language\":\"fr\",\"text\":\"Apfelstrudel\"}]}}",
+				su.getJsonUpdateString());
+	}
+	
+	/**
+	 * Adding an alias on an item that has already got one
+	 */
+	@Test
+	public void testAliasMerge() throws JsonProcessingException {
+		MonolingualTextValue label = Datamodel.makeMonolingualTextValue("strudel aux pommes", "fr");
+		MonolingualTextValue alias = Datamodel.makeMonolingualTextValue("Apfelstrudel", "fr");
+		ItemDocument currentDocument = ItemDocumentBuilder.forItemId(Q1).withLabel(label).withAlias(alias).build();
+		
+
+		MonolingualTextValue newAlias = Datamodel.makeMonolingualTextValue("Apfelstrudeln", "fr");
+		TermStatementUpdate su = makeUpdate(currentDocument,
+				Collections.<MonolingualTextValue> emptyList(),
+				Collections.<MonolingualTextValue> emptyList(),
+				Collections.singletonList(newAlias),
+				Collections.<MonolingualTextValue> emptyList());
+		
+		assertTrue(su.getLabelUpdates().isEmpty());
+		assertEquals(su.getAliasUpdates().size(), 1);
+		assertEquals(su.getAliasUpdates().get("fr").size(), 2);
+		assertEquals("{\"aliases\":{\"fr\":[{\"language\":\"fr\",\"text\":\"Apfelstrudel\"},{\"language\":\"fr\",\"text\":\"Apfelstrudeln\"}]}}",
+				su.getJsonUpdateString());
+	}
+	
+	/**
+	 * Deleting an alias
+	 */
+	@Test
+	public void testDeleteAlias() throws JsonProcessingException {
+		MonolingualTextValue label = Datamodel.makeMonolingualTextValue("strudel aux pommes", "fr");
+		MonolingualTextValue alias = Datamodel.makeMonolingualTextValue("Apfelstrudel", "fr");
+		ItemDocument currentDocument = ItemDocumentBuilder.forItemId(Q1).withLabel(label).withAlias(alias).build();
+		
+		TermStatementUpdate su = makeUpdate(currentDocument,
+				Collections.<MonolingualTextValue> emptyList(),
+				Collections.<MonolingualTextValue> emptyList(),
+				Collections.<MonolingualTextValue> emptyList(),
+				Collections.singletonList(alias)
+				);
+		
+		assertTrue(su.getLabelUpdates().isEmpty());
+		assertEquals(su.getAliasUpdates().size(), 1);
+		assertEquals(su.getAliasUpdates().get("fr").size(), 0);
+		assertEquals("{\"aliases\":{\"fr\":[]}}",
+				su.getJsonUpdateString());
+	}
+	
+	/**
+	 * Adding a description, for the sake of coverage…
+	 */
+	@Test
+	public void testDescription() throws JsonProcessingException {
+		MonolingualTextValue label = Datamodel.makeMonolingualTextValue("strudel aux pommes", "fr");
+		MonolingualTextValue alias = Datamodel.makeMonolingualTextValue("Apfelstrudel", "fr");
+		ItemDocument currentDocument = ItemDocumentBuilder.forItemId(Q1).withLabel(label).withAlias(alias).build();
+
+		MonolingualTextValue description = Datamodel.makeMonolingualTextValue("délicieuse pâtisserie aux pommes", "fr");
+		TermStatementUpdate su = makeUpdate(currentDocument,
+				Collections.<MonolingualTextValue> emptyList(),
+				Collections.singletonList(description),
+				Collections.<MonolingualTextValue> emptyList(),
+				Collections.<MonolingualTextValue> emptyList());
+		
+		assertTrue(su.getLabelUpdates().isEmpty());
+		assertTrue(su.getAliasUpdates().isEmpty());
+		assertEquals(Collections.singleton("fr"), su.getDescriptionUpdates().keySet());
+		assertEquals("délicieuse pâtisserie aux pommes", su.getDescriptionUpdates().get("fr").getText());
+		assertEquals("{\"descriptions\":{\"fr\":{\"language\":\"fr\",\"text\":\"délicieuse pâtisserie aux pommes\"}}}",
+				su.getJsonUpdateString());
+	}
+}


### PR DESCRIPTION
Technically not all the operations exposed by the API are supported yet: it is not possible to delete labels and descriptions yet. I am not sure I want to add support for that as I don't think it is critical.

This PR is not quite finished yet as it would be good to expose this functionality in WikibaseDataEditor. But if we want to move to a Builder-based construction, we should adapt WikibaseDataEditor accordingly - I am not sure what it would look like.

I am also not very happy with the fact that it currently only accepts `ItemDocument`s as initial entity - it should accept `PropertyDocument`s too, but it looks like curiously there is no common superclass of these two, so generics seem to be required here?