### PR TITLE
Adds Claims methods to Statement

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ClaimImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ClaimImpl.java
@@ -20,22 +20,13 @@ package org.wikidata.wdtk.datamodel.implementation;
  * #L%
  */
 
-import java.util.Iterator;
-import java.util.List;
-
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;
 import org.wikidata.wdtk.datamodel.implementation.json.JacksonPreStatement;
-import org.wikidata.wdtk.datamodel.interfaces.Claim;
-import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.Snak;
-import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
-import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
-import org.wikidata.wdtk.datamodel.interfaces.Value;
-import org.wikidata.wdtk.util.NestedIterator;
+import org.wikidata.wdtk.datamodel.interfaces.*;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.List;
 
 /**
  * Helper class to represent a {@link Claim} deserialized from JSON. The actual
@@ -47,10 +38,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  */
 public class ClaimImpl implements Claim {
 
-	private final StatementImpl statement;
+	private final Statement statement;
 
-	private List<SnakGroup> qualifiers = null;
-	
 	/**
 	 * Constructor to create a claim. This internally creates
 	 * a new statement, so if you want to create a statement later
@@ -83,33 +72,17 @@ public class ClaimImpl implements Claim {
 
 	@Override
 	public EntityIdValue getSubject() {
-		return this.statement.getSubject();
+		return statement.getSubject();
 	}
 
 	@Override
 	public Snak getMainSnak() {
-		return this.statement.getMainsnak();
+		return statement.getMainSnak();
 	}
 
 	@Override
 	public List<SnakGroup> getQualifiers() {
-		if (this.qualifiers == null) {
-			this.qualifiers = SnakGroupImpl.makeSnakGroups(
-					this.statement.getQualifiers(),
-					this.statement.getPropertyOrder());
-		}
-		return this.qualifiers;
-	}
-
-	@Override
-	public Iterator<Snak> getAllQualifiers() {
-		return new NestedIterator<>(getQualifiers());
-	}
-
-	@Override
-	@JsonIgnore
-	public Value getValue() {
-		return this.statement.getMainsnak().getValue();
+		return statement.getQualifiers();
 	}
 
 	@Override

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StatementImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StatementImpl.java
@@ -1,6 +1,6 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
-import java.util.HashMap;
+import java.util.*;
 
 /*
  * #%L
@@ -22,24 +22,17 @@ import java.util.HashMap;
  * #L%
  */
 
-import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.apache.commons.lang3.Validate;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;
-import org.wikidata.wdtk.datamodel.implementation.json.JacksonPreStatement;
-import org.wikidata.wdtk.datamodel.interfaces.Claim;
-import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.Reference;
-import org.wikidata.wdtk.datamodel.interfaces.Snak;
-import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
-import org.wikidata.wdtk.datamodel.interfaces.Statement;
-import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.wikidata.wdtk.datamodel.implementation.json.StatementRankSerializer;
+import org.wikidata.wdtk.datamodel.interfaces.*;
+import org.wikidata.wdtk.util.NestedIterator;
 
 /**
  * Jackson implementation of {@link Statement}. In JSON, the corresponding
@@ -47,24 +40,39 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  *
  * @author Fredo Erxleben
  * @author Antonin Delpeuch
+ * @author Thomas Pellissier Tanon
  *
  */
-public class StatementImpl extends JacksonPreStatement implements Statement {
-	
+@JsonInclude(JsonInclude.Include.NON_EMPTY)
+public class StatementImpl implements Statement {
+
+	private final String statementId;
+
+	private final StatementRank rank;
+
+	private final Snak mainSnak;
+
 	/**
-	 * The subject entity that this statement refers to. This is needed since it
-	 * is not part of the JSON serialization of statements, but is needed in
-	 * WDTK as part of {@link Claim}. Thus, it is necessary to set this
-	 * information after each deserialization in
-	 * {@link TermedStatementDocumentImpl}.
+	 * A map from property id strings to snaks that encodes the qualifiers.
 	 */
-	@JsonIgnore
-	private final EntityIdValue subject;
+	private final Map<String, List<Snak>> qualifiers;
+
+	/**
+	 * List of property string ids that encodes the desired order of qualifiers,
+	 * which is not specified by the map.
+	 */
+	private final List<String> qualifiersOrder;
+
+	private final EntityIdValue subjectId;
+
+	private final List<Reference> references;
+
+	private List<SnakGroup> qualifiersGroups;
 
 	/**
 	 * Constructor.
 	 * <p>
-	 * The string id is used mainly for communication with a Wikibase site, in
+	 * The statementId is used mainly for communication with a Wikibase site, in
 	 * order to refer to statements of that site. When creating new statements
 	 * that are not on any site, the empty string can be used.
 	 *
@@ -72,7 +80,7 @@ public class StatementImpl extends JacksonPreStatement implements Statement {
 	 *            the string id of the Statement: can be empty if the statement has not obtained it yet
 	 * @param rank
 	 *            the rank of the Statement
-	 * @param mainsnak
+	 * @param mainSnak
 	 * 			  the main snak for the Claim of the Statement
 	 * @param qualifiers
 	 *            the snak groups for the qualifiers
@@ -84,99 +92,121 @@ public class StatementImpl extends JacksonPreStatement implements Statement {
 	public StatementImpl(
 			String statementId,
 			StatementRank rank,
-			Snak mainsnak,
+			Snak mainSnak,
 			List<SnakGroup> qualifiers,
 			List<Reference> references,
 			EntityIdValue subjectId) {
-		super(statementId, rank, mainsnak,
-				qualifiers.stream()
-				.collect(Collectors.toMap(g -> g.getProperty().getId(), SnakGroup::getSnaks)),
-				qualifiers.stream()
-					.map(g -> g.getProperty().getId())
-					.collect(Collectors.toList()),
-				references);
-		Validate.notNull(subjectId);
-		this.subject = subjectId;
+		this(statementId, rank, mainSnak,
+				qualifiers.stream().collect(Collectors.toMap(g -> g.getProperty().getId(), SnakGroup::getSnaks)),
+				qualifiers.stream().map(g -> g.getProperty().getId()).collect(Collectors.toList()),
+				references, subjectId
+		);
 	}
-	
-	/**
-	 * Constructor provided for compatibility with previous implementation.
-	 * Note that constructing a {@link Statement} from an existing {@link Claim}
-	 * is inefficient: the constructor above should be preferred instead.
-	 * <p>
-	 * The string id is used mainly for communication with a Wikibase site, in
-	 * order to refer to statements of that site. When creating new statements
-	 * that are not on any site, the empty string can be used.
-	 *
-	 * @param claim
-	 *            the main claim the Statement refers to
-	 * @param references
-	 *            the references for the Statement
-	 * @param rank
-	 *            the rank of the Statement
-	 * @param id
-	 *            the string id of the Statement: can be empty if the statement has not obtained it yet
-	 */
-	@Deprecated
+
 	public StatementImpl(
-			Claim claim,
-			List<Reference> references,
+			String statementId,
 			StatementRank rank,
-			String id) {
-		super(id, rank, claim.getMainSnak(),
-				qualifierListToMap(claim.getQualifiers()),
-				claim.getQualifiers().stream().map(g -> g.getProperty().getId()).collect(Collectors.toList()),
-				references);
-		this.subject = claim.getSubject();
-	}
-	
-	/**
-	 * Constructor used for JSON deserialization with Jackson.
-	 * Not marked as @JsonCreator because it is not called directly by Jackson,
-	 * but rather from {@link TermedStatementDocumentImpl} to convert it
-	 * from a {@link JacksonPreStatement}.
-	 */
-	public StatementImpl(
-			String id,
-			StatementRank rank,
-			Snak mainsnak,
+			Snak mainSnak,
 			Map<String,List<Snak>> qualifiers,
-			List<String> propertyOrder,
+			List<String> qualifiersOrder,
 			List<Reference> references,
 			EntityIdValue subjectId) {
-		super(id, rank, mainsnak, qualifiers, propertyOrder, references);
+		this.statementId = (statementId == null) ? "" : statementId;
+		Validate.notNull(rank, "No rank provided to create a statement.");
+		this.rank = rank;
+		Validate.notNull(mainSnak, "No main snak provided to create a statement.");
+		this.mainSnak = mainSnak;
+		this.qualifiers = (qualifiers == null) ? Collections.emptyMap() : qualifiers;
+		this.qualifiersOrder = (qualifiersOrder == null) ? Collections.emptyList() : qualifiersOrder;
+		this.references = (references == null) ? Collections.emptyList() : references;
 		Validate.notNull(subjectId);
-		this.subject = subjectId;
+		this.subjectId = subjectId;
 	}
-	
 
 	/**
 	 * TODO review the utility of this constructor.
 	 */
-	public StatementImpl(String id, Snak mainsnak, EntityIdValue subject) {
-		super(id, StatementRank.NORMAL, mainsnak, null, null, null);
-		this.subject = subject;
+	public StatementImpl(String statementId, Snak mainsnak, EntityIdValue subjectId) {
+		this(statementId, StatementRank.NORMAL, mainsnak, null, null, null, subjectId);
 	}
-
 
 	/**
-	 * Returns the subject that this statement refers to. This method is only
-	 * used by {@link ClaimImpl} to retrieve data about the subject of this
-	 * statement. To access this data from elsewhere, use {@link #getClaim()}.
+	 * Returns the value for the "type" field used in JSON. Only for use by
+	 * Jackson during deserialization.
 	 *
-	 * @see Claim#getSubject()
-	 * @return the subject of this statement
+	 * @return "statement"
 	 */
-	@JsonIgnore 
-	public EntityIdValue getSubject() {
-		return this.subject;
+	@JsonProperty("type")
+	String getJsonType() {
+		return "statement";
 	}
-	
+
+
+	@Override
 	@JsonIgnore
 	public Claim getClaim() {
 		return new ClaimImpl(this);
 	}
-	
+
+	@Override
+	@JsonIgnore
+	public EntityIdValue getSubject() {
+		return subjectId;
+	}
+
+	@Override
+	@JsonProperty("mainsnak")
+	public Snak getMainSnak() {
+		return mainSnak;
+	}
+
+	@Override
+	@JsonIgnore
+	public List<SnakGroup> getQualifiers() {
+		if (qualifiersGroups == null) {
+			qualifiersGroups = SnakGroupImpl.makeSnakGroups(qualifiers, qualifiersOrder);
+		}
+		return qualifiersGroups;
+	}
+
+	/**
+	 * Returns the qualifiers of the claim of this statement. Only for use by
+	 * Jackson during serialization. To access this data, use
+	 * {@link Statement#getClaim()}.
+	 */
+	@JsonProperty("qualifiers")
+	Map<String, List<Snak>> getJsonQualifiers() {
+		return Collections.unmodifiableMap(qualifiers);
+	}
+
+	/**
+	 * Returns the list of property ids used to order qualifiers as found in
+	 * JSON. Only for use by Jackson during serialization.
+	 *
+	 * @return the list of property ids
+	 */
+	@JsonProperty("qualifiers-order")
+	List<String> getQualifiersOrder() {
+		return Collections.unmodifiableList(this.qualifiersOrder);
+	}
+
+	@Override
+	@JsonSerialize(using = StatementRankSerializer.class)
+	public StatementRank getRank() {
+		return rank;
+	}
+
+	@Override
+	public List<Reference> getReferences() {
+		return references;
+	}
+
+	@Override
+	@JsonProperty("id")
+	public String getStatementId() {
+		return statementId;
+	}
+
 	@Override
 	public int hashCode() {
 		return Hash.hashCode(this);
@@ -190,20 +220,5 @@ public class StatementImpl extends JacksonPreStatement implements Statement {
 	@Override
 	public String toString() {
 		return ToString.toString(this);
-	}
-	
-	/**
-	 * Helper to convert a list of qualifiers to the internal JSON representation.
-	 */
-	private static Map<String, List<Snak>> qualifierListToMap(List<SnakGroup> qualifiers) {
-		Map<String, List<Snak>> map = new HashMap<>();
-		for(SnakGroup group : qualifiers) {
-			if(map.containsKey(group.getProperty().getId())) {
-				throw new IllegalArgumentException("Attempting to create qualifiers with two snak groups for the same property");
-			} else {
-				map.put(group.getProperty().getId(), group.getSnaks());
-			}
-		}
-		return map;
 	}
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/json/JacksonPreStatement.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/json/JacksonPreStatement.java
@@ -21,11 +21,7 @@ package org.wikidata.wdtk.datamodel.implementation.json;
  */
 
 import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.apache.commons.lang3.Validate;
-import org.wikidata.wdtk.datamodel.implementation.ReferenceImpl;
 import org.wikidata.wdtk.datamodel.implementation.SnakImpl;
 import org.wikidata.wdtk.datamodel.implementation.StatementImpl;
 import org.wikidata.wdtk.datamodel.interfaces.*;
@@ -33,99 +29,52 @@ import org.wikidata.wdtk.datamodel.interfaces.*;
 import java.util.*;
 
 /**
- * Helper class storing a statement as represented in JSON. This
- * is a Statement missing a subject.
+ * Helper class for deserializing statements from JSON.
  * 
  * @author Antonin Delpeuch
+ * @author Thomas Pellissier Tanon
  *
  */
-@JsonInclude(Include.NON_EMPTY)
-@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class JacksonPreStatement {
 
-	/**
-	 * Id of this statement.
-	 *
-	 * @see Statement#getStatementId()
-	 */
-	private final String id;
+	private final String statementId;
 
-	/**
-	 * Rank of this statement.
-	 */
-	@JsonSerialize(using = StatementRankSerializer.class)
-	@JsonDeserialize(using = StatementRankDeserializer.class)
 	private final StatementRank rank;
 
-	@JsonDeserialize(contentAs=ReferenceImpl.class)
 	private final List<Reference> references;
 
-	/**
-	 * The main snak of this statement.
-	 */
-	@JsonDeserialize(contentAs=SnakImpl.class)
-	private final Snak mainsnak;
+	private final Snak mainSnak;
 
-	/**
-	 * A map from property id strings to snaks that encodes the qualifiers.
-	 * We use the explicit type {@link SnakImpl} because Jackson does
-	 * not know yet how to specify subclasses for interfaces nested in two
-	 * containers.
-	 */
-	@JsonIgnore
 	private final Map<String, List<Snak>> qualifiers;
 	
-	/**
-	 * List of property string ids that encodes the desired order of qualifiers,
-	 * which is not specified by the map.
-	 */
-	private final List<String> propertyOrder;
+	private final List<String> qualifiersOrder;
 
-	/**
-	 * Constructor.
-	 */
-	public JacksonPreStatement(
-			String id,
+	private JacksonPreStatement(
+			String statementId,
 			StatementRank rank,
 			Snak mainsnak,
 			Map<String, List<Snak>> qualifiers,
-			List<String> propertyOrder,
+			List<String> qualifiersOrder,
 			List<Reference> references) {
-		if (id == null) {
-			id = "";
-		}
-		this.id = id;
-		Validate.notNull(rank, "No rank provided to create a statement.");
+		this.statementId = statementId;
 		this.rank = rank;
-		Validate.notNull(mainsnak, "No main snak provided to create a statement.");
-		this.mainsnak = mainsnak;
-		if (qualifiers != null) {
-			this.qualifiers = qualifiers;
-		} else {
-			this.qualifiers = Collections.emptyMap();
-		}
-		if (propertyOrder != null) {
-			this.propertyOrder = propertyOrder;
-		} else {
-			this.propertyOrder = Collections.emptyList();
-		}
-		if (references != null) {
-			this.references = references;
-		} else {
-			this.references = Collections.emptyList();
-		}
+		this.mainSnak = mainsnak;
+		this.qualifiers = qualifiers;
+		this.qualifiersOrder = qualifiersOrder;
+		this.references = references;
 	}
 	
 	/**
 	 * JSON deserialization creator.
 	 */
 	@JsonCreator
-	protected static JacksonPreStatement fromJson(
+	static JacksonPreStatement fromJson(
 			@JsonProperty("id") String id,
-			@JsonProperty("rank") StatementRank rank,
+			@JsonProperty("rank") 	@JsonDeserialize(using = StatementRankDeserializer.class) StatementRank rank,
 			@JsonProperty("mainsnak") SnakImpl mainsnak,
 			@JsonProperty("qualifiers") Map<String, List<SnakImpl>> qualifiers,
-			@JsonProperty("qualifiers-order") List<String> propertyOrder,
+			@JsonProperty("qualifiers-order") List<String> qualifiersOrder,
 			@JsonProperty("references") List<Reference> references) {
 		// Forget the concrete type of Jackson snaks for the qualifiers
 		if(qualifiers == null) {
@@ -136,92 +85,11 @@ public class JacksonPreStatement {
 			List<Snak> snaks = new ArrayList<>(entry.getValue());
 			newQualifiers.put(entry.getKey(), snaks);
 		}
-		return new JacksonPreStatement(id, rank, mainsnak, newQualifiers, propertyOrder, references);
+		return new JacksonPreStatement(id, rank, mainsnak, newQualifiers, qualifiersOrder, references);
 	}
 	
 	
-	public StatementImpl withSubject(EntityIdValue subject) {
-		return new StatementImpl(
-				id, rank, mainsnak, qualifiers, propertyOrder, references, subject);
+	public StatementImpl withSubject(EntityIdValue subjectId) {
+		return new StatementImpl(statementId, rank, mainSnak, qualifiers, qualifiersOrder, references, subjectId);
 	}
-
-	/**
-	 * Returns the value for the "type" field used in JSON. Only for use by
-	 * Jackson during deserialization.
-	 *
-	 * @return "statement"
-	 */
-	@JsonProperty("type")
-	public String getJsonType() {
-		return "statement";
-	}
-
-	/**
-	 * Returns the rank of the statement.
-	 * @return "rank"
-	 */
-	@JsonProperty("rank")
-	public StatementRank getRank() {
-		return this.rank;
-	}
-
-	/**
-	 * Returns the references of this statement
-	 * @return "references"
-	 */
-	@JsonProperty("references")
-	public List<Reference> getReferences() {
-		return Collections.unmodifiableList(this.references);
-	}
-
-	/**
-	 * Returns the statement identifier.
-	 * @return "id"
-	 */
-	@JsonProperty("id")
-	public String getStatementId() {
-		return this.id;
-	}
-	
-
-	/**
-	 * Returns the main snak of the claim of this statement. Only for use by
-	 * Jackson during serialization. To access this data, use
-	 * {@link Statement#getClaim()}.
-	 *
-	 * @return main snak
-	 */
-	@JsonProperty("mainsnak")
-	public Snak getMainsnak() {
-		return this.mainsnak;
-	}
-
-	/**
-	 * Returns the qualifiers of the claim of this statement. Only for use by
-	 * Jackson during serialization. To access this data, use
-	 * {@link Statement#getClaim()}.
-	 *
-	 * @return qualifiers
-	 */
-	@JsonProperty("qualifiers")
-	public Map<String, List<Snak>> getQualifiers() {
-		return Collections.unmodifiableMap(this.qualifiers);
-	}
-
-	/**
-	 * Returns the list of property ids used to order qualifiers as found in
-	 * JSON. Only for use by Jackson during serialization.
-	 *
-	 * @return the list of property ids
-	 */
-	@JsonProperty("qualifiers-order")
-	public List<String> getPropertyOrder() {
-		return Collections.unmodifiableList(this.propertyOrder);
-	}
-
-	@JsonIgnore
-	public Value getValue() {
-		return this.mainsnak.getValue();
-	}
-
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/Claim.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/Claim.java
@@ -1,5 +1,7 @@
 package org.wikidata.wdtk.datamodel.interfaces;
 
+import org.wikidata.wdtk.util.NestedIterator;
+
 import java.util.Iterator;
 import java.util.List;
 
@@ -65,7 +67,9 @@ public interface Claim {
 	 *
 	 * @return iterator over all qualifier snaks
 	 */
-	Iterator<Snak> getAllQualifiers();
+	default Iterator<Snak> getAllQualifiers() {
+		return new NestedIterator<>(getQualifiers());
+	}
 
 	/**
 	 * Convenience method to get the value of the claim's main snak, or null if
@@ -73,5 +77,7 @@ public interface Claim {
 	 *
 	 * @return main value of the claim, or null
 	 */
-	Value getValue();
+	default Value getValue() {
+		return getMainSnak().getValue();
+	}
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/Statement.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/Statement.java
@@ -20,6 +20,9 @@ package org.wikidata.wdtk.datamodel.interfaces;
  * #L%
  */
 
+import org.wikidata.wdtk.util.NestedIterator;
+
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -38,6 +41,41 @@ public interface Statement {
 	 * @return the claim that this statement refers to
 	 */
 	Claim getClaim();
+
+	/**
+	 * The subject that the claim refers to, e.g., the id of "Berlin".
+	 *
+	 * @return EntityId of the subject
+	 */
+	EntityIdValue getSubject();
+
+	/**
+	 * Main Snak of the statement. This Snak refers directly to the subject,
+	 * e.g., the {@link ValueSnak} "Population: 3000000".
+	 *
+	 * @return the main snak
+	 */
+	Snak getMainSnak();
+
+	/**
+	 * Groups of auxiliary Snaks, also known as qualifiers, that provide
+	 * additional context information for this claim. For example, "as of: 2014"
+	 * might be a temporal context given for a claim that provides a population
+	 * number. The snaks are grouped by the property that they use.
+	 *
+	 * @return list of snak groups
+	 */
+	List<SnakGroup> getQualifiers();
+
+	/**
+	 * Returns an iterator over all qualifiers, without considering qualifier
+	 * groups. The relative order of qualifiers is preserved.
+	 *
+	 * @return iterator over all qualifier snaks
+	 */
+	default Iterator<Snak> getAllQualifiers() {
+		return new NestedIterator<>(getQualifiers());
+	}
 
 	/**
 	 * @see StatementRank
@@ -88,5 +126,7 @@ public interface Statement {
 	 *
 	 * @return main value of the statement, or null
 	 */
-	Value getValue();
+	default Value getValue() {
+		return getMainSnak().getValue();
+	}
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverterTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverterTest.java
@@ -101,13 +101,10 @@ public class DatamodelConverterTest {
 	@Test
 	public void testSingleBrokenStatement() {
 
-		StatementGroup sg1 = Datamodel.makeStatementGroup(Collections
-				.singletonList(getBrokenStatement()));
 		StatementGroup sg2 = DataObjectFactoryImplTest.getTestStatementGroup(2,
 				5, 1, EntityIdValue.ET_ITEM);
 
 		List<StatementGroup> brokenSgs = new ArrayList<>();
-		brokenSgs.add(sg1);
 		brokenSgs.add(sg2);
 		List<StatementGroup> fixedSgs = new ArrayList<>();
 		fixedSgs.add(sg2);
@@ -142,7 +139,6 @@ public class DatamodelConverterTest {
 		List<Statement> brokenSg1Statements = new ArrayList<>();
 		brokenSg1Statements.add(DataObjectFactoryImplTest.getTestStatement(2,
 				5, 1, EntityIdValue.ET_ITEM));
-		brokenSg1Statements.add(getBrokenStatement());
 		brokenSg1Statements.add(DataObjectFactoryImplTest.getTestStatement(2,
 				5, 2, EntityIdValue.ET_ITEM));
 		StatementGroup brokenSg1 = Datamodel

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ClaimImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ClaimImplTest.java
@@ -43,11 +43,11 @@ import org.wikidata.wdtk.datamodel.interfaces.ValueSnak;
 
 public class ClaimImplTest {
 
-	EntityIdValue subject;
-	ValueSnak mainSnak;
+	private EntityIdValue subject;
+	private ValueSnak mainSnak;
 
-	Claim c1;
-	Claim c2;
+	private Claim c1;
+	private Claim c2;
 
 	@Before
 	public void setUp() throws Exception {
@@ -67,7 +67,7 @@ public class ClaimImplTest {
 	public void gettersWorking() {
 		assertEquals(c1.getSubject(), subject);
 		assertEquals(c1.getMainSnak(), mainSnak);
-		assertEquals(c1.getQualifiers(), Collections. emptyList());
+		assertEquals(c1.getQualifiers(), Collections.emptyList());
 	}
 
 	@Test(expected = NullPointerException.class)

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementImplTest.java
@@ -28,82 +28,71 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
-import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.wikidata.wdtk.datamodel.interfaces.Claim;
-import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.Reference;
-import org.wikidata.wdtk.datamodel.interfaces.Snak;
-import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
-import org.wikidata.wdtk.datamodel.interfaces.Statement;
-import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
-import org.wikidata.wdtk.datamodel.interfaces.ValueSnak;
+import org.wikidata.wdtk.datamodel.interfaces.*;
+import org.wikidata.wdtk.util.NestedIterator;
 
 public class StatementImplTest {
 
-	EntityIdValue subject;
-	ValueSnak mainSnak;
-	Claim claim;
+	private EntityIdValue subjet;
+	private EntityIdValue value;
+	private ValueSnak mainSnak;
+	private Claim claim;
 
-	Statement s1;
-	Statement s2;
+	private Statement s1;
+	private Statement s2;
 
 	@Before
 	public void setUp() throws Exception {
-		subject = new ItemIdValueImpl("Q42", "http://wikidata.org/entity/");
+		subjet = new ItemIdValueImpl("Q1", "http://wikidata.org/entity/");
+		value = new ItemIdValueImpl("Q42", "http://wikidata.org/entity/");
 		PropertyIdValue property = new PropertyIdValueImpl("P42",
 				"http://wikidata.org/entity/");
-		mainSnak = new ValueSnakImpl(property, subject);
+		mainSnak = new ValueSnakImpl(property, value);
 
-		claim = new ClaimImpl(subject, mainSnak, Collections.emptyList());
+		claim = new ClaimImpl(subjet, mainSnak, Collections.emptyList());
 		s1 = new StatementImpl("MyId", StatementRank.NORMAL, mainSnak,
-				Collections.emptyList(), Collections.emptyList(), subject);
+				Collections.emptyList(), Collections.emptyList(), subjet);
 		s2 = new StatementImpl("MyId", StatementRank.NORMAL, mainSnak,
-				Collections.emptyList(), Collections.emptyList(), subject);
+				Collections.emptyList(), Collections.emptyList(), subjet);
 	}
 
 	@Test
 	public void gettersWorking() {
 		assertEquals(s1.getClaim(), claim);
-		assertEquals(s1.getReferences(),
-				Collections. emptyList());
+		assertEquals(s1.getMainSnak(), mainSnak);
+		assertEquals(s1.getQualifiers(), Collections.emptyList());
+		assertEquals(s1.getReferences(), Collections. emptyList());
 		assertEquals(s1.getRank(), StatementRank.NORMAL);
 		assertEquals(s1.getStatementId(), "MyId");
-		assertEquals(s1.getValue(), subject);
+		assertEquals(s1.getValue(), value);
+		assertEquals(s1.getSubject(), subjet);
 	}
 
 	@Test(expected = NullPointerException.class)
 	public void mainSnakNotNull() {
 		new StatementImpl("MyId", StatementRank.NORMAL, null,
-				Collections.emptyList(), Collections.emptyList(), subject);
-	}
-
-	@Test(expected = NullPointerException.class)
-	@SuppressWarnings("deprecation")
-	public void claimNotNull() {
-		new StatementImpl(null, Collections. emptyList(),
-				StatementRank.NORMAL, "MyId");
+				Collections.emptyList(), Collections.emptyList(), value);
 	}
 
 	@Test
 	public void referencesCanBeNull() {
-		Statement statement = new StatementImpl("MyId", StatementRank.NORMAL, mainSnak,  Collections.emptyList(), null, subject);
+		Statement statement = new StatementImpl("MyId", StatementRank.NORMAL, mainSnak,  Collections.emptyList(), null, value);
 		assertTrue(statement.getReferences().isEmpty());
 	}
 
 	@Test(expected = NullPointerException.class)
 	public void rankNotNull() {
 		new StatementImpl("MyId", null, mainSnak,
-				Collections.emptyList(), Collections.emptyList(), subject);
+				Collections.emptyList(), Collections.emptyList(), value);
 	}
 
 	@Test
 	public void idCanBeNull() {
 		Statement statement = new StatementImpl(null, StatementRank.NORMAL, mainSnak,
-				Collections.emptyList(), Collections.emptyList(), subject);
+				Collections.emptyList(), Collections.emptyList(), value);
 		assertEquals(statement.getStatementId(), "");
 	}
 
@@ -120,11 +109,11 @@ public class StatementImplTest {
 		Statement sDiffReferences = new StatementImpl("MyId", StatementRank.NORMAL, mainSnak,
 				Collections.emptyList(), Collections.singletonList(new ReferenceImpl(
 						Collections.singletonList(new SnakGroupImpl(Collections.singletonList(mainSnak)))
-				)), subject);
+				)), value);
 		Statement sDiffRank = new StatementImpl("MyId", StatementRank.PREFERRED, mainSnak,
-				Collections.emptyList(), Collections.emptyList(), subject);
+				Collections.emptyList(), Collections.emptyList(), value);
 		Statement sDiffId = new StatementImpl("MyOtherId", StatementRank.NORMAL, mainSnak,
-				Collections.emptyList(), Collections.emptyList(), subject);
+				Collections.emptyList(), Collections.emptyList(), value);
 
 		assertEquals(s1, s1);
 		assertEquals(s1, s2);

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/json/JsonTestData.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/json/JsonTestData.java
@@ -30,7 +30,6 @@ import org.wikidata.wdtk.datamodel.implementation.SiteLinkImpl;
 import org.wikidata.wdtk.datamodel.implementation.SomeValueSnakImpl;
 import org.wikidata.wdtk.datamodel.implementation.StatementImpl;
 import org.wikidata.wdtk.datamodel.implementation.ValueSnakImpl;
-import org.wikidata.wdtk.datamodel.implementation.json.JacksonPreStatement;
 import org.wikidata.wdtk.datamodel.implementation.ValueImpl;
 import org.wikidata.wdtk.datamodel.implementation.GlobeCoordinatesValueImpl;
 import org.wikidata.wdtk.datamodel.implementation.MonolingualTextValueImpl;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/json/TestItemDocument.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/json/TestItemDocument.java
@@ -34,15 +34,10 @@ import org.wikidata.wdtk.datamodel.helpers.DatamodelConverter;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.implementation.ItemDocumentImpl;
 import org.wikidata.wdtk.datamodel.implementation.DataObjectFactoryImpl;
-import org.wikidata.wdtk.datamodel.implementation.json.JacksonPreStatement;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
-import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class TestItemDocument {

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/json/TestPropertyDocument.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/json/TestPropertyDocument.java
@@ -28,7 +28,6 @@ import java.util.List;
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.implementation.PropertyDocumentImpl;
-import org.wikidata.wdtk.datamodel.implementation.json.JacksonPreStatement;
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/json/TestStatement.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/json/TestStatement.java
@@ -32,7 +32,6 @@ import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.implementation.DataObjectFactoryImplTest;
 import org.wikidata.wdtk.datamodel.implementation.StatementImpl;
-import org.wikidata.wdtk.datamodel.implementation.json.JacksonPreStatement;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 
@@ -45,7 +44,7 @@ public class TestStatement {
 
 	@Test
 	public void testEmptyStatementToJson() throws JsonProcessingException {
-		JacksonPreStatement statement = JsonTestData.getTestNoValueStatement();
+		StatementImpl statement = JsonTestData.getTestNoValueStatement();
 
 		String result = mapper.writeValueAsString(statement);
 		JsonComparator.compareJsonStrings(JsonTestData.JSON_NOVALUE_STATEMENT,
@@ -63,7 +62,7 @@ public class TestStatement {
 
 	@Test
 	public void testEmptyStatementNoIdToJson() throws JsonProcessingException {
-		JacksonPreStatement statement = JsonTestData.getTestNoValueNoIdStatement();
+		StatementImpl statement = JsonTestData.getTestNoValueNoIdStatement();
 
 		String result = mapper.writeValueAsString(statement);
 		JsonComparator.compareJsonStrings(


### PR DESCRIPTION
Makes easier for clients to retrieve statements content without requiring an unneeded getter.

Use JaksonPreStatement only for deserialization

Drops some broken tests of DatamodelConverter: the input validation is now stronger