### PR TITLE
Deprecates ItemDocument.getItemId and PropertyDocument.getPropertyId

### DIFF
--- a/wdtk-client/src/main/java/org/wikidata/wdtk/client/SchemaUsageAnalyzer.java
+++ b/wdtk-client/src/main/java/org/wikidata/wdtk/client/SchemaUsageAnalyzer.java
@@ -421,7 +421,7 @@ public class SchemaUsageAnalyzer implements DumpProcessingAction {
 	@Override
 	public void processItemDocument(ItemDocument itemDocument) {
 		// Record relevant labels:
-		Integer itemId = getNumId(itemDocument.getItemId().getId(), false);
+		Integer itemId = getNumId(itemDocument.getEntityId().getId(), false);
 		if (this.classRecords.containsKey(itemId)) {
 			this.classRecords.get(itemId).label = itemDocument.findLabel("en");
 		}
@@ -455,7 +455,7 @@ public class SchemaUsageAnalyzer implements DumpProcessingAction {
 	@Override
 	public void processPropertyDocument(PropertyDocument propertyDocument) {
 		// Record relevant labels:
-		PropertyRecord pr = getPropertyRecord(propertyDocument.getPropertyId());
+		PropertyRecord pr = getPropertyRecord(propertyDocument.getEntityId());
 		pr.label = propertyDocument.findLabel("en");
 
 		// Find best URL pattern:

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverter.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverter.java
@@ -478,7 +478,7 @@ public class DatamodelConverter implements SnakVisitor<Snak>,
 	public PropertyDocument copy(PropertyDocument object) {
 		if (this.deepCopy) {
 			return this.dataObjectFactory.getPropertyDocument(copy(object
-					.getPropertyId()), deepCopyMonoLingualTextValues(object
+					.getEntityId()), deepCopyMonoLingualTextValues(object
 					.getLabels().values()),
 					deepCopyMonoLingualTextValues(object.getDescriptions()
 							.values()), flattenDeepCopyAliasMap(object
@@ -487,7 +487,7 @@ public class DatamodelConverter implements SnakVisitor<Snak>,
 					object.getRevisionId());
 		} else {
 			return this.dataObjectFactory.getPropertyDocument(object
-					.getPropertyId(), copyMonoLingualTextValues(object
+					.getEntityId(), copyMonoLingualTextValues(object
 					.getLabels().values()), copyMonoLingualTextValues(object
 					.getDescriptions().values()), flattenAliasMap(object
 					.getAliases()), copyStatementGroups(object
@@ -506,7 +506,7 @@ public class DatamodelConverter implements SnakVisitor<Snak>,
 	public ItemDocument copy(ItemDocument object) {
 		if (this.deepCopy) {
 			return this.dataObjectFactory.getItemDocument(copy(object
-					.getItemId()), deepCopyMonoLingualTextValues(object
+					.getEntityId()), deepCopyMonoLingualTextValues(object
 					.getLabels().values()),
 					deepCopyMonoLingualTextValues(object.getDescriptions()
 							.values()), flattenDeepCopyAliasMap(object
@@ -515,7 +515,7 @@ public class DatamodelConverter implements SnakVisitor<Snak>,
 							.getSiteLinks()), object.getRevisionId());
 		} else {
 			return this.dataObjectFactory
-					.getItemDocument(object.getItemId(),
+					.getItemDocument(object.getEntityId(),
 							copyMonoLingualTextValues(object.getLabels()
 									.values()),
 							copyMonoLingualTextValues(object.getDescriptions()

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ToString.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ToString.java
@@ -349,7 +349,7 @@ public class ToString {
 	 * @return a string representation of the object
 	 */
 	public static String toString(PropertyDocument o) {
-		return "==PropertyDocument " + o.getPropertyId().getIri() + " (r"
+		return "==PropertyDocument " + o.getEntityId().getIri() + " (r"
 				+ o.getRevisionId() + ") ==\n" + "* Datatype: "
 				+ o.getDatatype() + toStringForTermedDocument(o)
 				+ toStringForStatementDocument(o);
@@ -365,7 +365,7 @@ public class ToString {
 	 */
 	public static String toString(ItemDocument o) {
 		StringBuilder sb = new StringBuilder();
-		sb.append("==ItemDocument ").append(o.getItemId().getIri());
+		sb.append("==ItemDocument ").append(o.getEntityId().getIri());
 		sb.append(" (r").append(o.getRevisionId()).append(") ");
 		sb.append("==").append(toStringForTermedDocument(o));
 		sb.append(toStringForStatementDocument(o));

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImpl.java
@@ -119,13 +119,13 @@ public class ItemDocumentImpl extends TermedStatementDocumentImpl
 	@JsonIgnore
 	@Override
 	public ItemIdValue getItemId() {
-		return new ItemIdValueImpl(this.entityId, this.siteIri);
+		return getEntityId();
 	}
 
 	@JsonIgnore
 	@Override
 	public ItemIdValue getEntityId() {
-		return getItemId();
+		return new ItemIdValueImpl(this.entityId, this.siteIri);
 	}
 
 	@JsonProperty("sitelinks")

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImpl.java
@@ -120,13 +120,13 @@ public class PropertyDocumentImpl extends TermedStatementDocumentImpl
 	@JsonIgnore
 	@Override
 	public PropertyIdValue getPropertyId() {
-		return new PropertyIdValueImpl(this.entityId, this.siteIri);
+		return getEntityId();
 	}
 
 	@JsonIgnore
 	@Override
 	public PropertyIdValue getEntityId() {
-		return getPropertyId();
+		return new PropertyIdValueImpl(this.entityId, this.siteIri);
 	}
 
 	@JsonIgnore

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/ItemDocument.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/ItemDocument.java
@@ -40,12 +40,15 @@ public interface ItemDocument extends TermedDocument, StatementDocument {
 	ItemIdValue getEntityId();
 
 	/**
+	 * @deprecated Use {@link #getEntityId()}
+	 *
 	 * Return the ID of the item that the data refers to. The result is the same
 	 * as that of {@link EntityDocument#getEntityId()}, but declared with a more
 	 * specific result type.
 	 *
 	 * @return item id
 	 */
+	@Deprecated
 	ItemIdValue getItemId();
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/PropertyDocument.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/PropertyDocument.java
@@ -40,12 +40,15 @@ public interface PropertyDocument extends TermedDocument, StatementDocument {
 	PropertyIdValue getEntityId();
 
 	/**
+	 * @deprecated Use {@link #getEntityId()}
+	 *
 	 * Return the ID of the property that the data refers to. The result is the
 	 * same as that of {@link EntityDocument#getEntityId()}, but declared with a
 	 * more specific result type.
 	 *
 	 * @return property id
 	 */
+	@Deprecated
 	PropertyIdValue getPropertyId();
 
 	/**

--- a/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/ClassPropertyUsageAnalyzer.java
+++ b/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/ClassPropertyUsageAnalyzer.java
@@ -286,9 +286,9 @@ public class ClassPropertyUsageAnalyzer implements EntityDocumentProcessor {
 		}
 
 		ClassRecord classRecord = null;
-		if (TOP_LEVEL_CLASSES.contains(itemDocument.getItemId().getId())
-				|| this.classRecords.containsKey(itemDocument.getItemId())) {
-			classRecord = getClassRecord(itemDocument.getItemId());
+		if (TOP_LEVEL_CLASSES.contains(itemDocument.getEntityId().getId())
+				|| this.classRecords.containsKey(itemDocument.getEntityId())) {
+			classRecord = getClassRecord(itemDocument.getEntityId());
 		}
 
 		for (StatementGroup sg : itemDocument.getStatementGroups()) {
@@ -299,7 +299,7 @@ public class ClassPropertyUsageAnalyzer implements EntityDocumentProcessor {
 			boolean isInstanceOf = "P31".equals(sg.getProperty().getId());
 			boolean isSubclassOf = "P279".equals(sg.getProperty().getId());
 			if (isSubclassOf && classRecord == null) {
-				classRecord = getClassRecord(itemDocument.getItemId());
+				classRecord = getClassRecord(itemDocument.getEntityId());
 			}
 
 			for (Statement s : sg) {
@@ -360,8 +360,7 @@ public class ClassPropertyUsageAnalyzer implements EntityDocumentProcessor {
 	public void processPropertyDocument(PropertyDocument propertyDocument) {
 		this.countProperties++;
 
-		PropertyRecord propertyRecord = getPropertyRecord(propertyDocument
-				.getPropertyId());
+		PropertyRecord propertyRecord = getPropertyRecord(propertyDocument.getEntityId());
 		propertyRecord.propertyDocument = propertyDocument;
 	}
 

--- a/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/DataExtractionProcessor.java
+++ b/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/DataExtractionProcessor.java
@@ -95,7 +95,7 @@ public class DataExtractionProcessor implements EntityDocumentProcessor {
 		// If a value was found, write the data:
 		if (stringValue != null) {
 			this.itemsWithPropertyCount++;
-			out.print(itemDocument.getItemId().getId());
+			out.print(itemDocument.getEntityId().getId());
 			out.print(",");
 			out.print(csvEscape(itemDocument.findLabel("en")));
 			out.print(",");

--- a/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/EditOnlineDataExample.java
+++ b/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/EditOnlineDataExample.java
@@ -131,7 +131,7 @@ public class EditOnlineDataExample {
 		ItemDocument newItemDocument = wbde.createItemDocument(itemDocument,
 				"Wikidata Toolkit example test item creation");
 
-		ItemIdValue newItemId = newItemDocument.getItemId();
+		ItemIdValue newItemId = newItemDocument.getEntityId();
 		System.out.println("*** Successfully created a new item "
 				+ newItemId.getId()
 				+ " (see https://test.wikidata.org/w/index.php?title="
@@ -250,7 +250,7 @@ public class EditOnlineDataExample {
 				PropertyDocument pd = (PropertyDocument) ed;
 				if (DatatypeIdValue.DT_STRING.equals(pd.getDatatype().getIri())
 						&& pd.getLabels().containsKey("en")) {
-					stringProperties.add(pd.getPropertyId());
+					stringProperties.add(pd.getEntityId());
 					System.out.println("* Found string property "
 							+ pd.getEntityId().getId() + " ("
 							+ pd.getLabels().get("en") + ")");

--- a/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/GreatestNumberProcessor.java
+++ b/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/GreatestNumberProcessor.java
@@ -86,7 +86,7 @@ public class GreatestNumberProcessor implements EntityDocumentProcessor {
 			if (this.largestNumberValue == null
 					|| numericValue.compareTo(this.largestNumberValue) > 0) {
 				this.largestNumberValue = numericValue;
-				this.largestNumberItem = itemDocument.getItemId();
+				this.largestNumberItem = itemDocument.getEntityId();
 				MonolingualTextValue label = itemDocument.getLabels().get("en");
 				if (label != null) {
 					this.largestNumberItemLabel = label.getText();

--- a/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/bots/FixIntegerQuantityPrecisionsBot.java
+++ b/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/bots/FixIntegerQuantityPrecisionsBot.java
@@ -254,7 +254,7 @@ public class FixIntegerQuantityPrecisionsBot implements EntityDocumentProcessor 
 		for (String propertyId : integerProperties) {
 			if (hasPlusMinusOneValues(itemDocument
 					.findStatementGroup(propertyId))) {
-				fixIntegerPrecisions(itemDocument.getItemId(), propertyId);
+				fixIntegerPrecisions(itemDocument.getEntityId(), propertyId);
 			} // else: ignore items that have no value or only correct values
 				// for the property we consider
 		}
@@ -334,7 +334,7 @@ public class FixIntegerQuantityPrecisionsBot implements EntityDocumentProcessor 
 				return;
 			}
 
-			logEntityModification(currentItemDocument.getItemId(),
+			logEntityModification(currentItemDocument.getEntityId(),
 					updateStatements, propertyId);
 
 			dataEditor.updateStatements(currentItemDocument, updateStatements,

--- a/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/bots/SetLabelsForNumbersBot.java
+++ b/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/bots/SetLabelsForNumbersBot.java
@@ -195,10 +195,10 @@ public class SetLabelsForNumbersBot implements EntityDocumentProcessor {
 	public void processItemDocument(ItemDocument itemDocument) {
 		if (itemDocument.hasStatement("P1181")) {
 			if (lacksSomeLanguage(itemDocument)) {
-				addLabelForNumbers(itemDocument.getItemId());
+				addLabelForNumbers(itemDocument.getEntityId());
 			} else {
 				System.out.println("*** Labels already complete for "
-						+ itemDocument.getItemId().getId());
+						+ itemDocument.getEntityId().getId());
 			}
 		} // else: ignore items that have no numeric value
 	}
@@ -286,7 +286,7 @@ public class SetLabelsForNumbersBot implements EntityDocumentProcessor {
 				return;
 			}
 
-			logEntityModification(currentItemDocument.getItemId(),
+			logEntityModification(currentItemDocument.getEntityId(),
 					numberString, languages);
 
 			dataEditor.editItemDocument(itemDocumentBuilder.build(), false,

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/RdfConverter.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/RdfConverter.java
@@ -184,7 +184,7 @@ public class RdfConverter {
 	public void writePropertyDocument(PropertyDocument document)
 			throws RDFHandlerException {
 
-		propertyRegister.setPropertyType(document.getPropertyId(), document
+		propertyRegister.setPropertyType(document.getEntityId(), document
 				.getDatatype().getIri());
 
 		if (!hasTask(RdfSerializer.TASK_PROPERTIES)) {
@@ -235,50 +235,50 @@ public class RdfConverter {
 				.getIri());
 		this.rdfWriter.writeTripleUriObject(subject, this.rdfWriter
 				.getUri(Vocabulary.WB_DIRECT_CLAIM_PROP), Vocabulary
-				.getPropertyUri(document.getPropertyId(),
+				.getPropertyUri(document.getEntityId(),
 						PropertyContext.DIRECT));
 
 		this.rdfWriter.writeTripleUriObject(subject, this.rdfWriter
 				.getUri(Vocabulary.WB_CLAIM_PROP), Vocabulary.getPropertyUri(
-				document.getPropertyId(), PropertyContext.STATEMENT));
+				document.getEntityId(), PropertyContext.STATEMENT));
 
 		this.rdfWriter.writeTripleUriObject(subject, this.rdfWriter
 				.getUri(Vocabulary.WB_STATEMENT_PROP), Vocabulary
-				.getPropertyUri(document.getPropertyId(),
+				.getPropertyUri(document.getEntityId(),
 						PropertyContext.VALUE_SIMPLE));
 
 		this.rdfWriter.writeTripleUriObject(subject, this.rdfWriter
 				.getUri(Vocabulary.WB_STATEMENT_VALUE_PROP),
-				Vocabulary.getPropertyUri(document.getPropertyId(),
+				Vocabulary.getPropertyUri(document.getEntityId(),
 						PropertyContext.VALUE));
 
 		this.rdfWriter.writeTripleUriObject(subject, this.rdfWriter
 				.getUri(Vocabulary.WB_QUALIFIER_PROP), Vocabulary
-				.getPropertyUri(document.getPropertyId(),
+				.getPropertyUri(document.getEntityId(),
 						PropertyContext.QUALIFIER_SIMPLE));
 
 		this.rdfWriter.writeTripleUriObject(subject, this.rdfWriter
 				.getUri(Vocabulary.WB_QUALIFIER_VALUE_PROP), Vocabulary
-				.getPropertyUri(document.getPropertyId(),
+				.getPropertyUri(document.getEntityId(),
 						PropertyContext.QUALIFIER));
 
 		this.rdfWriter.writeTripleUriObject(subject, this.rdfWriter
 				.getUri(Vocabulary.WB_REFERENCE_PROP), Vocabulary
-				.getPropertyUri(document.getPropertyId(),
+				.getPropertyUri(document.getEntityId(),
 						PropertyContext.REFERENCE_SIMPLE));
 
 		this.rdfWriter.writeTripleUriObject(subject, this.rdfWriter
 				.getUri(Vocabulary.WB_REFERENCE_VALUE_PROP), Vocabulary
-				.getPropertyUri(document.getPropertyId(),
+				.getPropertyUri(document.getEntityId(),
 						PropertyContext.REFERENCE));
 
 		this.rdfWriter.writeTripleUriObject(subject, this.rdfWriter
 				.getUri(Vocabulary.WB_NO_VALUE_PROP), Vocabulary
-				.getPropertyUri(document.getPropertyId(),
+				.getPropertyUri(document.getEntityId(),
 						PropertyContext.NO_VALUE));
 		this.rdfWriter.writeTripleUriObject(subject, this.rdfWriter
 				.getUri(Vocabulary.WB_NO_QUALIFIER_VALUE_PROP), Vocabulary
-				.getPropertyUri(document.getPropertyId(),
+				.getPropertyUri(document.getEntityId(),
 						PropertyContext.NO_QUALIFIER_VALUE));
 		// TODO something more with NO_VALUE
 	}

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
@@ -289,7 +289,7 @@ public class WikibaseDataEditor {
 			MediaWikiApiErrorException {
 		String data = JsonSerializer.getJsonString(itemDocument);
 		return (ItemDocument) this.wbEditEntityAction.wbEditEntity(itemDocument
-				.getItemId().getId(), null, null, null, data, clear,
+				.getEntityId().getId(), null, null, null, data, clear,
 				this.editAsBot, itemDocument.getRevisionId(), summary);
 	}
 
@@ -334,7 +334,7 @@ public class WikibaseDataEditor {
 			throws IOException, MediaWikiApiErrorException {
 		String data = JsonSerializer.getJsonString(propertyDocument);
 		return (PropertyDocument) this.wbEditEntityAction.wbEditEntity(
-				propertyDocument.getPropertyId().getId(), null, null, null,
+				propertyDocument.getEntityId().getId(), null, null, null,
 				data, clear, this.editAsBot, propertyDocument.getRevisionId(),
 				summary);
 	}


### PR DESCRIPTION
Removes also all their usage but tests in WikidataToolkit.

We should probably keep them for ever until v1.0 because they are heavily used.