### PR TITLE
Change the default value of the "After" parameter of TimeValues

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Datamodel.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Datamodel.java
@@ -239,7 +239,7 @@ public class Datamodel {
 			byte hour, byte minute, byte second, int timezoneOffset,
 			String calendarModel) {
 		return factory.getTimeValue(year, month, day, hour, minute, second,
-				TimeValue.PREC_SECOND, 0, 1, timezoneOffset, calendarModel);
+				TimeValue.PREC_SECOND, 0, 0, timezoneOffset, calendarModel);
 	}
 
 	/**
@@ -261,7 +261,7 @@ public class Datamodel {
 	public static TimeValue makeTimeValue(long year, byte month, byte day,
 			String calendarModel) {
 		return factory.getTimeValue(year, month, day, (byte) 0, (byte) 0,
-				(byte) 0, TimeValue.PREC_DAY, 0, 1, 0, calendarModel);
+				(byte) 0, TimeValue.PREC_DAY, 0, 0, 0, calendarModel);
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/DatamodelFilter.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/DatamodelFilter.java
@@ -1,5 +1,25 @@
 package org.wikidata.wdtk.datamodel.helpers;
 
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 - 2018 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import org.wikidata.wdtk.datamodel.interfaces.*;
 
 import java.util.*;

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/TimeValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/TimeValue.java
@@ -250,9 +250,12 @@ public interface TimeValue extends Value {
 	 * 2007-07-12T10:45:00. This information about the uncertainty of time
 	 * points can be taken into account in query answering, but simplified
 	 * implementations can also ignore it and work with the given (exact) time
-	 * point instead. If not set specifically by the user, the before-tolerance
+	 * point instead. If not set specifically by the user, the after-tolerance
 	 * value should be 1, i.e., the interval of uncertainty is exactly the
-	 * length given by precision.
+	 * length given by precision. However, because most (if not all) other
+	 * known implementations of the data model got this detail wrong and use 0
+	 * instead, we are also using 0 as a default value. This issue is tracked
+	 * at https://phabricator.wikimedia.org/T194869.
 	 * <p>
 	 * The boundary is exclusive. For example, a date 2013-02-01T00:00:00 with
 	 * precision {@link TimeValue#PREC_MONTH} and after-tolerance value 1 and

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverterTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverterTest.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.helpers;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelFilterTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelFilterTest.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.helpers;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelTest.java
@@ -105,10 +105,10 @@ public class DatamodelTest {
 	@Test
 	public final void testGetTimeValue() {
 		TimeValue o1 = Datamodel.makeTimeValue(2007, (byte) 5, (byte) 12,
-				(byte) 10, (byte) 45, (byte) 0, TimeValue.PREC_DAY, 0, 1, 60,
+				(byte) 10, (byte) 45, (byte) 0, TimeValue.PREC_DAY, 0, 0, 60,
 				TimeValue.CM_GREGORIAN_PRO);
 		TimeValue o2 = factory.getTimeValue(2007, (byte) 5, (byte) 12,
-				(byte) 10, (byte) 45, (byte) 0, TimeValue.PREC_DAY, 0, 1, 60,
+				(byte) 10, (byte) 45, (byte) 0, TimeValue.PREC_DAY, 0, 0, 60,
 				TimeValue.CM_GREGORIAN_PRO);
 		assertEquals(o1, o2);
 	}
@@ -119,7 +119,7 @@ public class DatamodelTest {
 				.makeTimeValue(2007, (byte) 5, (byte) 12, (byte) 10, (byte) 45,
 						(byte) 0, 60, TimeValue.CM_GREGORIAN_PRO);
 		TimeValue o2 = factory.getTimeValue(2007, (byte) 5, (byte) 12,
-				(byte) 10, (byte) 45, (byte) 0, TimeValue.PREC_SECOND, 0, 1,
+				(byte) 10, (byte) 45, (byte) 0, TimeValue.PREC_SECOND, 0, 0,
 				60, TimeValue.CM_GREGORIAN_PRO);
 		assertEquals(o1, o2);
 	}
@@ -129,7 +129,7 @@ public class DatamodelTest {
 		TimeValue o1 = Datamodel.makeTimeValue(2007, (byte) 5, (byte) 12,
 				TimeValue.CM_GREGORIAN_PRO);
 		TimeValue o2 = factory.getTimeValue(2007, (byte) 5, (byte) 12,
-				(byte) 0, (byte) 0, (byte) 0, TimeValue.PREC_DAY, 0, 1, 0,
+				(byte) 0, (byte) 0, (byte) 0, TimeValue.PREC_DAY, 0, 0, 0,
 				TimeValue.CM_GREGORIAN_PRO);
 		assertEquals(o1, o2);
 	}


### PR DESCRIPTION
The default value is now 0, which is incorrect but in line with other
tools and the Wikibase UI.

https://phabricator.wikimedia.org/T194869