### PR TITLE
Makes *Impl constructors care about TermImpl vs MonolingualTextValueImpl

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermImpl.java
@@ -77,6 +77,7 @@ public class TermImpl implements MonolingualTextValue {
 	 * @param mltv
 	 *            the object to copy the data from
 	 */
+	@Deprecated
 	public TermImpl(MonolingualTextValue mltv) {
 		this(mltv.getLanguageCode(), mltv.getText());
 	}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermedStatementDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermedStatementDocumentImpl.java
@@ -336,9 +336,7 @@ public abstract class TermedStatementDocumentImpl implements
 			if(map.containsKey(language)) {
 				throw new IllegalArgumentException("Multiple terms provided for the same language.");
 			}
-			// We need to make sure the terms are of the right type, otherwise they will not
-			// be serialized correctly.
-			map.put(language, new TermImpl(term));
+			map.put(language, toTerm(term));
 		}
 		return map;
 	}
@@ -349,17 +347,17 @@ public abstract class TermedStatementDocumentImpl implements
 			String language = term.getLanguageCode();
 			// We need to make sure the terms are of the right type, otherwise they will not
 			// be serialized correctly.
-			TermImpl castTerm = new TermImpl(term);
-			List<MonolingualTextValue> aliases = map.get(language);
-			if(aliases == null) {
-				aliases = new ArrayList<>();
-				aliases.add(castTerm);
-				map.put(language, aliases);
-			} else {
-				aliases.add(castTerm);
-			}
+			List<MonolingualTextValue> aliases = map.computeIfAbsent(language, (l) -> new ArrayList<>());
+			aliases.add(toTerm(term));
 		}
 		return map;
+	}
+
+	/**
+	 * We need to make sure the terms are of the right type, otherwise they will not be serialized correctly.
+	 */
+	private static MonolingualTextValue toTerm(MonolingualTextValue term) {
+		return term instanceof TermImpl ? term : new TermImpl(term.getLanguageCode(), term.getText());
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ValueSnakImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ValueSnakImpl.java
@@ -78,7 +78,9 @@ public class ValueSnakImpl extends SnakImpl implements ValueSnak {
 	public ValueSnakImpl(PropertyIdValue property, Value value) {
 		super(property);
 		Validate.notNull(value, "A datavalue must be provided to create a value snak.");
-		this.datavalue = value;
+		datavalue = (value instanceof TermImpl)
+				? new MonolingualTextValueImpl(((TermImpl) value).getText(), ((TermImpl) value).getLanguageCode())
+				: value;
 		this.datatype = getJsonPropertyTypeForValueType(datavalue);
 	}
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImplTest.java
@@ -45,9 +45,9 @@ public class ItemDocumentImplTest {
 	);
 	private final MonolingualTextValue label = new TermImpl("en", "label");
 	private final List<MonolingualTextValue> labelList = Collections.singletonList(label);
-	private final MonolingualTextValue desc = new TermImpl("fr", "des");
+	private final MonolingualTextValue desc = new MonolingualTextValueImpl("des", "fr");
 	private final List<MonolingualTextValue> descList = Collections.singletonList(desc);
-	private final MonolingualTextValue alias = new TermImpl("de", "alias");
+	private final MonolingualTextValue alias = new MonolingualTextValueImpl("alias", "de");
 	private final List<MonolingualTextValue> aliasList = Collections.singletonList(alias);
 	private final List<SiteLink> sitelinks = Collections.singletonList(
 			new SiteLinkImpl("Douglas Adams", "enwiki", Collections.emptyList())

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SnakImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SnakImplTest.java
@@ -43,6 +43,8 @@ public class SnakImplTest {
 	private final ValueSnak vs2 = new ValueSnakImpl(p1, p1);
 	private final ValueSnak vs3 = new ValueSnakImpl(p2, p1);
 	private final ValueSnak vs4 = new ValueSnakImpl(p1, p2);
+	private final ValueSnak vsmt1 = new ValueSnakImpl(p1, new TermImpl("en", "foo"));
+	private final ValueSnak vsmt2 = new ValueSnakImpl(p1, new MonolingualTextValueImpl("foo", "en"));
 	private final SomeValueSnak svs1 = new SomeValueSnakImpl(p1);
 	private final SomeValueSnak svs2 = new SomeValueSnakImpl(p1);
 	private final SomeValueSnak svs3 = new SomeValueSnakImpl(p2);
@@ -52,10 +54,12 @@ public class SnakImplTest {
 	private final String JSON_NOVALUE_SNAK = "{\"snaktype\":\"novalue\",\"property\":\"P42\"}";
 	private final String JSON_SOMEVALUE_SNAK = "{\"snaktype\":\"somevalue\",\"property\":\"P42\"}";
 	private final String JSON_VALUE_SNAK = "{\"snaktype\":\"value\",\"property\":\"P42\",\"datatype\":\"wikibase-property\",\"datavalue\":{\"value\":{\"id\":\"P42\",\"numeric-id\":42,\"entity-type\":\"property\"},\"type\":\"wikibase-entityid\"}}";
+	private final String JSON_MONOLINGUAL_TEXT_VALUE_SNAK = "{\"snaktype\":\"value\",\"property\":\"P42\",\"datatype\":\"monolingualtext\",\"datavalue\":{\"value\":{\"language\":\"en\",\"text\":\"foo\"},\"type\":\"monolingualtext\"}}";
 
 	@Test
 	public void snakHashBasedOnContent() {
 		assertEquals(vs1.hashCode(), vs2.hashCode());
+		assertEquals(vsmt1.hashCode(), vsmt2.hashCode());
 		assertEquals(svs1.hashCode(), svs2.hashCode());
 		assertEquals(nvs1.hashCode(), nvs2.hashCode());
 	}
@@ -88,6 +92,7 @@ public class SnakImplTest {
 		assertEquals(svs1, svs2);
 		assertNotEquals(svs1, svs3);
 		assertNotEquals(svs1, null);
+		assertEquals(vsmt1, vsmt2);
 	}
 
 	@Test
@@ -138,5 +143,17 @@ public class SnakImplTest {
 	@Test
 	public void testValueSnakToJson() throws JsonProcessingException {
 		JsonComparator.compareJsonStrings(JSON_VALUE_SNAK, mapper.writeValueAsString(vs1));
+	}
+
+	@Test
+	public void testMonolingualTextValueSnakToJava() throws IOException {
+		assertEquals(vsmt1, mapper.readValue(JSON_MONOLINGUAL_TEXT_VALUE_SNAK, SnakImpl.class));
+		assertEquals(vsmt2, mapper.readValue(JSON_MONOLINGUAL_TEXT_VALUE_SNAK, SnakImpl.class));
+	}
+
+	@Test
+	public void testMonolingualTextValueSnakToJson() throws JsonProcessingException {
+		JsonComparator.compareJsonStrings(JSON_MONOLINGUAL_TEXT_VALUE_SNAK, mapper.writeValueAsString(vsmt1));
+		JsonComparator.compareJsonStrings(JSON_MONOLINGUAL_TEXT_VALUE_SNAK, mapper.writeValueAsString(vsmt2));
 	}
 }


### PR DESCRIPTION
There are two different implementations of `MonolingualTextValue`, one for snaks and one for labels/description/aliases. This PR makes sure that the constructors cares that their parameters are using the right implementation.