### PR TITLE
Makes clearer the cases where Snak.getValue returns null 

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/Snak.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/Snak.java
@@ -45,7 +45,7 @@ public interface Snak {
 	 * Get the {@link Value} of this Snak, or null if the snak has no specified
 	 * value.
 	 *
-	 * @return Value
+	 * @return Value if it is a {@link ValueSnak} or null if it is not
 	 */
 	Value getValue();
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/ValueSnak.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/ValueSnak.java
@@ -31,4 +31,9 @@ package org.wikidata.wdtk.datamodel.interfaces;
  */
 public interface ValueSnak extends Snak {
 
+	/**
+	 * Get the {@link Value} of this Snak
+	 */
+	@Override
+	Value getValue();
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SnakImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SnakImplTest.java
@@ -57,17 +57,23 @@ public class SnakImplTest {
 	private final String JSON_MONOLINGUAL_TEXT_VALUE_SNAK = "{\"snaktype\":\"value\",\"property\":\"P42\",\"datatype\":\"monolingualtext\",\"datavalue\":{\"value\":{\"language\":\"en\",\"text\":\"foo\"},\"type\":\"monolingualtext\"}}";
 
 	@Test
+	public void fieldsAreCorrect() {
+		assertEquals(vs1.getPropertyId(), p1);
+		assertEquals(vs1.getValue(), p1);
+
+		assertEquals(svs1.getPropertyId(), p1);
+		assertEquals(svs1.getValue(), null);
+
+		assertEquals(nvs1.getPropertyId(), p1);
+		assertEquals(nvs1.getValue(), null);
+	}
+
+	@Test
 	public void snakHashBasedOnContent() {
 		assertEquals(vs1.hashCode(), vs2.hashCode());
 		assertEquals(vsmt1.hashCode(), vsmt2.hashCode());
 		assertEquals(svs1.hashCode(), svs2.hashCode());
 		assertEquals(nvs1.hashCode(), nvs2.hashCode());
-	}
-
-	@Test
-	public void snaksWithoutValues() {
-		assertEquals(svs1.getValue(), null);
-		assertEquals(nvs1.getValue(), null);
 	}
 
 	@Test


### PR DESCRIPTION
Avoids a getter that may return null