### PR TITLE
Adds EntityDocumentImpl and StatementDocumentImpl as abstract utility classes

### DIFF
--- a/wdtk-client/src/test/java/org/wikidata/wdtk/client/JsonSerializationActionTest.java
+++ b/wdtk-client/src/test/java/org/wikidata/wdtk/client/JsonSerializationActionTest.java
@@ -34,7 +34,7 @@ import java.util.List;
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
-import org.wikidata.wdtk.datamodel.implementation.TermedStatementDocumentImpl;
+import org.wikidata.wdtk.datamodel.implementation.EntityDocumentImpl;
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
@@ -117,15 +117,15 @@ public class JsonSerializationActionTest {
 				Paths.get("/path/to/"), false);
 
 		ObjectMapper mapper = new DatamodelMapper(Datamodel.SITE_WIKIDATA);
-		ObjectReader documentReader = mapper.readerFor(TermedStatementDocumentImpl.class);
-		MappingIterator<TermedStatementDocumentImpl> documentIterator = documentReader
+		ObjectReader documentReader = mapper
+				.readerFor(EntityDocumentImpl.class);
+		MappingIterator<EntityDocument> documentIterator = documentReader
 				.readValues(mdm.getInputStreamForFile("output.json",
 						CompressionType.NONE));
 
 		List<EntityDocument> results = new ArrayList<>();
 		while (documentIterator.hasNextValue()) {
-			TermedStatementDocumentImpl document = documentIterator
-					.nextValue();
+			EntityDocument document = documentIterator.nextValue();
 			results.add(document);
 		}
 		documentIterator.close();
@@ -169,15 +169,14 @@ public class JsonSerializationActionTest {
 				Paths.get("/path/to/"), false);
 
 		ObjectMapper mapper = new DatamodelMapper(Datamodel.SITE_WIKIDATA);
-		ObjectReader documentReader = mapper.readerFor(TermedStatementDocumentImpl.class);
-		MappingIterator<TermedStatementDocumentImpl> documentIterator = documentReader
+		ObjectReader documentReader = mapper.readerFor(EntityDocumentImpl.class);
+		MappingIterator<EntityDocument> documentIterator = documentReader
 				.readValues(mdm.getInputStreamForFile("output.json.gz",
 						CompressionType.GZIP));
 
 		List<EntityDocument> results = new ArrayList<>();
 		while (documentIterator.hasNextValue()) {
-			TermedStatementDocumentImpl document = documentIterator
-					.nextValue();
+			EntityDocument document = documentIterator.nextValue();
 			results.add(document);
 		}
 		documentIterator.close();
@@ -218,15 +217,14 @@ public class JsonSerializationActionTest {
 				false);
 
 		ObjectMapper mapper = new DatamodelMapper(Datamodel.SITE_WIKIDATA);
-		ObjectReader documentReader = mapper.readerFor(TermedStatementDocumentImpl.class);
-		MappingIterator<TermedStatementDocumentImpl> documentIterator = documentReader
+		ObjectReader documentReader = mapper.readerFor(EntityDocumentImpl.class);
+		MappingIterator<EntityDocument> documentIterator = documentReader
 				.readValues(mdm.getInputStreamForFile("output.json.bz2",
 						CompressionType.BZ2));
 
 		List<EntityDocument> results = new ArrayList<>();
 		while (documentIterator.hasNextValue()) {
-			TermedStatementDocumentImpl document = documentIterator
-					.nextValue();
+			EntityDocument document = documentIterator.nextValue();
 			results.add(document);
 		}
 		documentIterator.close();

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/EntityDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/EntityDocumentImpl.java
@@ -1,0 +1,149 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.fasterxml.jackson.annotation.*;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
+import org.apache.commons.lang3.Validate;
+import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
+import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
+
+/**
+ * Abstract Jackson implementation of {@link EntityDocument}. Like all Jackson
+ * objects, it is not technically immutable, but it is strongly recommended to
+ * treat it as such in all contexts: the setters are for Jackson; never call
+ * them in your code.
+ *
+ * @author Thomas Pellissier Tanon
+ *
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
+@JsonSubTypes({
+		@Type(value = ItemDocumentImpl.class, name = EntityDocumentImpl.JSON_TYPE_ITEM),
+		@Type(value = PropertyDocumentImpl.class, name = EntityDocumentImpl.JSON_TYPE_PROPERTY) })
+public abstract class EntityDocumentImpl implements EntityDocument {
+
+	/**
+	 * String used to refer to items in JSON.
+	 */
+	static final String JSON_TYPE_ITEM = "item";
+	/**
+	 * String used to refer to properties in JSON.
+	 */
+	static final String JSON_TYPE_PROPERTY = "property";
+
+	/**
+	 * The id of the entity that the document refers to. This is not mapped to
+	 * JSON directly by Jackson but split into two fields, "type" and "id". The
+	 * type field is ignored during deserialization since the type is clear for
+	 * a concrete document. For serialization, the type is hard-coded.
+	 * <p>
+	 * The site IRI, which would also be required to create a complete
+	 * {@link EntityIdValue}, is not encoded in JSON. It needs to be injected
+	 * from the outside (if not, we default to Wikidata).
+	 */
+	@JsonIgnore
+	protected final String entityId;
+
+	/**
+	 * The site IRI that this document refers to, or null if not specified. In
+	 * the latter case, we assume Wikidata as the default.
+	 *
+	 * @see EntityIdValue#getSiteIri()
+	 */
+	@JsonIgnore
+	protected final String siteIri;
+
+	/**
+	 * The revision id of this document.
+	 *
+	 * @see EntityDocument#getRevisionId()
+	 */
+	@JsonIgnore
+	protected final long revisionId;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param id
+	 * 		the identifier of the subject of this document
+	 * @param revisionId
+	 * 		the id of the last revision of this document
+	 */
+	EntityDocumentImpl(EntityIdValue id, long revisionId) {
+		Validate.notNull(id);
+		this.entityId = id.getId();
+		this.siteIri = id.getSiteIri();
+		this.revisionId = revisionId;
+	}
+
+	/**
+	 * Constructor used for JSON deserialization with Jackson.
+	 */
+	EntityDocumentImpl(
+			@JsonProperty("id") String jsonId,
+			@JsonProperty("lastrevid") long revisionId,
+			@JacksonInject("siteIri") String siteIri) {
+		Validate.notNull(jsonId);
+		this.entityId = jsonId;
+		Validate.notNull(siteIri);
+		this.siteIri = siteIri;
+		this.revisionId = revisionId;
+	}
+
+	/**
+	 * Returns the string id of the entity that this document refers to. Only
+	 * for use by Jackson during serialization.
+	 *
+	 * @return string id
+	 */
+	@JsonInclude(Include.NON_EMPTY)
+	@JsonProperty("id")
+	public String getJsonId() {
+		if (!EntityIdValue.SITE_LOCAL.equals(this.siteIri)) {
+			return this.entityId;
+		} else {
+			return null;
+		}
+	}
+
+	@JsonIgnore
+	public String getSiteIri() {
+		return this.siteIri;
+	}
+	
+	private static class NonZeroFilter {
+		@Override
+		public boolean equals(Object other) {
+			return (other instanceof Long) && (long)other == 0;
+		}
+	}
+
+	@Override
+	@JsonInclude(value=Include.CUSTOM, valueFilter=NonZeroFilter.class)
+	@JsonProperty("lastrevid")
+	public long getRevisionId() {
+		return this.revisionId;
+
+	}
+}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImpl.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;
@@ -102,9 +101,9 @@ public class ItemDocumentImpl extends TermedStatementDocumentImpl
 	@JsonCreator
 	public ItemDocumentImpl(
 			@JsonProperty("id") String jsonId,
-			@JsonProperty("labels") Map<String, MonolingualTextValue> labels,
-			@JsonProperty("descriptions") Map<String, MonolingualTextValue> descriptions,
-			@JsonProperty("aliases") Map<String, List<MonolingualTextValue>> aliases,
+			@JsonProperty("labels") @JsonDeserialize(contentAs=TermImpl.class) Map<String, MonolingualTextValue> labels,
+			@JsonProperty("descriptions") @JsonDeserialize(contentAs=TermImpl.class) Map<String, MonolingualTextValue> descriptions,
+			@JsonProperty("aliases") @JsonDeserialize(using = AliasesDeserializer.class) Map<String, List<MonolingualTextValue>> aliases,
 			@JsonProperty("claims") Map<String, List<StatementImpl.PreStatement>> claims,
 			@JsonProperty("sitelinks") Map<String, SiteLink> sitelinks,
 			@JsonProperty("lastrevid") long revisionId,

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImpl.java
@@ -23,7 +23,7 @@ import java.util.Map;
  * #L%
  */
 
-import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;
@@ -94,9 +94,9 @@ public class PropertyDocumentImpl extends TermedStatementDocumentImpl
 	@JsonCreator
 	public PropertyDocumentImpl(
 			@JsonProperty("id") String jsonId,
-			@JsonProperty("labels") Map<String, MonolingualTextValue> labels,
-			@JsonProperty("descriptions") Map<String, MonolingualTextValue> descriptions,
-			@JsonProperty("aliases") Map<String, List<MonolingualTextValue>> aliases,
+			@JsonProperty("labels") @JsonDeserialize(contentAs=TermImpl.class) Map<String, MonolingualTextValue> labels,
+			@JsonProperty("descriptions") @JsonDeserialize(contentAs=TermImpl.class) Map<String, MonolingualTextValue> descriptions,
+			@JsonProperty("aliases") @JsonDeserialize(using = AliasesDeserializer.class) Map<String, List<MonolingualTextValue>> aliases,
 			@JsonProperty("claims") Map<String, List<StatementImpl.PreStatement>> claims,
 			@JsonProperty("datatype") String datatype,
 			@JsonProperty("lastrevid") long revisionId,

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StatementDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StatementDocumentImpl.java
@@ -1,0 +1,137 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.fasterxml.jackson.annotation.*;
+import org.apache.commons.lang3.Validate;
+import org.wikidata.wdtk.datamodel.interfaces.*;
+import org.wikidata.wdtk.util.NestedIterator;
+
+import java.util.*;
+import java.util.Map.Entry;
+
+/**
+ * Abstract Jackson implementation of {@link StatementDocument}.
+ * You should not rely on it directly.
+ *
+ * @author Fredo Erxleben
+ * @author Antonin Delpeuch
+ * @author Thomas Pellissier Tanon
+ *
+ */
+abstract class StatementDocumentImpl extends EntityDocumentImpl implements StatementDocument {
+
+	/**
+	 * This is what is called <i>claim</i> in the JSON model. It corresponds to
+	 * the statement group in the WDTK model.
+	 */
+	private final Map<String, List<Statement>> claims;
+
+	/**
+	 * Statement groups. This member is initialized when statements are
+	 * accessed.
+	 */
+	private List<StatementGroup> statementGroups;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param id
+	 * 		the identifier of the subject of this document
+	 * @param claims
+	 * 		the statement groups contained in this document
+	 * @param revisionId
+	 * 		the id of the last revision of this document
+	 */
+	StatementDocumentImpl(
+			EntityIdValue id,
+			List<StatementGroup> claims,
+			long revisionId) {
+		super(id, revisionId);
+		this.claims = new HashMap<>();
+		if(claims != null) {
+			for(StatementGroup group : claims) {
+				EntityIdValue otherId = group.getSubject();
+				otherId.getIri();
+				Validate.isTrue(group.getSubject().equals(id), "Subject for the statement group and the document are different: "+otherId.toString()+" vs "+id.toString());
+				this.claims.put(group.getProperty().getId(), group.getStatements());
+			}
+		}
+	}
+
+	/**
+	 * Constructor used for JSON deserialization with Jackson.
+	 */
+	StatementDocumentImpl(
+			@JsonProperty("id") String jsonId,
+			@JsonProperty("claims") Map<String, List<StatementImpl.PreStatement>> claims,
+			@JsonProperty("lastrevid") long revisionId,
+			@JacksonInject("siteIri") String siteIri) {
+		super(jsonId, revisionId, siteIri);
+		if (claims != null) {
+			this.claims = new HashMap<>();
+			EntityIdValue subject = this.getEntityId();
+			for (Entry<String, List<StatementImpl.PreStatement>> entry : claims
+					.entrySet()) {
+				List<Statement> statements = new ArrayList<>(entry.getValue().size());
+				for (StatementImpl.PreStatement statement : entry.getValue()) {
+					statements.add(statement.withSubject(subject));
+				}
+				this.claims.put(entry.getKey(), statements);
+			}
+		} else {
+			this.claims = Collections.emptyMap();
+		}
+	}
+
+	@JsonIgnore
+	@Override
+	public List<StatementGroup> getStatementGroups() {
+		if (this.statementGroups == null) {
+			this.statementGroups = new ArrayList<>(this.claims.size());
+			for (List<Statement> statements : this.claims.values()) {
+				this.statementGroups
+						.add(new StatementGroupImpl(statements));
+			}
+		}
+		return this.statementGroups;
+	}
+
+	/**
+	 * Returns the "claims". Only used by Jackson.
+	 * <p>
+	 * JSON "claims" correspond to statement groups in the WDTK model. You
+	 * should use {@link ItemDocumentImpl#getStatementGroups()} to obtain
+	 * this data.
+	 *
+	 * @return map of statement groups
+	 */
+	@JsonProperty("claims")
+	public Map<String, List<Statement>> getJsonClaims() {
+		return this.claims;
+	}
+
+	@Override
+	@JsonIgnore
+	public Iterator<Statement> getAllStatements() {
+		return new NestedIterator<>(getStatementGroups());
+	}
+}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermedStatementDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermedStatementDocumentImpl.java
@@ -59,8 +59,8 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes({ //TODO: drop in future release
-		@Type(value = ItemDocumentImpl.class, name = TermedStatementDocumentImpl.JSON_TYPE_ITEM),
-		@Type(value = PropertyDocumentImpl.class, name = TermedStatementDocumentImpl.JSON_TYPE_PROPERTY) })
+		@Type(value = ItemDocumentImpl.class, name = EntityDocumentImpl.JSON_TYPE_ITEM),
+		@Type(value = PropertyDocumentImpl.class, name = EntityDocumentImpl.JSON_TYPE_PROPERTY) })
 public abstract class TermedStatementDocumentImpl extends StatementDocumentImpl implements TermedDocument {
 
 	protected final Map<String, List<MonolingualTextValue>> aliases;

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ValueImpl.java
@@ -1,10 +1,10 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.ObjectCodec;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 
 /*
@@ -113,7 +113,7 @@ public abstract class ValueImpl implements Value {
 		public ValueImpl deserialize(JsonParser jsonParser,
 				DeserializationContext ctxt) throws IOException {
 
-			ObjectMapper mapper = (ObjectMapper) jsonParser.getCodec();
+			ObjectCodec mapper = jsonParser.getCodec();
 			JsonNode root = mapper.readTree(jsonParser);
 			Class<? extends ValueImpl> valueClass = getValueClass(root, jsonParser);
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/JsonSerializerTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/JsonSerializerTest.java
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import org.junit.Test;
-import org.wikidata.wdtk.datamodel.implementation.TermedStatementDocumentImpl;
+import org.wikidata.wdtk.datamodel.implementation.EntityDocumentImpl;
 import org.wikidata.wdtk.datamodel.implementation.JsonComparator;
 import org.wikidata.wdtk.datamodel.interfaces.*;
 
@@ -79,9 +79,9 @@ public class JsonSerializerTest {
 		List<EntityDocument> outputDocuments = new ArrayList<>();
 
 		ObjectMapper mapper = new DatamodelMapper("http://www.wikidata.org/entity/");
-		ObjectReader documentReader = mapper.readerFor(TermedStatementDocumentImpl.class);
+		ObjectReader documentReader = mapper.readerFor(EntityDocumentImpl.class);
 
-		MappingIterator<TermedStatementDocumentImpl> documentIterator = documentReader.readValues(out.toString());
+		MappingIterator<EntityDocument> documentIterator = documentReader.readValues(out.toString());
 		while (documentIterator.hasNextValue()) {
 			outputDocuments.add(documentIterator.nextValue());
 		}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImplTest.java
@@ -239,7 +239,7 @@ public class ItemDocumentImplTest {
 		ItemDocumentImpl document = new ItemDocumentImpl(iid,
 				labelList, Collections.emptyList(), Collections.emptyList(),
 				Collections.emptyList(), Collections.emptyList(), 0);
-		assertEquals(document, mapper.readValue(JSON_ITEM_LABEL, TermedStatementDocumentImpl.class));
+		assertEquals(document, mapper.readValue(JSON_ITEM_LABEL, EntityDocumentImpl.class));
 	}
 
 	@Test
@@ -255,7 +255,7 @@ public class ItemDocumentImplTest {
 		ItemDocumentImpl document = new ItemDocumentImpl(iid,
 				Collections.emptyList(), descList, Collections.emptyList(),
 				Collections.emptyList(), Collections.emptyList(), 0);
-		assertEquals(document, mapper.readValue(JSON_ITEM_DESCRIPTION, TermedStatementDocumentImpl.class));
+		assertEquals(document, mapper.readValue(JSON_ITEM_DESCRIPTION, EntityDocumentImpl.class));
 	}
 
 	@Test

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbGetEntitiesAction.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbGetEntitiesAction.java
@@ -21,7 +21,6 @@ package org.wikidata.wdtk.wikibaseapi;
  */
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
@@ -30,8 +29,8 @@ import java.util.Map.Entry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
+import org.wikidata.wdtk.datamodel.implementation.EntityDocumentImpl;
 import org.wikidata.wdtk.datamodel.implementation.ItemDocumentImpl;
-import org.wikidata.wdtk.datamodel.implementation.TermedStatementDocumentImpl;
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
 import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
 
@@ -196,9 +195,7 @@ public class WbGetEntitiesAction {
 				JsonNode entityNode = entry.getValue();
 				if (!entityNode.has("missing")) {
 					try {
-						TermedStatementDocumentImpl ed = mapper.treeToValue(
-								entityNode,
-								TermedStatementDocumentImpl.class);
+						EntityDocument ed = mapper.treeToValue(entityNode, EntityDocumentImpl.class);
 
 						if (titles == null) {
 							// We use the JSON key rather than the id of the value


### PR DESCRIPTION
`EntityDocumentImpl` is used as top class of the implementations of `EntityDocument` and serves as a dispatcher for the deserialization of entity documents.
`StatementDocumentImpl` is introduced as an implementation detail in order to be able to share code between `StatementTermedDocumentImpl` and the future `LexemeImpl`.


This PR also replaces usages of `StatementTermedDocumentImpl` by `EntityDocumentImpl` everywhere it is useful to deserialize an entity.