### PR TITLE
[Breaking] Uses "1" as the identifier for empty unit

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ToString.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ToString.java
@@ -187,7 +187,7 @@ public class ToString {
 		if(o.getLowerBound() != null && o.getUpperBound() != null) {
 			str += " [" + o.getLowerBound().toString() + " .. " + o.getUpperBound().toString() + "]";
 		}
-		if(!"".equals(o.getUnit())) {
+		if(!"1".equals(o.getUnit())) {
 			str += " " + o.getUnit();
 		}
 		return str;

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImpl.java
@@ -94,13 +94,13 @@ public class DataObjectFactoryImpl implements DataObjectFactory {
 
 	@Override
 	public QuantityValue getQuantityValue(BigDecimal numericValue) {
-		return getQuantityValue(numericValue, null, null, "");
+		return getQuantityValue(numericValue, null, null, "1");
 	}
 
 	@Override
 	public QuantityValue getQuantityValue(BigDecimal numericValue,
 			BigDecimal lowerBound, BigDecimal upperBound) {
-		return getQuantityValue(numericValue, lowerBound, upperBound, "");
+		return getQuantityValue(numericValue, lowerBound, upperBound, "1");
 	}
 
 	@Override

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/json/JacksonInnerQuantity.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/json/JacksonInnerQuantity.java
@@ -46,7 +46,7 @@ public class JacksonInnerQuantity {
 	private final BigDecimal amount;
 	private final BigDecimal upperBound;
 	private final BigDecimal lowerBound;
-	private final String jsonUnit;
+	private final String unit;
 
 	/**
 	 * Constructor. The unit given here is a unit string as used in WDTK, with
@@ -63,34 +63,31 @@ public class JacksonInnerQuantity {
 	 */
 	@JsonCreator
 	public JacksonInnerQuantity(
-			@JsonProperty("amount") BigDecimal numericValue,
+			@JsonProperty("amount") BigDecimal amount,
 			@JsonProperty("lowerBound") BigDecimal lowerBound,
 			@JsonProperty("upperBound") BigDecimal upperBound,
 			@JsonProperty("unit") String unit) {
-		Validate.notNull(numericValue, "Numeric value cannot be null");
+		Validate.notNull(amount, "Numeric value cannot be null");
 		Validate.notNull(unit, "Unit cannot be null");
+		Validate.notEmpty(unit, "Unit cannot be empty. Use \"1\" for unit-less quantities.");
 
 		if(lowerBound != null || upperBound != null) {
 			Validate.notNull(lowerBound, "Lower and upper bounds should be null at the same time");
 			Validate.notNull(upperBound, "Lower and upper bounds should be null at the same time");
 
-			if (lowerBound.compareTo(numericValue) == 1) {
+			if (lowerBound.compareTo(amount) > 0) {
 				throw new IllegalArgumentException(
 						"Lower bound cannot be strictly greater than numeric value");
 			}
-			if (numericValue.compareTo(upperBound) == 1) {
+			if (amount.compareTo(upperBound) > 0) {
 				throw new IllegalArgumentException(
 						"Upper bound cannot be strictly smaller than numeric value");
 			}
 		}
-		this.amount = numericValue;
+		this.amount = amount;
 		this.upperBound = upperBound;
 		this.lowerBound = lowerBound;
-		if ("".equals(unit)) {
-			this.jsonUnit = "1";
-		} else {
-			this.jsonUnit = unit;
-		}
+		this.unit = unit;
 	}
 
 	/**
@@ -148,22 +145,8 @@ public class JacksonInnerQuantity {
 	 * @return unit string
 	 */
 	@JsonProperty("unit")
-	public String getJsonUnit() {
-		return this.jsonUnit;
-	}
-
-	/**
-	 * Returns the unit to be used, converting JSON-specific encodings of
-	 * "no unit" to the one used in WDTK.
-	 *
-	 * @return unit string
-	 */
 	public String getUnit() {
-		if ("1".equals(this.jsonUnit)) {
-			return "";
-		} else {
-			return this.jsonUnit;
-		}
+		return this.unit;
 	}
 
 	@Override
@@ -179,7 +162,7 @@ public class JacksonInnerQuantity {
 		return this.amount.equals(other.amount)
 				&& equalsNullable(this.lowerBound, other.lowerBound)
 				&& equalsNullable(this.upperBound, other.upperBound)
-				&& this.jsonUnit.equals(other.jsonUnit);
+				&& this.unit.equals(other.unit);
 	}
 
 	private boolean equalsNullable(Object o1, Object o2) {

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/QuantityValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/QuantityValue.java
@@ -54,10 +54,10 @@ public interface QuantityValue extends Value {
 	BigDecimal getUpperBound();
 
 	/**
-	 * Returns the unit of this quantity, or an empty string if there is no
+	 * Returns the unit of this quantity, or the string "1" if there is no
 	 * unit. Units are typically encoded as entity IRIs.
 	 *
-	 * @return unit string, or empty string if no unit is given
+	 * @return unit string (IRI or the string "1" if there is no unit)
 	 */
 	String getUnit();
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/QuantityValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/QuantityValueImplTest.java
@@ -60,7 +60,7 @@ public class QuantityValueImplTest {
 		QuantityValue q4 = new QuantityValueImpl(nvplus, lb, ub, unitMeter);
 		QuantityValue q5 = new QuantityValueImpl(nv, nvminus, ub, unitMeter);
 		QuantityValue q6 = new QuantityValueImpl(nv, lb, nvplus, unitMeter);
-		QuantityValue q7 = new QuantityValueImpl(nv, lb, ub, "");
+		QuantityValue q7 = new QuantityValueImpl(nv, lb, ub, "1");
 
 		assertEquals(q1, q1);
 		assertEquals(q1, q2);
@@ -113,6 +113,11 @@ public class QuantityValueImplTest {
 	@Test(expected = NullPointerException.class)
 	public void unitNotNull() {
 		new QuantityValueImpl(nv, lb, ub, null);
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void unitNotEmpty() {
+		new QuantityValueImpl(nv, lb, ub, "");
 	}
 
 	@Test(expected = IllegalArgumentException.class)

--- a/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/bots/FixIntegerQuantityPrecisionsBot.java
+++ b/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/bots/FixIntegerQuantityPrecisionsBot.java
@@ -317,7 +317,7 @@ public class FixIntegerQuantityPrecisionsBot implements EntityDocumentProcessor 
 				if (qv != null && isPlusMinusOneValue(qv)) {
 					QuantityValue exactValue = Datamodel.makeQuantityValue(
 							qv.getNumericValue(), qv.getNumericValue(),
-							qv.getNumericValue(), "");
+							qv.getNumericValue());
 					Statement exactStatement = StatementBuilder
 							.forSubjectAndProperty(itemIdValue, property)
 							.withValue(exactValue).withId(s.getStatementId())
@@ -393,7 +393,7 @@ public class FixIntegerQuantityPrecisionsBot implements EntityDocumentProcessor 
 		BigDecimal valuePrec = quantityValue.getNumericValue().subtract(
 				BigDecimal.ONE);
 		return (quantityValue.getLowerBound().equals(valuePrec)
-				&& quantityValue.getUpperBound().equals(valueSucc) && ""
+				&& quantityValue.getUpperBound().equals(valueSucc) && "1"
 					.equals(quantityValue.getUnit()));
 	}
 

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/values/QuantityValueConverter.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/values/QuantityValueConverter.java
@@ -87,12 +87,9 @@ public class QuantityValueConverter extends
 					RdfWriter.WB_QUANTITY_UPPER_BOUND, value.getUpperBound().toString(),
 					RdfWriter.XSD_DECIMAL);
 		}
-		String unitIri;
-		if ("".equals(value.getUnit())) {
-			unitIri = Vocabulary.WB_NO_UNIT;
-		} else {
-			unitIri = value.getUnit();
-		}
+		String unitIri = ("1".equals(value.getUnit()))
+				? Vocabulary.WB_NO_UNIT
+				: value.getUnit();
 		this.rdfWriter.writeTripleUriObject(resource,
 				RdfWriter.WB_QUANTITY_UNIT, unitIri);
 	}

--- a/wdtk-rdf/src/test/resources/QuantityValue.rdf
+++ b/wdtk-rdf/src/test/resources/QuantityValue.rdf
@@ -1,4 +1,4 @@
-<http://www.wikidata.org/entity/VQe2632d37f5189ef2e1087f0267377ad3> a <http://wikiba.se/ontology#QuantityValue> ;
+<http://www.wikidata.org/entity/VQ690bb9c41a83f7db4274267776c6d276> a <http://wikiba.se/ontology#QuantityValue> ;
 	<http://wikiba.se/ontology#quantityAmount> "100"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	<http://wikiba.se/ontology#quantityLowerBound> "100"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	<http://wikiba.se/ontology#quantityUpperBound> "100"^^<http://www.w3.org/2001/XMLSchema#decimal> ;

--- a/wdtk-rdf/src/test/resources/UnboundedQuantityValue.rdf
+++ b/wdtk-rdf/src/test/resources/UnboundedQuantityValue.rdf
@@ -1,4 +1,4 @@
 
-<http://www.wikidata.org/entity/VQ5848bf8e7e0f5b519f848167bbeed681> a <http://wikiba.se/ontology#QuantityValue> ;
+<http://www.wikidata.org/entity/VQ2a9ceaceca73f51166c0f95e84bca92b> a <http://wikiba.se/ontology#QuantityValue> ;
 	<http://wikiba.se/ontology#quantityAmount> "100"^^<http://www.w3.org/2001/XMLSchema#decimal> ;
 	<http://wikiba.se/ontology#quantityUnit> <http://www.wikidata.org/entity/Q199>.


### PR DESCRIPTION
Consistent with the PHP implementation: https://github.com/DataValues/Number/blob/master/src/DataValues/UnboundedQuantityValue.php#L41

It has the advantage of removing one of the easy to miss difference between WikidataToolkit and the API output but the disadvantage of being a braking change compared to the released versions.