### PR TITLE
Adds Claims methods to Statement

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ClaimImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ClaimImpl.java
@@ -20,37 +20,25 @@ package org.wikidata.wdtk.datamodel.implementation;
  * #L%
  */
 
-import java.util.Iterator;
-import java.util.List;
-
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;
-import org.wikidata.wdtk.datamodel.implementation.json.JacksonPreStatement;
-import org.wikidata.wdtk.datamodel.interfaces.Claim;
-import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.Snak;
-import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
-import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
-import org.wikidata.wdtk.datamodel.interfaces.Value;
-import org.wikidata.wdtk.util.NestedIterator;
+import org.wikidata.wdtk.datamodel.interfaces.*;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.Iterator;
+import java.util.List;
 
 /**
- * Helper class to represent a {@link Claim} deserialized from JSON. The actual
- * data is part of {@link JacksonPreStatement}. This is merely a facade that
- * provides a suitable view.
+ * Helper class to represent a {@link Claim}.
+ * This is  a ffacade for a {@link Statement}
  *
  * @author Fredo Erxleben
  * @author Antonin Delpeuch
  */
 public class ClaimImpl implements Claim {
 
-	private final StatementImpl statement;
+	private final Statement statement;
 
-	private List<SnakGroup> qualifiers = null;
-	
 	/**
 	 * Constructor to create a claim. This internally creates
 	 * a new statement, so if you want to create a statement later
@@ -83,33 +71,27 @@ public class ClaimImpl implements Claim {
 
 	@Override
 	public EntityIdValue getSubject() {
-		return this.statement.getSubject();
+		return statement.getSubject();
 	}
 
 	@Override
 	public Snak getMainSnak() {
-		return this.statement.getMainsnak();
+		return statement.getMainSnak();
 	}
 
 	@Override
 	public List<SnakGroup> getQualifiers() {
-		if (this.qualifiers == null) {
-			this.qualifiers = SnakGroupImpl.makeSnakGroups(
-					this.statement.getQualifiers(),
-					this.statement.getPropertyOrder());
-		}
-		return this.qualifiers;
+		return statement.getQualifiers();
 	}
 
 	@Override
 	public Iterator<Snak> getAllQualifiers() {
-		return new NestedIterator<>(getQualifiers());
+		return statement.getAllQualifiers();
 	}
 
 	@Override
-	@JsonIgnore
 	public Value getValue() {
-		return this.statement.getMainsnak().getValue();
+		return statement.getValue();
 	}
 
 	@Override

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImpl.java
@@ -189,7 +189,7 @@ public class DataObjectFactoryImpl implements DataObjectFactory {
 	public StatementGroup getStatementGroup(List<Statement> statements) {
 		List<Statement> newStatements = new ArrayList<>(statements.size());
 		for (Statement statement : statements) {
-			if (statement instanceof JacksonPreStatement) {
+			if (statement instanceof StatementImpl) {
 				newStatements.add(statement);
 			} else {
 				newStatements.add(this.dataModelConverter.copy(statement));

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StatementGroupImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StatementGroupImpl.java
@@ -28,23 +28,20 @@ import org.apache.commons.lang3.Validate;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;
-import org.wikidata.wdtk.datamodel.implementation.json.JacksonPreStatement;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
 
 /**
- * Helper class to represent a {@link StatementGroup} deserialized from JSON.
- * The actual data is part of a map of lists of {@link JacksonPreStatement} objects
- * in JSON, so there is no corresponding JSON object.
+ * Helper class to represent a {@link StatementGroup}.
  *
  * @author Markus Kroetzsch
  * @author Antonin Delpeuch
  */
 public class StatementGroupImpl implements StatementGroup {
 
-	final List<Statement> statements;
+	private final List<Statement> statements;
 
 	/**
 	 * Constructor.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StatementImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StatementImpl.java
@@ -1,7 +1,5 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
-import java.util.*;
-
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -22,6 +20,7 @@ import java.util.*;
  * #L%
  */
 
+import java.util.*;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.*;

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/json/JacksonPreStatement.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/json/JacksonPreStatement.java
@@ -21,10 +21,7 @@ package org.wikidata.wdtk.datamodel.implementation.json;
  */
 
 import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import org.apache.commons.lang3.Validate;
 import org.wikidata.wdtk.datamodel.implementation.ReferenceImpl;
 import org.wikidata.wdtk.datamodel.implementation.SnakImpl;
 import org.wikidata.wdtk.datamodel.implementation.StatementImpl;
@@ -33,100 +30,53 @@ import org.wikidata.wdtk.datamodel.interfaces.*;
 import java.util.*;
 
 /**
- * Helper class storing a statement as represented in JSON. This
- * is a Statement missing a subject.
+ * Helper class for deserializing statements from JSON.
  * 
  * @author Antonin Delpeuch
+ * @author Thomas Pellissier Tanon
  *
  */
-@JsonInclude(Include.NON_EMPTY)
-@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonIgnoreProperties(ignoreUnknown=true)
 public class JacksonPreStatement {
 
-	/**
-	 * Id of this statement.
-	 *
-	 * @see Statement#getStatementId()
-	 */
-	private final String id;
+	private final String statementId;
 
-	/**
-	 * Rank of this statement.
-	 */
-	@JsonSerialize(using = StatementRankSerializer.class)
-	@JsonDeserialize(using = StatementRankDeserializer.class)
 	private final StatementRank rank;
 
-	@JsonDeserialize(contentAs=ReferenceImpl.class)
 	private final List<Reference> references;
 
-	/**
-	 * The main snak of this statement.
-	 */
-	@JsonDeserialize(contentAs=SnakImpl.class)
-	private final Snak mainsnak;
+	private final Snak mainSnak;
 
-	/**
-	 * A map from property id strings to snaks that encodes the qualifiers.
-	 * We use the explicit type {@link SnakImpl} because Jackson does
-	 * not know yet how to specify subclasses for interfaces nested in two
-	 * containers.
-	 */
-	@JsonIgnore
 	private final Map<String, List<Snak>> qualifiers;
 	
-	/**
-	 * List of property string ids that encodes the desired order of qualifiers,
-	 * which is not specified by the map.
-	 */
-	private final List<String> propertyOrder;
+	private final List<String> qualifiersOrder;
 
-	/**
-	 * Constructor.
-	 */
-	public JacksonPreStatement(
-			String id,
+	private JacksonPreStatement(
+			String statementId,
 			StatementRank rank,
 			Snak mainsnak,
 			Map<String, List<Snak>> qualifiers,
-			List<String> propertyOrder,
+			List<String> qualifiersOrder,
 			List<Reference> references) {
-		if (id == null) {
-			id = "";
-		}
-		this.id = id;
-		Validate.notNull(rank, "No rank provided to create a statement.");
+		this.statementId = statementId;
 		this.rank = rank;
-		Validate.notNull(mainsnak, "No main snak provided to create a statement.");
-		this.mainsnak = mainsnak;
-		if (qualifiers != null) {
-			this.qualifiers = qualifiers;
-		} else {
-			this.qualifiers = Collections.emptyMap();
-		}
-		if (propertyOrder != null) {
-			this.propertyOrder = propertyOrder;
-		} else {
-			this.propertyOrder = Collections.emptyList();
-		}
-		if (references != null) {
-			this.references = references;
-		} else {
-			this.references = Collections.emptyList();
-		}
+		this.mainSnak = mainsnak;
+		this.qualifiers = qualifiers;
+		this.qualifiersOrder = qualifiersOrder;
+		this.references = references;
 	}
 	
 	/**
 	 * JSON deserialization creator.
 	 */
 	@JsonCreator
-	protected static JacksonPreStatement fromJson(
+	static JacksonPreStatement fromJson(
 			@JsonProperty("id") String id,
-			@JsonProperty("rank") StatementRank rank,
+			@JsonProperty("rank") 	@JsonDeserialize(using = StatementRankDeserializer.class) StatementRank rank,
 			@JsonProperty("mainsnak") SnakImpl mainsnak,
 			@JsonProperty("qualifiers") Map<String, List<SnakImpl>> qualifiers,
-			@JsonProperty("qualifiers-order") List<String> propertyOrder,
-			@JsonProperty("references") List<Reference> references) {
+			@JsonProperty("qualifiers-order") List<String> qualifiersOrder,
+			@JsonProperty("references") @JsonDeserialize(contentAs=ReferenceImpl.class) List<Reference> references) {
 		// Forget the concrete type of Jackson snaks for the qualifiers
 		if(qualifiers == null) {
 			qualifiers = Collections.emptyMap();
@@ -136,92 +86,11 @@ public class JacksonPreStatement {
 			List<Snak> snaks = new ArrayList<>(entry.getValue());
 			newQualifiers.put(entry.getKey(), snaks);
 		}
-		return new JacksonPreStatement(id, rank, mainsnak, newQualifiers, propertyOrder, references);
+		return new JacksonPreStatement(id, rank, mainsnak, newQualifiers, qualifiersOrder, references);
 	}
 	
 	
-	public StatementImpl withSubject(EntityIdValue subject) {
-		return new StatementImpl(
-				id, rank, mainsnak, qualifiers, propertyOrder, references, subject);
+	public StatementImpl withSubject(EntityIdValue subjectId) {
+		return new StatementImpl(statementId, rank, mainSnak, qualifiers, qualifiersOrder, references, subjectId);
 	}
-
-	/**
-	 * Returns the value for the "type" field used in JSON. Only for use by
-	 * Jackson during deserialization.
-	 *
-	 * @return "statement"
-	 */
-	@JsonProperty("type")
-	public String getJsonType() {
-		return "statement";
-	}
-
-	/**
-	 * Returns the rank of the statement.
-	 * @return "rank"
-	 */
-	@JsonProperty("rank")
-	public StatementRank getRank() {
-		return this.rank;
-	}
-
-	/**
-	 * Returns the references of this statement
-	 * @return "references"
-	 */
-	@JsonProperty("references")
-	public List<Reference> getReferences() {
-		return Collections.unmodifiableList(this.references);
-	}
-
-	/**
-	 * Returns the statement identifier.
-	 * @return "id"
-	 */
-	@JsonProperty("id")
-	public String getStatementId() {
-		return this.id;
-	}
-	
-
-	/**
-	 * Returns the main snak of the claim of this statement. Only for use by
-	 * Jackson during serialization. To access this data, use
-	 * {@link Statement#getClaim()}.
-	 *
-	 * @return main snak
-	 */
-	@JsonProperty("mainsnak")
-	public Snak getMainsnak() {
-		return this.mainsnak;
-	}
-
-	/**
-	 * Returns the qualifiers of the claim of this statement. Only for use by
-	 * Jackson during serialization. To access this data, use
-	 * {@link Statement#getClaim()}.
-	 *
-	 * @return qualifiers
-	 */
-	@JsonProperty("qualifiers")
-	public Map<String, List<Snak>> getQualifiers() {
-		return Collections.unmodifiableMap(this.qualifiers);
-	}
-
-	/**
-	 * Returns the list of property ids used to order qualifiers as found in
-	 * JSON. Only for use by Jackson during serialization.
-	 *
-	 * @return the list of property ids
-	 */
-	@JsonProperty("qualifiers-order")
-	public List<String> getPropertyOrder() {
-		return Collections.unmodifiableList(this.propertyOrder);
-	}
-
-	@JsonIgnore
-	public Value getValue() {
-		return this.mainsnak.getValue();
-	}
-
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/Claim.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/Claim.java
@@ -1,8 +1,5 @@
 package org.wikidata.wdtk.datamodel.interfaces;
 
-import java.util.Iterator;
-import java.util.List;
-
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -22,6 +19,9 @@ import java.util.List;
  * limitations under the License.
  * #L%
  */
+
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * Interface for Wikidata claims. Claims consist of those parts of Wikibase

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/Statement.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/Statement.java
@@ -20,6 +20,7 @@ package org.wikidata.wdtk.datamodel.interfaces;
  * #L%
  */
 
+import java.util.Iterator;
 import java.util.List;
 
 /**
@@ -38,6 +39,39 @@ public interface Statement {
 	 * @return the claim that this statement refers to
 	 */
 	Claim getClaim();
+
+	/**
+	 * The subject that the claim refers to, e.g., the id of "Berlin".
+	 *
+	 * @return EntityId of the subject
+	 */
+	EntityIdValue getSubject();
+
+	/**
+	 * Main Snak of the statement. This Snak refers directly to the subject,
+	 * e.g., the {@link ValueSnak} "Population: 3000000".
+	 *
+	 * @return the main snak
+	 */
+	Snak getMainSnak();
+
+	/**
+	 * Groups of auxiliary Snaks, also known as qualifiers, that provide
+	 * additional context information for this claim. For example, "as of: 2014"
+	 * might be a temporal context given for a claim that provides a population
+	 * number. The snaks are grouped by the property that they use.
+	 *
+	 * @return list of snak groups
+	 */
+	List<SnakGroup> getQualifiers();
+
+	/**
+	 * Returns an iterator over all qualifiers, without considering qualifier
+	 * groups. The relative order of qualifiers is preserved.
+	 *
+	 * @return iterator over all qualifier snaks
+	 */
+	Iterator<Snak> getAllQualifiers();
 
 	/**
 	 * @see StatementRank

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverterTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverterTest.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.helpers;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ClaimImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ClaimImplTest.java
@@ -43,11 +43,11 @@ import org.wikidata.wdtk.datamodel.interfaces.ValueSnak;
 
 public class ClaimImplTest {
 
-	EntityIdValue subject;
-	ValueSnak mainSnak;
+	private EntityIdValue subject;
+	private ValueSnak mainSnak;
 
-	Claim c1;
-	Claim c2;
+	private Claim c1;
+	private Claim c2;
 
 	@Before
 	public void setUp() throws Exception {
@@ -67,7 +67,7 @@ public class ClaimImplTest {
 	public void gettersWorking() {
 		assertEquals(c1.getSubject(), subject);
 		assertEquals(c1.getMainSnak(), mainSnak);
-		assertEquals(c1.getQualifiers(), Collections. emptyList());
+		assertEquals(c1.getQualifiers(), Collections.emptyList());
 	}
 
 	@Test(expected = NullPointerException.class)

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementImplTest.java
@@ -28,82 +28,71 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
-import java.util.List;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.wikidata.wdtk.datamodel.interfaces.Claim;
-import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.Reference;
-import org.wikidata.wdtk.datamodel.interfaces.Snak;
-import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
-import org.wikidata.wdtk.datamodel.interfaces.Statement;
-import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
-import org.wikidata.wdtk.datamodel.interfaces.ValueSnak;
+import org.wikidata.wdtk.datamodel.interfaces.*;
+import org.wikidata.wdtk.util.NestedIterator;
 
 public class StatementImplTest {
 
-	EntityIdValue subject;
-	ValueSnak mainSnak;
-	Claim claim;
+	private EntityIdValue subjet;
+	private EntityIdValue value;
+	private ValueSnak mainSnak;
+	private Claim claim;
 
-	Statement s1;
-	Statement s2;
+	private Statement s1;
+	private Statement s2;
 
 	@Before
 	public void setUp() throws Exception {
-		subject = new ItemIdValueImpl("Q42", "http://wikidata.org/entity/");
+		subjet = new ItemIdValueImpl("Q1", "http://wikidata.org/entity/");
+		value = new ItemIdValueImpl("Q42", "http://wikidata.org/entity/");
 		PropertyIdValue property = new PropertyIdValueImpl("P42",
 				"http://wikidata.org/entity/");
-		mainSnak = new ValueSnakImpl(property, subject);
+		mainSnak = new ValueSnakImpl(property, value);
 
-		claim = new ClaimImpl(subject, mainSnak, Collections.emptyList());
+		claim = new ClaimImpl(subjet, mainSnak, Collections.emptyList());
 		s1 = new StatementImpl("MyId", StatementRank.NORMAL, mainSnak,
-				Collections.emptyList(), Collections.emptyList(), subject);
+				Collections.emptyList(), Collections.emptyList(), subjet);
 		s2 = new StatementImpl("MyId", StatementRank.NORMAL, mainSnak,
-				Collections.emptyList(), Collections.emptyList(), subject);
+				Collections.emptyList(), Collections.emptyList(), subjet);
 	}
 
 	@Test
 	public void gettersWorking() {
 		assertEquals(s1.getClaim(), claim);
-		assertEquals(s1.getReferences(),
-				Collections. emptyList());
+		assertEquals(s1.getMainSnak(), mainSnak);
+		assertEquals(s1.getQualifiers(), Collections.emptyList());
+		assertEquals(s1.getReferences(), Collections. emptyList());
 		assertEquals(s1.getRank(), StatementRank.NORMAL);
 		assertEquals(s1.getStatementId(), "MyId");
-		assertEquals(s1.getValue(), subject);
+		assertEquals(s1.getValue(), value);
+		assertEquals(s1.getSubject(), subjet);
 	}
 
 	@Test(expected = NullPointerException.class)
 	public void mainSnakNotNull() {
 		new StatementImpl("MyId", StatementRank.NORMAL, null,
-				Collections.emptyList(), Collections.emptyList(), subject);
-	}
-
-	@Test(expected = NullPointerException.class)
-	@SuppressWarnings("deprecation")
-	public void claimNotNull() {
-		new StatementImpl(null, Collections. emptyList(),
-				StatementRank.NORMAL, "MyId");
+				Collections.emptyList(), Collections.emptyList(), value);
 	}
 
 	@Test
 	public void referencesCanBeNull() {
-		Statement statement = new StatementImpl("MyId", StatementRank.NORMAL, mainSnak,  Collections.emptyList(), null, subject);
+		Statement statement = new StatementImpl("MyId", StatementRank.NORMAL, mainSnak,  Collections.emptyList(), null, value);
 		assertTrue(statement.getReferences().isEmpty());
 	}
 
 	@Test(expected = NullPointerException.class)
 	public void rankNotNull() {
 		new StatementImpl("MyId", null, mainSnak,
-				Collections.emptyList(), Collections.emptyList(), subject);
+				Collections.emptyList(), Collections.emptyList(), value);
 	}
 
 	@Test
 	public void idCanBeNull() {
 		Statement statement = new StatementImpl(null, StatementRank.NORMAL, mainSnak,
-				Collections.emptyList(), Collections.emptyList(), subject);
+				Collections.emptyList(), Collections.emptyList(), value);
 		assertEquals(statement.getStatementId(), "");
 	}
 
@@ -120,11 +109,11 @@ public class StatementImplTest {
 		Statement sDiffReferences = new StatementImpl("MyId", StatementRank.NORMAL, mainSnak,
 				Collections.emptyList(), Collections.singletonList(new ReferenceImpl(
 						Collections.singletonList(new SnakGroupImpl(Collections.singletonList(mainSnak)))
-				)), subject);
+				)), value);
 		Statement sDiffRank = new StatementImpl("MyId", StatementRank.PREFERRED, mainSnak,
-				Collections.emptyList(), Collections.emptyList(), subject);
+				Collections.emptyList(), Collections.emptyList(), value);
 		Statement sDiffId = new StatementImpl("MyOtherId", StatementRank.NORMAL, mainSnak,
-				Collections.emptyList(), Collections.emptyList(), subject);
+				Collections.emptyList(), Collections.emptyList(), value);
 
 		assertEquals(s1, s1);
 		assertEquals(s1, s2);

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/json/JsonTestData.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/json/JsonTestData.java
@@ -30,7 +30,6 @@ import org.wikidata.wdtk.datamodel.implementation.SiteLinkImpl;
 import org.wikidata.wdtk.datamodel.implementation.SomeValueSnakImpl;
 import org.wikidata.wdtk.datamodel.implementation.StatementImpl;
 import org.wikidata.wdtk.datamodel.implementation.ValueSnakImpl;
-import org.wikidata.wdtk.datamodel.implementation.json.JacksonPreStatement;
 import org.wikidata.wdtk.datamodel.implementation.ValueImpl;
 import org.wikidata.wdtk.datamodel.implementation.GlobeCoordinatesValueImpl;
 import org.wikidata.wdtk.datamodel.implementation.MonolingualTextValueImpl;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/json/TestItemDocument.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/json/TestItemDocument.java
@@ -34,15 +34,10 @@ import org.wikidata.wdtk.datamodel.helpers.DatamodelConverter;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.implementation.ItemDocumentImpl;
 import org.wikidata.wdtk.datamodel.implementation.DataObjectFactoryImpl;
-import org.wikidata.wdtk.datamodel.implementation.json.JacksonPreStatement;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
-import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
 
-import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class TestItemDocument {

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/json/TestPropertyDocument.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/json/TestPropertyDocument.java
@@ -28,7 +28,6 @@ import java.util.List;
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.implementation.PropertyDocumentImpl;
-import org.wikidata.wdtk.datamodel.implementation.json.JacksonPreStatement;
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
 
 import com.fasterxml.jackson.databind.ObjectMapper;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/json/TestStatement.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/json/TestStatement.java
@@ -32,7 +32,6 @@ import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.implementation.DataObjectFactoryImplTest;
 import org.wikidata.wdtk.datamodel.implementation.StatementImpl;
-import org.wikidata.wdtk.datamodel.implementation.json.JacksonPreStatement;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 
@@ -45,7 +44,7 @@ public class TestStatement {
 
 	@Test
 	public void testEmptyStatementToJson() throws JsonProcessingException {
-		JacksonPreStatement statement = JsonTestData.getTestNoValueStatement();
+		StatementImpl statement = JsonTestData.getTestNoValueStatement();
 
 		String result = mapper.writeValueAsString(statement);
 		JsonComparator.compareJsonStrings(JsonTestData.JSON_NOVALUE_STATEMENT,
@@ -63,7 +62,7 @@ public class TestStatement {
 
 	@Test
 	public void testEmptyStatementNoIdToJson() throws JsonProcessingException {
-		JacksonPreStatement statement = JsonTestData.getTestNoValueNoIdStatement();
+		StatementImpl statement = JsonTestData.getTestNoValueNoIdStatement();
 
 		String result = mapper.writeValueAsString(statement);
 		JsonComparator.compareJsonStrings(

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/StatementUpdate.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/StatementUpdate.java
@@ -25,20 +25,13 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelConverter;
 import org.wikidata.wdtk.datamodel.implementation.DataObjectFactoryImpl;
-import org.wikidata.wdtk.datamodel.interfaces.Claim;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.Reference;
-import org.wikidata.wdtk.datamodel.interfaces.Snak;
-import org.wikidata.wdtk.datamodel.interfaces.Statement;
-import org.wikidata.wdtk.datamodel.interfaces.StatementDocument;
-import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
-import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
-import org.wikidata.wdtk.datamodel.interfaces.Value;
+import org.wikidata.wdtk.datamodel.interfaces.*;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -92,6 +85,30 @@ public class StatementUpdate {
 		@Override
 		@JsonIgnore
 		public Claim getClaim() {
+			return null;
+		}
+
+		@Override
+		@JsonIgnore
+		public EntityIdValue getSubject() {
+			return null;
+		}
+
+		@Override
+		@JsonIgnore
+		public Snak getMainSnak() {
+			return null;
+		}
+
+		@Override
+		@JsonIgnore
+		public List<SnakGroup> getQualifiers() {
+			return null;
+		}
+
+		@Override
+		@JsonIgnore
+		public Iterator<Snak> getAllQualifiers() {
 			return null;
 		}
 

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/StatementUpdate.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/StatementUpdate.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;


### PR DESCRIPTION
Makes easier for clients to retrieve statements content without requiring an unneeded getter.

Uses JaksonPreStatement only for deserialization