### PR TITLE
Skip unintentional null edits

### DIFF
--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/StatementUpdate.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/StatementUpdate.java
@@ -189,6 +189,16 @@ public class StatementUpdate {
 		}
 		return updatedStatements;
 	}
+	
+	/**
+	 * Returns true when the edit is not going to change anything on the item.
+	 * In this case, the change can be safely skipped, except if the side effects
+	 * of a null edit are desired.
+	 */
+	@JsonIgnore
+	public boolean isNull() {
+		return getUpdatedStatements().isEmpty();
+	}
 
 	/**
 	 * Marks the given lists of statements for being added to or deleted from

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/StatementUpdate.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/StatementUpdate.java
@@ -196,7 +196,7 @@ public class StatementUpdate {
 	 * of a null edit are desired.
 	 */
 	@JsonIgnore
-	public boolean isNull() {
+	public boolean isEmptyEdit() {
 		return getUpdatedStatements().isEmpty();
 	}
 

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdate.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdate.java
@@ -32,7 +32,7 @@ import org.slf4j.LoggerFactory;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
-import org.wikidata.wdtk.datamodel.json.jackson.datavalues.JacksonInnerMonolingualText;
+import org.wikidata.wdtk.datamodel.json.jackson.JacksonMonolingualTextValue;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -262,7 +262,7 @@ public class TermStatementUpdate extends StatementUpdate {
      */
     @JsonProperty("labels")
     @JsonInclude(Include.NON_EMPTY)
-    public Map<String, JacksonInnerMonolingualText> getLabelUpdates() {
+    public Map<String, JacksonMonolingualTextValue> getLabelUpdates() {
     	return getMonolingualUpdatedValues(newLabels);
     }
     
@@ -271,7 +271,7 @@ public class TermStatementUpdate extends StatementUpdate {
      */
     @JsonProperty("descriptions")
     @JsonInclude(Include.NON_EMPTY)
-    public Map<String, JacksonInnerMonolingualText> getDescriptionUpdates() {
+    public Map<String, JacksonMonolingualTextValue> getDescriptionUpdates() {
     	return getMonolingualUpdatedValues(newDescriptions);
     }
     
@@ -280,15 +280,15 @@ public class TermStatementUpdate extends StatementUpdate {
      */
     @JsonProperty("aliases")
     @JsonInclude(Include.NON_EMPTY)
-    public Map<String, List<JacksonInnerMonolingualText> > getAliasUpdates() {
+    public Map<String, List<JacksonMonolingualTextValue>> getAliasUpdates() {
     	
-    	Map<String, List<JacksonInnerMonolingualText>> updatedValues = new HashMap<>();
+    	Map<String, List<JacksonMonolingualTextValue>> updatedValues = new HashMap<>();
     	for(Entry<String,AliasesWithUpdate> entry : newAliases.entrySet()) {
     		AliasesWithUpdate update = entry.getValue();
     		if (!update.write) {
     			continue;
     		}
-    		List<JacksonInnerMonolingualText> convertedAliases = new ArrayList<>();
+    		List<JacksonMonolingualTextValue> convertedAliases = new ArrayList<>();
     		for(MonolingualTextValue alias : update.aliases) {
     			convertedAliases.add(monolingualToJackson(alias));
     		}
@@ -315,8 +315,8 @@ public class TermStatementUpdate extends StatementUpdate {
      * 		planned updates for the type of term
      * @return map ready to be serialized as JSON by Jackson
      */
-    protected Map<String, JacksonInnerMonolingualText> getMonolingualUpdatedValues(Map<String, NameWithUpdate> updates) {
-    	Map<String, JacksonInnerMonolingualText> updatedValues = new HashMap<>();
+    protected Map<String, JacksonMonolingualTextValue> getMonolingualUpdatedValues(Map<String, NameWithUpdate> updates) {
+    	Map<String, JacksonMonolingualTextValue> updatedValues = new HashMap<>();
     	for(NameWithUpdate update : updates.values()) {
             if (!update.write) {
                 continue;
@@ -332,7 +332,7 @@ public class TermStatementUpdate extends StatementUpdate {
      * 		target monolingual value for serialization
      * @return Jackson implementation that is serialized appropriately
      */
-    protected JacksonInnerMonolingualText monolingualToJackson(MonolingualTextValue monolingualTextValue) {
-    	return new JacksonInnerMonolingualText(monolingualTextValue.getLanguageCode(), monolingualTextValue.getText());
+    protected JacksonMonolingualTextValue monolingualToJackson(MonolingualTextValue monolingualTextValue) {
+    	return new JacksonMonolingualTextValue(monolingualTextValue.getLanguageCode(), monolingualTextValue.getText());
     }
 }

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdate.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdate.java
@@ -291,6 +291,18 @@ public class TermStatementUpdate extends StatementUpdate {
     }
     
     /**
+     * Is this change null?
+     */
+    @Override
+    @JsonIgnore
+    public boolean isNull() {
+    	return (super.isNull() && 
+    			getLabelUpdates().isEmpty() &&
+    			getDescriptionUpdates().isEmpty() &&
+    			getAliasUpdates().isEmpty());
+    }
+    
+    /**
      * Helper to format term updates as expected by the Wikibase API
      * @param updates
      * 		planned updates for the type of term

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdate.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdate.java
@@ -302,8 +302,8 @@ public class TermStatementUpdate extends StatementUpdate {
      */
     @Override
     @JsonIgnore
-    public boolean isNull() {
-    	return (super.isNull() && 
+    public boolean isEmptyEdit() {
+    	return (super.isEmptyEdit() && 
     			getLabelUpdates().isEmpty() &&
     			getDescriptionUpdates().isEmpty() &&
     			getAliasUpdates().isEmpty());

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdate.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdate.java
@@ -124,7 +124,7 @@ public class TermStatementUpdate extends StatementUpdate {
         
         // Fill the terms with their current values
         newLabels = initUpdatesFromCurrentValues(currentDocument.getLabels().values());
-        newDescriptions = initUpdatesFromCurrentValues(currentDocument.getLabels().values());
+        newDescriptions = initUpdatesFromCurrentValues(currentDocument.getDescriptions().values());
         newAliases = new HashMap<>();
         for(Map.Entry<String, List<MonolingualTextValue>> entry : currentDocument.getAliases().entrySet()) {
             newAliases.put(entry.getKey(),
@@ -224,8 +224,12 @@ public class TermStatementUpdate extends StatementUpdate {
      */
     protected void processDescriptions(List<MonolingualTextValue> descriptions) {
         for(MonolingualTextValue description : descriptions) {
-            newDescriptions.put(description.getLanguageCode(),
+        	NameWithUpdate currentValue = newDescriptions.get(description.getLanguageCode());
+        	// only mark the description as added if the value we are writing is different from the current one
+        	if (currentValue == null || !currentValue.value.equals(description)) {
+        		newDescriptions.put(description.getLanguageCode(),
                     new NameWithUpdate(description, true));
+        	}
         }
     }
 
@@ -238,14 +242,17 @@ public class TermStatementUpdate extends StatementUpdate {
     protected void processLabels(List<MonolingualTextValue> labels) {
         for(MonolingualTextValue label : labels) {
         	String lang = label.getLanguageCode();
-            newLabels.put(lang,
-                    new NameWithUpdate(label, true));
-            
-            // Delete any alias that matches the new label
-            AliasesWithUpdate currentAliases = newAliases.get(lang);
-            if (currentAliases != null && currentAliases.aliases.contains(label)) {
-            	deleteAlias(label);
-            }
+        	NameWithUpdate currentValue = newLabels.get(lang);
+        	if (currentValue == null || !currentValue.value.equals(label)) {
+	            newLabels.put(lang,
+	                    new NameWithUpdate(label, true));
+	            
+	            // Delete any alias that matches the new label
+	            AliasesWithUpdate currentAliases = newAliases.get(lang);
+	            if (currentAliases != null && currentAliases.aliases.contains(label)) {
+	            	deleteAlias(label);
+	            }
+        	}
         }
         
     }

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
@@ -497,11 +497,15 @@ public class WikibaseDataEditor {
 
 		StatementUpdate statementUpdate = new StatementUpdate(currentDocument,
 				addStatements, deleteStatements);
-
-		return (T) this.wbEditEntityAction.wbEditEntity(currentDocument
+		
+		if (statementUpdate.isNull()) {
+			return currentDocument;
+		} else {
+			return (T) this.wbEditEntityAction.wbEditEntity(currentDocument
 				.getEntityId().getId(), null, null, null, statementUpdate
 				.getJsonUpdateString(), false, this.editAsBot, currentDocument
 				.getRevisionId(), summary);
+		}
 	}
 	
 	/**
@@ -551,10 +555,14 @@ public class WikibaseDataEditor {
 		TermStatementUpdate termStatementUpdate = new TermStatementUpdate(currentDocument,
 				addStatements, deleteStatements,
 				addLabels, addDescriptions, addAliases, deleteAliases);
-
-		return (ItemDocument) this.wbEditEntityAction.wbEditEntity(currentDocument
+		
+		if (termStatementUpdate.isNull()) {
+			return currentDocument;
+		} else {
+			return (ItemDocument) this.wbEditEntityAction.wbEditEntity(currentDocument
 				.getEntityId().getId(), null, null, null, termStatementUpdate
 				.getJsonUpdateString(), false, this.editAsBot, currentDocument
 				.getRevisionId(), summary);
+		}
 	}
 }

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
@@ -21,6 +21,7 @@ package org.wikidata.wdtk.wikibaseapi;
  */
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -564,5 +565,75 @@ public class WikibaseDataEditor {
 				.getJsonUpdateString(), false, this.editAsBot, currentDocument
 				.getRevisionId(), summary);
 		}
+	}
+	
+	/**
+	 * Performs a null edit on an item. This has some effects on Wikibase,
+	 * such as refreshing the labels of the referred items in the UI.
+	 * 
+	 * @param currentDocument
+	 * 			the document to perform a null edit on
+	 * @param summary
+	 * 			a summary that can be passed to Wikibase (although it is not
+	 * 			clear if it is kept at all)
+	 * @throws MediaWikiApiErrorException
+	 * 	        if the API returns errors
+	 * @throws IOException 
+	 * 		    if there are any IO errors, such as missing network connection
+	 */
+	public <T extends StatementDocument> void nullEdit(ItemIdValue itemId, String summary)
+			throws IOException, MediaWikiApiErrorException {
+		ItemDocument currentDocument = (ItemDocument) this.wikibaseDataFetcher
+				.getEntityDocument(itemId.getId());
+		
+		nullEdit(currentDocument, summary);
+	}
+	
+	/**
+	 * Performs a null edit on a property. This has some effects on Wikibase,
+	 * such as refreshing the labels of the referred items in the UI.
+	 * 
+	 * @param currentDocument
+	 * 			the document to perform a null edit on
+	 * @param summary
+	 * 			a summary that can be passed to Wikibase (although it is not
+	 * 			clear if it is kept at all)
+	 * @throws MediaWikiApiErrorException
+	 * 	        if the API returns errors
+	 * @throws IOException 
+	 * 		    if there are any IO errors, such as missing network connection
+	 */
+	public <T extends StatementDocument> void nullEdit(PropertyIdValue propertyId, String summary)
+			throws IOException, MediaWikiApiErrorException {
+		PropertyDocument currentDocument = (PropertyDocument) this.wikibaseDataFetcher
+				.getEntityDocument(propertyId.getId());
+		
+		nullEdit(currentDocument, summary);
+	}
+	
+	/**
+	 * Performs a null edit on an entity. This has some effects on Wikibase,
+	 * such as refreshing the labels of the referred items in the UI.
+	 * 
+	 * @param currentDocument
+	 * 			the document to perform a null edit on
+	 * @param summary
+	 * 			a summary that can be passed to Wikibase (although it is not
+	 * 			clear if it is kept at all)
+	 * @throws MediaWikiApiErrorException
+	 * 	        if the API returns errors
+	 * @throws IOException 
+	 * 		    if there are any IO errors, such as missing network connection
+	 */
+	@SuppressWarnings("unchecked")
+	public <T extends StatementDocument> T nullEdit(T currentDocument, String summary)
+			throws IOException, MediaWikiApiErrorException {
+		StatementUpdate statementUpdate = new StatementUpdate(currentDocument,
+				Collections.<Statement>emptyList(), Collections.<Statement>emptyList());
+		
+	    return (T) this.wbEditEntityAction.wbEditEntity(currentDocument
+				.getEntityId().getId(), null, null, null, statementUpdate
+				.getJsonUpdateString(), false, this.editAsBot, currentDocument
+				.getRevisionId(), summary);
 	}
 }

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
@@ -499,7 +499,7 @@ public class WikibaseDataEditor {
 		StatementUpdate statementUpdate = new StatementUpdate(currentDocument,
 				addStatements, deleteStatements);
 		
-		if (statementUpdate.isNull()) {
+		if (statementUpdate.isEmptyEdit()) {
 			return currentDocument;
 		} else {
 			return (T) this.wbEditEntityAction.wbEditEntity(currentDocument
@@ -557,7 +557,7 @@ public class WikibaseDataEditor {
 				addStatements, deleteStatements,
 				addLabels, addDescriptions, addAliases, deleteAliases);
 		
-		if (termStatementUpdate.isNull()) {
+		if (termStatementUpdate.isEmptyEdit()) {
 			return currentDocument;
 		} else {
 			return (ItemDocument) this.wbEditEntityAction.wbEditEntity(currentDocument
@@ -573,9 +573,6 @@ public class WikibaseDataEditor {
 	 * 
 	 * @param currentDocument
 	 * 			the document to perform a null edit on
-	 * @param summary
-	 * 			a summary that can be passed to Wikibase (although it is not
-	 * 			clear if it is kept at all)
 	 * @throws MediaWikiApiErrorException
 	 * 	        if the API returns errors
 	 * @throws IOException 
@@ -586,7 +583,7 @@ public class WikibaseDataEditor {
 		ItemDocument currentDocument = (ItemDocument) this.wikibaseDataFetcher
 				.getEntityDocument(itemId.getId());
 		
-		nullEdit(currentDocument, summary);
+		nullEdit(currentDocument);
 	}
 	
 	/**
@@ -595,20 +592,17 @@ public class WikibaseDataEditor {
 	 * 
 	 * @param currentDocument
 	 * 			the document to perform a null edit on
-	 * @param summary
-	 * 			a summary that can be passed to Wikibase (although it is not
-	 * 			clear if it is kept at all)
 	 * @throws MediaWikiApiErrorException
 	 * 	        if the API returns errors
 	 * @throws IOException 
 	 * 		    if there are any IO errors, such as missing network connection
 	 */
-	public <T extends StatementDocument> void nullEdit(PropertyIdValue propertyId, String summary)
+	public <T extends StatementDocument> void nullEdit(PropertyIdValue propertyId)
 			throws IOException, MediaWikiApiErrorException {
 		PropertyDocument currentDocument = (PropertyDocument) this.wikibaseDataFetcher
 				.getEntityDocument(propertyId.getId());
 		
-		nullEdit(currentDocument, summary);
+		nullEdit(currentDocument);
 	}
 	
 	/**
@@ -617,16 +611,13 @@ public class WikibaseDataEditor {
 	 * 
 	 * @param currentDocument
 	 * 			the document to perform a null edit on
-	 * @param summary
-	 * 			a summary that can be passed to Wikibase (although it is not
-	 * 			clear if it is kept at all)
 	 * @throws MediaWikiApiErrorException
 	 * 	        if the API returns errors
 	 * @throws IOException 
 	 * 		    if there are any IO errors, such as missing network connection
 	 */
 	@SuppressWarnings("unchecked")
-	public <T extends StatementDocument> T nullEdit(T currentDocument, String summary)
+	public <T extends StatementDocument> T nullEdit(T currentDocument)
 			throws IOException, MediaWikiApiErrorException {
 		StatementUpdate statementUpdate = new StatementUpdate(currentDocument,
 				Collections.<Statement>emptyList(), Collections.<Statement>emptyList());
@@ -634,6 +625,6 @@ public class WikibaseDataEditor {
 	    return (T) this.wbEditEntityAction.wbEditEntity(currentDocument
 				.getEntityId().getId(), null, null, null, statementUpdate
 				.getJsonUpdateString(), false, this.editAsBot, currentDocument
-				.getRevisionId(), summary);
+				.getRevisionId(), null);
 	}
 }

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/StatementUpdateTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/StatementUpdateTest.java
@@ -275,7 +275,7 @@ public class StatementUpdateTest {
 		assertTrue(su.toKeep.containsKey(P2));
 		assertEquals(1, su.toKeep.get(P2).size());
 		assertEquals(s3, su.toKeep.get(P2).get(0).statement);
-		assertFalse(su.isNull());
+		assertFalse(su.isEmptyEdit());
 	}
 
 	@Test
@@ -303,7 +303,7 @@ public class StatementUpdateTest {
 		assertTrue(su.toKeep.get(P1).get(0).write);
 		assertEquals(s2, su.toKeep.get(P1).get(1).statement);
 		assertFalse(su.toKeep.get(P1).get(1).write);
-		assertFalse(su.isNull());
+		assertFalse(su.isEmptyEdit());
 	}
 	
 	@Test
@@ -320,7 +320,7 @@ public class StatementUpdateTest {
 		
 		StatementUpdate su = new StatementUpdate(currentDocument,
 				Arrays.asList(s1dup), Arrays.asList(s2));
-		assertTrue(su.isNull());
+		assertTrue(su.isEmptyEdit());
 		
 	}
 
@@ -344,7 +344,7 @@ public class StatementUpdateTest {
 		assertEquals(1, su.toKeep.get(P3).size());
 		assertEquals(s1, su.toKeep.get(P3).get(0).statement);
 		assertTrue(su.toKeep.get(P3).get(0).write);
-		assertFalse(su.isNull());
+		assertFalse(su.isEmptyEdit());
 	}
 
 	@Test
@@ -379,7 +379,7 @@ public class StatementUpdateTest {
 		assertEquals(Arrays.asList("ID-s2", "ID-s5"), su.toDelete);
 		assertEquals(0, su.toKeep.size());
 		assertEquals(expectedJson, actualJson);
-		assertFalse(su.isNull());
+		assertFalse(su.isEmptyEdit());
 	}
 
 }

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/StatementUpdateTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/StatementUpdateTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -40,6 +41,10 @@ import org.wikidata.wdtk.datamodel.interfaces.Reference;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
 import org.wikidata.wdtk.datamodel.json.jackson.JsonSerializer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class StatementUpdateTest {
 
@@ -270,6 +275,7 @@ public class StatementUpdateTest {
 		assertTrue(su.toKeep.containsKey(P2));
 		assertEquals(1, su.toKeep.get(P2).size());
 		assertEquals(s3, su.toKeep.get(P2).get(0).statement);
+		assertFalse(su.isNull());
 	}
 
 	@Test
@@ -297,6 +303,25 @@ public class StatementUpdateTest {
 		assertTrue(su.toKeep.get(P1).get(0).write);
 		assertEquals(s2, su.toKeep.get(P1).get(1).statement);
 		assertFalse(su.toKeep.get(P1).get(1).write);
+		assertFalse(su.isNull());
+	}
+	
+	@Test
+	public void testNullEdit() {
+		Statement s1 = StatementBuilder.forSubjectAndProperty(Q1, P1)
+				.withValue(Q1).withId("ID-s1").build();
+		Statement s1dup = StatementBuilder.forSubjectAndProperty(Q1, P1)
+				.withValue(Q1).build();
+		Statement s2 = StatementBuilder.forSubjectAndProperty(Q1, P1)
+				.withValue(Q1).withId("ID-s2").build();
+		
+		ItemDocument currentDocument = ItemDocumentBuilder.forItemId(Q1)
+				.withStatement(s1).build();
+		
+		StatementUpdate su = new StatementUpdate(currentDocument,
+				Arrays.asList(s1dup), Arrays.asList(s2));
+		assertTrue(su.isNull());
+		
 	}
 
 	@Test
@@ -319,10 +344,11 @@ public class StatementUpdateTest {
 		assertEquals(1, su.toKeep.get(P3).size());
 		assertEquals(s1, su.toKeep.get(P3).get(0).statement);
 		assertTrue(su.toKeep.get(P3).get(0).write);
+		assertFalse(su.isNull());
 	}
 
 	@Test
-	public void testDelete() {
+	public void testDelete() throws JsonProcessingException, IOException {
 		Statement s1 = StatementBuilder.forSubjectAndProperty(Q1, P1)
 				.withValue(Q1).withId("ID-s1").build();
 		Statement s2 = StatementBuilder.forSubjectAndProperty(Q1, P1)
@@ -345,12 +371,15 @@ public class StatementUpdateTest {
 		StatementUpdate su = new StatementUpdate(currentDocument,
 				Collections.<Statement> emptyList(), Arrays.asList(s2, s3, s4,
 						s5));
+		
+		ObjectMapper mapper = new ObjectMapper();
+		JsonNode expectedJson = mapper.readTree("{\"claims\":[{\"id\":\"ID-s2\",\"remove\":\"\"},{\"id\":\"ID-s5\",\"remove\":\"\"}]}");
+		JsonNode actualJson = mapper.readTree(su.getJsonUpdateString());
 
 		assertEquals(Arrays.asList("ID-s2", "ID-s5"), su.toDelete);
 		assertEquals(0, su.toKeep.size());
-		assertEquals(
-				"{\"claims\":[{\"id\":\"ID-s2\",\"remove\":\"\"},{\"id\":\"ID-s5\",\"remove\":\"\"}]}",
-				su.getJsonUpdateString());
+		assertEquals(expectedJson, actualJson);
+		assertFalse(su.isNull());
 	}
 
 }

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdateTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdateTest.java
@@ -76,6 +76,7 @@ public class TermStatementUpdateTest {
 		// Check JSON output
 		assertEquals("{\"labels\":{\"de\":{\"language\":\"de\",\"text\":\"Apfelstrudel\"}}}",
 				su.getJsonUpdateString());
+		assertTrue(!su.isNull());
 	}
 	
 	/**
@@ -98,6 +99,7 @@ public class TermStatementUpdateTest {
 		assertEquals(su.getLabelUpdates().get("de").getText(), alias.getText());
 		assertTrue(su.getAliasUpdates().isEmpty());
 		assertTrue(su.getDescriptionUpdates().isEmpty());
+		assertTrue(!su.isNull());
 	}
 	
 	/**
@@ -119,6 +121,7 @@ public class TermStatementUpdateTest {
 		assertEquals(Collections.singleton("fr"), su.getAliasUpdates().keySet());
 		assertEquals(alias.getText(), su.getAliasUpdates().get("fr").get(0).getText());
 		assertTrue(su.getDescriptionUpdates().isEmpty());
+		assertTrue(!su.isNull());
 	}
 	
 	/**
@@ -142,6 +145,7 @@ public class TermStatementUpdateTest {
 		assertEquals(su.getAliasUpdates().size(), 1);
 		assertEquals("{\"aliases\":{\"fr\":[{\"language\":\"fr\",\"text\":\"Apfelstrudel\"}]}}",
 				su.getJsonUpdateString());
+		assertTrue(!su.isNull());
 	}
 	
 	/**
@@ -166,6 +170,7 @@ public class TermStatementUpdateTest {
 		assertEquals(2, su.getAliasUpdates().get("fr").size());
 		assertEquals("{\"aliases\":{\"fr\":[{\"language\":\"fr\",\"text\":\"Apfelstrudel\"},{\"language\":\"fr\",\"text\":\"Apfelstrudeln\"}]}}",
 				su.getJsonUpdateString());
+		assertTrue(!su.isNull());
 	}
 	
 	/**
@@ -187,6 +192,7 @@ public class TermStatementUpdateTest {
 		assertTrue(su.getLabelUpdates().isEmpty());
 		assertTrue(su.getAliasUpdates().isEmpty());
 		assertTrue(su.getDescriptionUpdates().isEmpty());
+		assertTrue(su.isNull());
 	}
 	
 	/**
@@ -210,6 +216,7 @@ public class TermStatementUpdateTest {
 		assertEquals(Collections.singleton("fr"), su.getLabelUpdates().keySet());
 		assertEquals(su.getLabelUpdates().get("fr").getText(), alias.getText());
 		assertTrue(su.getDescriptionUpdates().isEmpty());
+		assertTrue(!su.isNull());
 	}
 	
 	/**
@@ -233,6 +240,7 @@ public class TermStatementUpdateTest {
 		assertEquals(su.getAliasUpdates().get("fr").size(), 0);
 		assertEquals("{\"aliases\":{\"fr\":[]}}",
 				su.getJsonUpdateString());
+		assertTrue(!su.isNull());
 	}
 	
 	/**
@@ -257,5 +265,6 @@ public class TermStatementUpdateTest {
 		assertEquals("délicieuse pâtisserie aux pommes", su.getDescriptionUpdates().get("fr").getText());
 		assertEquals("{\"descriptions\":{\"fr\":{\"language\":\"fr\",\"text\":\"délicieuse pâtisserie aux pommes\"}}}",
 				su.getJsonUpdateString());
+		assertTrue(!su.isNull());
 	}
 }

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdateTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdateTest.java
@@ -74,7 +74,7 @@ public class TermStatementUpdateTest {
 		assertTrue(su.getDescriptionUpdates().isEmpty());
 		
 		// Check JSON output
-		assertEquals("{\"labels\":{\"de\":{\"language\":\"de\",\"text\":\"Apfelstrudel\"}}}",
+		assertEquals("{\"labels\":{\"de\":{\"language\":\"de\",\"value\":\"Apfelstrudel\"}}}",
 				su.getJsonUpdateString());
 		assertTrue(!su.isNull());
 	}
@@ -143,7 +143,7 @@ public class TermStatementUpdateTest {
 		
 		assertTrue(su.getLabelUpdates().isEmpty());
 		assertEquals(su.getAliasUpdates().size(), 1);
-		assertEquals("{\"aliases\":{\"fr\":[{\"language\":\"fr\",\"text\":\"Apfelstrudel\"}]}}",
+		assertEquals("{\"aliases\":{\"fr\":[{\"language\":\"fr\",\"value\":\"Apfelstrudel\"}]}}",
 				su.getJsonUpdateString());
 		assertTrue(!su.isNull());
 	}
@@ -168,7 +168,7 @@ public class TermStatementUpdateTest {
 		assertTrue(su.getLabelUpdates().isEmpty());
 		assertEquals(1, su.getAliasUpdates().size());
 		assertEquals(2, su.getAliasUpdates().get("fr").size());
-		assertEquals("{\"aliases\":{\"fr\":[{\"language\":\"fr\",\"text\":\"Apfelstrudel\"},{\"language\":\"fr\",\"text\":\"Apfelstrudeln\"}]}}",
+		assertEquals("{\"aliases\":{\"fr\":[{\"language\":\"fr\",\"value\":\"Apfelstrudel\"},{\"language\":\"fr\",\"value\":\"Apfelstrudeln\"}]}}",
 				su.getJsonUpdateString());
 		assertTrue(!su.isNull());
 	}
@@ -263,7 +263,7 @@ public class TermStatementUpdateTest {
 		assertTrue(su.getAliasUpdates().isEmpty());
 		assertEquals(Collections.singleton("fr"), su.getDescriptionUpdates().keySet());
 		assertEquals("délicieuse pâtisserie aux pommes", su.getDescriptionUpdates().get("fr").getText());
-		assertEquals("{\"descriptions\":{\"fr\":{\"language\":\"fr\",\"text\":\"délicieuse pâtisserie aux pommes\"}}}",
+		assertEquals("{\"descriptions\":{\"fr\":{\"language\":\"fr\",\"value\":\"délicieuse pâtisserie aux pommes\"}}}",
 				su.getJsonUpdateString());
 		assertTrue(!su.isNull());
 	}

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdateTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdateTest.java
@@ -267,4 +267,63 @@ public class TermStatementUpdateTest {
 				su.getJsonUpdateString());
 		assertTrue(!su.isNull());
 	}
+	
+	/**
+	 * Adding a label, identical to the current one
+	 */
+	@Test
+	public void testAddIdenticalLabel() {
+		MonolingualTextValue label = Datamodel.makeMonolingualTextValue("strudel aux pommes", "fr");
+		ItemDocument currentDocument = ItemDocumentBuilder.forItemId(Q1).withLabel(label).build();
+		TermStatementUpdate su = makeUpdate(currentDocument,
+				Collections.singletonList(label),
+				Collections.<MonolingualTextValue> emptyList(),
+				Collections.<MonolingualTextValue> emptyList(),
+				Collections.<MonolingualTextValue> emptyList());
+		
+		assertEquals("{}", su.getJsonUpdateString());
+		assertTrue(su.isNull());
+	}
+	
+	/**
+	 * Adding a description, identical to the current one
+	 */
+	@Test
+	public void testAddIdenticalDescription() {
+		MonolingualTextValue label = Datamodel.makeMonolingualTextValue("strudel aux pommes", "fr");
+		MonolingualTextValue description = Datamodel.makeMonolingualTextValue("délicieuse pâtisserie aux pommes", "fr");
+		ItemDocument currentDocument = ItemDocumentBuilder.forItemId(Q1)
+				.withLabel(label)
+				.withDescription(description)
+				.build();
+		TermStatementUpdate su = makeUpdate(currentDocument,
+				Collections.<MonolingualTextValue> emptyList(),
+				Collections.singletonList(description),
+				Collections.<MonolingualTextValue> emptyList(),
+				Collections.<MonolingualTextValue> emptyList());
+		
+		assertEquals("{}", su.getJsonUpdateString());
+		assertTrue(su.isNull());
+	}
+	
+	/**
+	 * Adding an alias, identical to the current one
+	 */
+	@Test
+	public void testAddIdenticalAlias() {
+		MonolingualTextValue label = Datamodel.makeMonolingualTextValue("strudel aux pommes", "fr");
+		MonolingualTextValue alias = Datamodel.makeMonolingualTextValue("Apfelstrudel", "fr");
+		ItemDocument currentDocument = ItemDocumentBuilder.forItemId(Q1)
+				.withLabel(label)
+				.withAlias(alias)
+				.build();
+		TermStatementUpdate su = makeUpdate(currentDocument,
+				Collections.<MonolingualTextValue> emptyList(),
+				Collections.<MonolingualTextValue> emptyList(),
+				Collections.singletonList(alias),
+				Collections.<MonolingualTextValue> emptyList());
+		
+		assertEquals("{}", su.getJsonUpdateString());
+		assertTrue(su.isNull());
+	}
 }

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdateTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdateTest.java
@@ -1,6 +1,7 @@
 package org.wikidata.wdtk.wikibaseapi;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 import java.util.Collections;
 import java.util.List;
@@ -76,7 +77,7 @@ public class TermStatementUpdateTest {
 		// Check JSON output
 		assertEquals("{\"labels\":{\"de\":{\"language\":\"de\",\"value\":\"Apfelstrudel\"}}}",
 				su.getJsonUpdateString());
-		assertTrue(!su.isNull());
+		assertFalse(su.isEmptyEdit());
 	}
 	
 	/**
@@ -99,7 +100,7 @@ public class TermStatementUpdateTest {
 		assertEquals(su.getLabelUpdates().get("de").getText(), alias.getText());
 		assertTrue(su.getAliasUpdates().isEmpty());
 		assertTrue(su.getDescriptionUpdates().isEmpty());
-		assertTrue(!su.isNull());
+		assertFalse(su.isEmptyEdit());
 	}
 	
 	/**
@@ -121,7 +122,7 @@ public class TermStatementUpdateTest {
 		assertEquals(Collections.singleton("fr"), su.getAliasUpdates().keySet());
 		assertEquals(alias.getText(), su.getAliasUpdates().get("fr").get(0).getText());
 		assertTrue(su.getDescriptionUpdates().isEmpty());
-		assertTrue(!su.isNull());
+		assertFalse(su.isEmptyEdit());
 	}
 	
 	/**
@@ -145,7 +146,7 @@ public class TermStatementUpdateTest {
 		assertEquals(su.getAliasUpdates().size(), 1);
 		assertEquals("{\"aliases\":{\"fr\":[{\"language\":\"fr\",\"value\":\"Apfelstrudel\"}]}}",
 				su.getJsonUpdateString());
-		assertTrue(!su.isNull());
+		assertFalse(su.isEmptyEdit());
 	}
 	
 	/**
@@ -170,7 +171,7 @@ public class TermStatementUpdateTest {
 		assertEquals(2, su.getAliasUpdates().get("fr").size());
 		assertEquals("{\"aliases\":{\"fr\":[{\"language\":\"fr\",\"value\":\"Apfelstrudel\"},{\"language\":\"fr\",\"value\":\"Apfelstrudeln\"}]}}",
 				su.getJsonUpdateString());
-		assertTrue(!su.isNull());
+		assertFalse(su.isEmptyEdit());
 	}
 	
 	/**
@@ -192,7 +193,7 @@ public class TermStatementUpdateTest {
 		assertTrue(su.getLabelUpdates().isEmpty());
 		assertTrue(su.getAliasUpdates().isEmpty());
 		assertTrue(su.getDescriptionUpdates().isEmpty());
-		assertTrue(su.isNull());
+		assertTrue(su.isEmptyEdit());
 	}
 	
 	/**
@@ -216,7 +217,7 @@ public class TermStatementUpdateTest {
 		assertEquals(Collections.singleton("fr"), su.getLabelUpdates().keySet());
 		assertEquals(su.getLabelUpdates().get("fr").getText(), alias.getText());
 		assertTrue(su.getDescriptionUpdates().isEmpty());
-		assertTrue(!su.isNull());
+		assertFalse(su.isEmptyEdit());
 	}
 	
 	/**
@@ -240,7 +241,7 @@ public class TermStatementUpdateTest {
 		assertEquals(su.getAliasUpdates().get("fr").size(), 0);
 		assertEquals("{\"aliases\":{\"fr\":[]}}",
 				su.getJsonUpdateString());
-		assertTrue(!su.isNull());
+		assertFalse(su.isEmptyEdit());
 	}
 	
 	/**
@@ -265,7 +266,7 @@ public class TermStatementUpdateTest {
 		assertEquals("délicieuse pâtisserie aux pommes", su.getDescriptionUpdates().get("fr").getText());
 		assertEquals("{\"descriptions\":{\"fr\":{\"language\":\"fr\",\"value\":\"délicieuse pâtisserie aux pommes\"}}}",
 				su.getJsonUpdateString());
-		assertTrue(!su.isNull());
+		assertFalse(su.isEmptyEdit());
 	}
 	
 	/**
@@ -282,7 +283,7 @@ public class TermStatementUpdateTest {
 				Collections.<MonolingualTextValue> emptyList());
 		
 		assertEquals("{}", su.getJsonUpdateString());
-		assertTrue(su.isNull());
+		assertTrue(su.isEmptyEdit());
 	}
 	
 	/**
@@ -303,7 +304,7 @@ public class TermStatementUpdateTest {
 				Collections.<MonolingualTextValue> emptyList());
 		
 		assertEquals("{}", su.getJsonUpdateString());
-		assertTrue(su.isNull());
+		assertTrue(su.isEmptyEdit());
 	}
 	
 	/**
@@ -324,6 +325,6 @@ public class TermStatementUpdateTest {
 				Collections.<MonolingualTextValue> emptyList());
 		
 		assertEquals("{}", su.getJsonUpdateString());
-		assertTrue(su.isNull());
+		assertTrue(su.isEmptyEdit());
 	}
 }

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditorTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditorTest.java
@@ -471,7 +471,6 @@ public class WikibaseDataEditorTest {
 		Map<String, String> params = new HashMap<String, String>();
 		params.put("action", "wbeditentity");
 		params.put("id", "Q1234");
-		params.put("summary", "My summary");
 		params.put("token", "42307b93c79b0cb558d2dfb4c3c92e0955e06041+\\");
 		params.put("format", "json");
 		params.put("baserevid", "1234");
@@ -481,7 +480,7 @@ public class WikibaseDataEditorTest {
 		String expectedResult = "{\"entity\":"+data+",\"success\":1}";
 		con.setWebResource(params, expectedResult);
 		
-		ItemDocument nullEditedItemDocument = wde.nullEdit(itemDocument, "My summary");
+		ItemDocument nullEditedItemDocument = wde.nullEdit(itemDocument);
 		
 		assertEquals(itemDocument, nullEditedItemDocument);
 		assertEquals(9, wde.getRemainingEdits());

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditorTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditorTest.java
@@ -408,6 +408,40 @@ public class WikibaseDataEditorTest {
 		assertEquals(itemDocument, editedItemDocument);
 		assertEquals(10, wde.getRemainingEdits());
 	}
+	
+	@Test
+	public void testNullEdit() throws IOException, MediaWikiApiErrorException {
+		WikibaseDataEditor wde = new WikibaseDataEditor(this.con,
+				Datamodel.SITE_WIKIDATA);
+		wde.setRemainingEdits(10);
+		
+		ItemIdValue id = Datamodel.makeWikidataItemIdValue("Q1234");
+		ItemIdValue Q5 = Datamodel.makeWikidataItemIdValue("Q5");
+		PropertyIdValue P31 = Datamodel.makeWikidataPropertyIdValue("P31");
+		Statement s1 = StatementBuilder.forSubjectAndProperty(id, P31)
+				.withValue(Q5).withId("ID-s1").build();
+		ItemDocument itemDocument = ItemDocumentBuilder.forItemId(id)
+				.withStatement(s1)
+				.withRevisionId(1234).build();
+		
+		Map<String, String> params = new HashMap<String, String>();
+		params.put("action", "wbeditentity");
+		params.put("id", "Q1234");
+		params.put("summary", "My summary");
+		params.put("token", "42307b93c79b0cb558d2dfb4c3c92e0955e06041+\\");
+		params.put("format", "json");
+		params.put("baserevid", "1234");
+		params.put("maxlag", "5");
+		params.put("data", "{}");
+		String data = JsonSerializer.getJsonString(itemDocument);
+		String expectedResult = "{\"entity\":"+data+",\"success\":1}";
+		con.setWebResource(params, expectedResult);
+		
+		ItemDocument nullEditedItemDocument = wde.nullEdit(itemDocument, "My summary");
+		
+		assertEquals(itemDocument, nullEditedItemDocument);
+		assertEquals(9, wde.getRemainingEdits());
+	}
 
 	@Test
 	public void testEditProperty() throws IOException,


### PR DESCRIPTION
If the changes made on an item end up being spurious (adding statements that already exist, deleting statements that do not exist, setting labels to their current value, and so on), then by default we do not want to perform any edit (because it costs time, bandwidth, server resources for the Wikibase instance).