### PR TITLE
Adds specialized return type for (Item|Property)Document.getEntityId

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImpl.java
@@ -124,7 +124,7 @@ public class ItemDocumentImpl extends TermedStatementDocumentImpl
 
 	@JsonIgnore
 	@Override
-	public EntityIdValue getEntityId() {
+	public ItemIdValue getEntityId() {
 		return getItemId();
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImpl.java
@@ -125,7 +125,7 @@ public class PropertyDocumentImpl extends TermedStatementDocumentImpl
 
 	@JsonIgnore
 	@Override
-	public EntityIdValue getEntityId() {
+	public PropertyIdValue getEntityId() {
 		return getPropertyId();
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/ItemDocument.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/ItemDocument.java
@@ -32,6 +32,14 @@ import java.util.Map;
 public interface ItemDocument extends TermedDocument, StatementDocument {
 
 	/**
+	 * Return the ID of the item that the data refers to.
+	 *
+	 * @return item id
+	 */
+	@Override
+	ItemIdValue getEntityId();
+
+	/**
 	 * Return the ID of the item that the data refers to. The result is the same
 	 * as that of {@link EntityDocument#getEntityId()}, but declared with a more
 	 * specific result type.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/PropertyDocument.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/PropertyDocument.java
@@ -32,6 +32,14 @@ package org.wikidata.wdtk.datamodel.interfaces;
 public interface PropertyDocument extends TermedDocument, StatementDocument {
 
 	/**
+	 * Return the ID of the item that the data refers to.
+	 *
+	 * @return item id
+	 */
+	@Override
+	PropertyIdValue getEntityId();
+
+	/**
 	 * Return the ID of the property that the data refers to. The result is the
 	 * same as that of {@link EntityDocument#getEntityId()}, but declared with a
 	 * more specific result type.


### PR DESCRIPTION
Makes the interface more convenient without breaking backward compatibility.
It enforces in the interface an implicit contract.