### PR TITLE
Cleanup a few issues with JSON serialization after the refactoring

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/NoValueSnakImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/NoValueSnakImpl.java
@@ -49,7 +49,7 @@ public class NoValueSnakImpl extends SnakImpl implements NoValueSnak {
 	 * 		the property id used by this no value snak
 	 */
 	public NoValueSnakImpl(PropertyIdValue property) {
-		super(property.getId(), property.getSiteIri());
+		super(property);
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ReferenceImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ReferenceImpl.java
@@ -115,6 +115,7 @@ public class ReferenceImpl implements Reference {
 	 *
 	 * @return the map of snaks
 	 */
+	@JsonProperty("snaks")
 	public Map<String, List<Snak>> getSnaks() {
 		return Collections.unmodifiableMap(this.snaks);
 	}
@@ -131,6 +132,7 @@ public class ReferenceImpl implements Reference {
 	}
 
 	@Override
+	@JsonIgnore
 	public Iterator<Snak> getAllSnaks() {
 		return new NestedIterator<>(getSnakGroups());
 	}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SnakImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SnakImpl.java
@@ -65,31 +65,31 @@ public abstract class SnakImpl implements Snak {
 	public static final String JSON_SNAK_TYPE_NOVALUE = "novalue";
 
 	/**
-	 * Value of the "property" field in JSON, e.g., "P31".
+	 * The property used by this snak.
 	 */
-	private final String property;
-
+	private final PropertyIdValue property;
+	
 	/**
-	 * The site IRI of this snak. This is needed since the site that this snak
-	 * refers to is not part of the JSON serialization of snaks, but is needed
-	 * in WDTK to build {@link PropertyIdValue} objects etc. Thus, it is
-	 * necessary to set this information after each deserialization.
+	 * Constructor.
 	 */
-	@JsonIgnore
-	private final String siteIri;
+	public SnakImpl(PropertyIdValue property) {
+		Validate.notNull(property);
+		this.property = property;
+	}
 
 	/**
 	 * Constructor. Creates an empty object that can be populated during JSON
 	 * deserialization. Should only be used by Jackson for this very purpose.
+	 * 
+	 * This is not marked as JsonCreator because only concrete subclasses will
+	 * be deserialized directly.
 	 */
-	@JsonCreator
 	protected SnakImpl(
-			@JsonProperty("property") String property,
-			@JacksonInject("siteIri") String siteIri) {
-		Validate.notNull(property);
-		this.property = property;
+			String id,
+			String siteIri) {
+		Validate.notNull(id);
 		Validate.notNull(siteIri);
-		this.siteIri = siteIri;
+		this.property = Datamodel.makePropertyIdValue(id, siteIri);
 	}
 
 	/**
@@ -100,13 +100,13 @@ public abstract class SnakImpl implements Snak {
 	 */
 	@JsonProperty("property")
 	public String getProperty() {
-		return this.property;
+		return this.property.getId();
 	}
 
 	@JsonIgnore
 	@Override
 	public PropertyIdValue getPropertyId() {
-		return Datamodel.makePropertyIdValue(property, this.siteIri);
+		return property;
 	}
 
 	@JsonIgnore

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SomeValueSnakImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SomeValueSnakImpl.java
@@ -48,7 +48,7 @@ public class SomeValueSnakImpl extends SnakImpl implements SomeValueSnak {
 	 * 		the id of the property used for this some value snak
 	 */
 	public SomeValueSnakImpl(PropertyIdValue property) {
-		super(property.getId(), property.getSiteIri());
+		super(property);
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ValueSnakImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ValueSnakImpl.java
@@ -76,7 +76,7 @@ public class ValueSnakImpl extends SnakImpl implements ValueSnak {
 	 * 		the target value for this snak
 	 */
 	public ValueSnakImpl(PropertyIdValue property, Value value) {
-		super(property.getId(), property.getSiteIri());
+		super(property);
 		Validate.notNull(value, "A datavalue must be provided to create a value snak.");
 		this.datavalue = value;
 		this.datatype = getJsonPropertyTypeForValueType(datavalue);

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/json/JacksonPreStatement.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/json/JacksonPreStatement.java
@@ -174,6 +174,7 @@ public class JacksonPreStatement {
 	 * Returns the rank of the statement.
 	 * @return "rank"
 	 */
+	@JsonProperty("rank")
 	public StatementRank getRank() {
 		return this.rank;
 	}
@@ -182,6 +183,7 @@ public class JacksonPreStatement {
 	 * Returns the references of this statement
 	 * @return "references"
 	 */
+	@JsonProperty("references")
 	public List<Reference> getReferences() {
 		return Collections.unmodifiableList(this.references);
 	}
@@ -203,6 +205,7 @@ public class JacksonPreStatement {
 	 *
 	 * @return main snak
 	 */
+	@JsonProperty("mainsnak")
 	public Snak getMainsnak() {
 		return this.mainsnak;
 	}
@@ -214,6 +217,7 @@ public class JacksonPreStatement {
 	 *
 	 * @return qualifiers
 	 */
+	@JsonProperty("qualifiers")
 	public Map<String, List<Snak>> getQualifiers() {
 		return Collections.unmodifiableMap(this.qualifiers);
 	}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/ItemIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/ItemIdValue.java
@@ -1,6 +1,7 @@
 package org.wikidata.wdtk.datamodel.interfaces;
 
 import org.wikidata.wdtk.datamodel.helpers.Equality;
+import org.wikidata.wdtk.datamodel.helpers.Hash;
 
 /*
  * #%L
@@ -66,6 +67,11 @@ public interface ItemIdValue extends EntityIdValue {
 		@Override
 		public boolean equals(Object other) {
 			return Equality.equalsEntityIdValue(this, other);
+		}
+		
+		@Override
+		public int hashCode() {
+			return Hash.hashCode(this);
 		}
 
 	};

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/PropertyIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/PropertyIdValue.java
@@ -1,6 +1,7 @@
 package org.wikidata.wdtk.datamodel.interfaces;
 
 import org.wikidata.wdtk.datamodel.helpers.Equality;
+import org.wikidata.wdtk.datamodel.helpers.Hash;
 
 /*
  * #%L
@@ -67,5 +68,11 @@ public interface PropertyIdValue extends EntityIdValue {
 		public boolean equals(Object other) {
 			return Equality.equalsEntityIdValue(this, other);
 		}
+		
+		@Override
+		public int hashCode() {
+			return Hash.hashCode(this);
+		}
+
 	};
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/QuantityValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/QuantityValueImplTest.java
@@ -72,6 +72,23 @@ public class QuantityValueImplTest {
 		assertThat(q1, not(equalTo(null)));
 		assertFalse(q1.equals(this));
 	}
+	
+	@Test
+	public void equalityBasedOnRepresentation() {
+		BigDecimal amount1 = new BigDecimal("4.00");
+		BigDecimal amount2 = new BigDecimal("4");
+		assertFalse(amount1.equals(amount2));
+		QuantityValue quantity1 = new QuantityValueImpl(amount1, null, null, "1");
+		QuantityValue quantity2 = new QuantityValueImpl(amount2, null, null, "1");
+		assertFalse(quantity1.equals(quantity2));
+	}
+	
+	@Test
+	public void faithfulJsonSerialization() {
+		BigDecimal amount = new BigDecimal("4.00");
+		QuantityValueImpl quantity = new QuantityValueImpl(amount, null, null, "1");
+		assertEquals("+4.00", quantity.getValue().getAmountAsString());
+	}
 
 	@Test
 	public void hashBasedOnContent() {

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/json/TestStatement.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/json/TestStatement.java
@@ -30,8 +30,11 @@ import java.io.IOException;
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
+import org.wikidata.wdtk.datamodel.implementation.DataObjectFactoryImplTest;
 import org.wikidata.wdtk.datamodel.implementation.StatementImpl;
 import org.wikidata.wdtk.datamodel.implementation.json.JacksonPreStatement;
+import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -47,6 +50,15 @@ public class TestStatement {
 		String result = mapper.writeValueAsString(statement);
 		JsonComparator.compareJsonStrings(JsonTestData.JSON_NOVALUE_STATEMENT,
 				result);
+	}
+	
+	@Test
+	public void testFullStatementToJson() throws IOException {
+		Statement statement = DataObjectFactoryImplTest.getTestStatement(2, 3, 4, EntityIdValue.ET_ITEM);
+		ObjectMapper mapper = new DatamodelMapper(statement.getClaim().getSubject().getSiteIri());
+		String json = mapper.writeValueAsString(statement);
+		JacksonPreStatement deserialized = mapper.readValue(json, JacksonPreStatement.class);
+		assertEquals(statement, deserialized.withSubject(statement.getClaim().getSubject()));
 	}
 
 	@Test
@@ -69,7 +81,6 @@ public class TestStatement {
 		assertNull(result.getValue());
 		assertNull(result.getClaim().getValue());
 		assertEquals(JsonTestData.getTestNoValueStatement(), result);
-
 	}
 
 	@Test


### PR DESCRIPTION
I have noticed a few issues with the refactoring of the datamodel:
- qualifiers were not serialized correctly anymore. I have preventively added explicit `@JsonProperty` on the getters where it was missing to prevent that from happening at other places (and added a test `testFullStatementToJson` for that)
- `SnakImpl` was deconstructing and reconstructing its `PropertyIdValue` for no reason, this is now fixed

As a result another bug resurfaced: `ItemIdValue.NULL` and `PropertyIdValue.NULL` were not hashed properly (that's independent from the rewrite - although I have to admit that I am responsible for adding `equals` there, without which the bug would not appear either… but surely we do want to have both `equals` and `hashCode` there, right?).