### PR TITLE
[Breaking] Uses ItemIdValue instead of String for badges

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Datamodel.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Datamodel.java
@@ -532,7 +532,7 @@ public class Datamodel {
 	 * @return a {@link SiteLink} corresponding to the input
 	 */
 	public static SiteLink makeSiteLink(String title, String siteKey,
-			List<String> badges) {
+			List<ItemIdValue> badges) {
 		return factory.getSiteLink(title, siteKey, badges);
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ItemDocumentBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ItemDocumentBuilder.java
@@ -119,7 +119,7 @@ public class ItemDocumentBuilder extends
 	 *            one or more badges
 	 */
 	public ItemDocumentBuilder withSiteLink(String title, String siteKey,
-			String... badges) {
+			ItemIdValue... badges) {
 		withSiteLink(factory.getSiteLink(title, siteKey, Arrays.asList(badges)));
 		return this;
 	}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImpl.java
@@ -191,7 +191,7 @@ public class DataObjectFactoryImpl implements DataObjectFactory {
 
 	@Override
 	public SiteLink getSiteLink(String title, String siteKey,
-			List<String> badges) {
+			List<ItemIdValue> badges) {
 		return new SiteLinkImpl(title, siteKey, badges);
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DataObjectFactory.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DataObjectFactory.java
@@ -358,7 +358,7 @@ public interface DataObjectFactory {
 	 *            the list of badges of the linked article
 	 * @return a {@link SiteLink} corresponding to the input
 	 */
-	SiteLink getSiteLink(String title, String siteKey, List<String> badges);
+	SiteLink getSiteLink(String title, String siteKey, List<ItemIdValue> badges);
 
 	/**
 	 * Creates a {@link PropertyDocument}. It might be more convenient to use

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/SiteLink.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/SiteLink.java
@@ -50,10 +50,7 @@ public interface SiteLink {
 
 	/**
 	 * Get the list of badges of the linked article.
-	 * 
-	 * TODO This feature is not used yet in Wikibase. This interface might
-	 * change when more details are known.
 	 */
-	List<String> getBadges();
+	List<ItemIdValue> getBadges();
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/ItemDocumentBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/ItemDocumentBuilderTest.java
@@ -75,7 +75,7 @@ public class ItemDocumentBuilderTest {
 		MonolingualTextValue mtv = Datamodel.makeMonolingualTextValue("Test",
 				"de");
 		SiteLink sl = Datamodel.makeSiteLink("Test", "frwiki",
-				Collections.singletonList("Badge"));
+				Collections.singletonList(Datamodel.makeWikidataItemIdValue("Q42")));
 
 		ItemDocument id1 = Datamodel.makeItemDocument(i,
 				Collections.singletonList(mtv), Collections.singletonList(mtv),
@@ -85,7 +85,7 @@ public class ItemDocumentBuilderTest {
 		ItemDocument id2 = ItemDocumentBuilder.forItemId(i)
 				.withLabel("Test", "de").withDescription("Test", "de")
 				.withAlias("Test", "de")
-				.withSiteLink("Test", "frwiki", "Badge").withStatement(s1)
+				.withSiteLink("Test", "frwiki", Datamodel.makeWikidataItemIdValue("Q42")).withStatement(s1)
 				.withStatement(s2).withRevisionId(1234).build();
 
 		assertEquals(id1, id2);
@@ -99,7 +99,7 @@ public class ItemDocumentBuilderTest {
 				"fr");
 		MonolingualTextValue alias2 = Datamodel.makeMonolingualTextValue("atoca", "fr");
 		SiteLink sl = Datamodel.makeSiteLink("Canneberge", "frwiki",
-				Collections.singletonList("Badge"));
+				Collections.singletonList(Datamodel.makeWikidataItemIdValue("Q42")));
 		
 		ItemDocument initial = Datamodel.makeItemDocument(i,
 				Collections.singletonList(label),

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SiteLinkImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SiteLinkImplTest.java
@@ -23,36 +23,42 @@ package org.wikidata.wdtk.datamodel.implementation;
 import static org.junit.Assert.*;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
+import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
+import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
 
 public class SiteLinkImplTest {
 
-	private final ObjectMapper mapper = new ObjectMapper();
+	private final ObjectMapper mapper = new DatamodelMapper("http://example.com/entity/");
 
-	private final SiteLink s1 = new SiteLinkImpl("Dresden", "enwiki", Collections.emptyList());
-	private final SiteLink s2 = new SiteLinkImpl("Dresden", "enwiki", Collections.emptyList());
-	private final String JSON_SITE_LINK = "{\"site\":\"enwiki\", \"title\":\"Dresden\", \"badges\":[]}";
+	private final List<ItemIdValue> badges = Arrays.asList(
+			new ItemIdValueImpl("Q43", "http://example.com/entity/"),
+			new ItemIdValueImpl("Q42", "http://example.com/entity/")
+	);
+	private final SiteLink s1 = new SiteLinkImpl("Dresden", "enwiki", badges);
+	private final SiteLink s2 = new SiteLinkImpl("Dresden", "enwiki", badges);
+	private final String JSON_SITE_LINK = "{\"site\":\"enwiki\", \"title\":\"Dresden\", \"badges\":[\"Q42\",\"Q43\"]}";
 
 	@Test
 	public void fieldsIsCorrect() {
 		assertEquals(s1.getPageTitle(), "Dresden");
 		assertEquals(s1.getSiteKey(), "enwiki");
-		assertEquals(s1.getBadges(), Collections.emptyList());
+		assertEquals(s1.getBadges(), badges);
 	}
 
 	@Test
 	public void equalityBasedOnContent() {
-		SiteLink sDiffTitle = new SiteLinkImpl("Berlin", "enwiki",
-				Collections.emptyList());
-		SiteLink sDiffSiteKey = new SiteLinkImpl("Dresden", "dewiki",
-				Collections.emptyList());
+		SiteLink sDiffTitle = new SiteLinkImpl("Berlin", "enwiki", badges);
+		SiteLink sDiffSiteKey = new SiteLinkImpl("Dresden", "dewiki", badges);
 		SiteLink sDiffBadges = new SiteLinkImpl("Dresden", "enwiki",
-				Collections.singletonList("some badge?"));
+				Collections.emptyList());
 
 		assertEquals(s1, s1);
 		assertEquals(s1, s2);
@@ -93,4 +99,4 @@ public class SiteLinkImplTest {
 	public void testToJava() throws IOException {
 		assertEquals(s1, mapper.readValue(JSON_SITE_LINK, SiteLinkImpl.class));
 	}
-};
+}

--- a/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/SitesTest.java
+++ b/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/SitesTest.java
@@ -74,7 +74,7 @@ public class SitesTest {
 
 		DataObjectFactory factory = new DataObjectFactoryImpl();
 		SiteLink siteLink = factory.getSiteLink("Douglas Adams", "dewiki",
-				Collections.<String> emptyList());
+				Collections.emptyList());
 
 		Sites sites = this.dpc.getSitesInformation();
 

--- a/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/TestObjectFactory.java
+++ b/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/TestObjectFactory.java
@@ -329,9 +329,9 @@ public class TestObjectFactory {
 	public Map<String, SiteLink> createSiteLinks() {
 		Map<String, SiteLink> result = new HashMap<String, SiteLink>();
 		result.put("enwiki", factory.getSiteLink("title_en", "enwiki",
-				new LinkedList<String>()));
+				Collections.emptyList()));
 		result.put("dewiki", factory.getSiteLink("title_de", "dewiki",
-				new LinkedList<String>()));
+				Collections.emptyList()));
 		return result;
 	}
 


### PR DESCRIPTION
Matches the other Wikibase DataModel implementations
Enforces an order on badges for correct comparison