### PR TITLE
DatatypeIdValue no longer extends Value

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverter.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverter.java
@@ -565,11 +565,6 @@ public class DatamodelConverter implements SnakVisitor<Snak>,
 	}
 
 	@Override
-	public Value visit(DatatypeIdValue value) {
-		return copy(value);
-	}
-
-	@Override
 	public Value visit(EntityIdValue value) {
 		if (value instanceof ItemIdValue) {
 			return copy((ItemIdValue) value);

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/DatatypeIdImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/DatatypeIdImpl.java
@@ -241,11 +241,6 @@ public class DatatypeIdImpl implements DatatypeIdValue {
 	}
 
 	@Override
-	public <T> T accept(ValueVisitor<T> valueVisitor) {
-		return valueVisitor.visit(this);
-	}
-
-	@Override
 	public String toString() {
 		return ToString.toString(this);
 	}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DatatypeIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DatatypeIdValue.java
@@ -22,13 +22,13 @@ package org.wikidata.wdtk.datamodel.interfaces;
 
 /**
  * A value that represents one of the available Wikibase datatypes. The method
- * {@link IriIdentifiedValue#getIri() getIri()} will always return one of the
+ * {@link DatatypeIdValue#getIri() getIri()} will always return one of the
  * datatype IRIs defined in this interface.
  *
  * @author Markus Kroetzsch
  *
  */
-public interface DatatypeIdValue extends IriIdentifiedValue {
+public interface DatatypeIdValue {
 	/**
 	 * IRI of the item datatype in Wikibase.
 	 */
@@ -78,4 +78,10 @@ public interface DatatypeIdValue extends IriIdentifiedValue {
 	 */
 	String DT_GEO_SHAPE = "http://wikiba.se/ontology#GeoShape";
 
+	/**
+	 * Get the IRI of this entity.
+	 * 
+	 * @return String with the IRI
+	 */
+	String getIri();
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/ValueVisitor.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/ValueVisitor.java
@@ -36,16 +36,6 @@ package org.wikidata.wdtk.datamodel.interfaces;
 public interface ValueVisitor<T> {
 
 	/**
-	 * Visits a DatatypeIdValue and returns a result. This type of value does
-	 * not occur in snaks, so some implementation will not need this method.
-	 * 
-	 * @param value
-	 *            the value to visit
-	 * @return the result for this value
-	 */
-	T visit(DatatypeIdValue value);
-
-	/**
 	 * Visits a EntityIdValue and returns a result. In practice, only specific
 	 * subtypes of EntityIdValue are used, such as {@link ItemIdValue} and
 	 * {@link PropertyIdValue}. Since the set of possible subtypes can be

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementDocumentAccessTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementDocumentAccessTest.java
@@ -243,22 +243,4 @@ public class StatementDocumentAccessTest {
 		assertEquals(v, id.findStatementStringValue("P1"));
 	}
 
-	/**
-	 * A datatype cannot be the value of a statement by itself.
-	 * 
-	 * @todo DatatypeIdValue should not inherit from Value,
-	 * 		 and it should probably be renamed.
-	 */
-	@Test(expected = UnsupportedOperationException.class)
-	public void testFindStatementDatatypeIdValue() {
-		DatatypeIdValue v = Datamodel
-				.makeDatatypeIdValue(DatatypeIdValue.DT_STRING);
-
-		Statement s = StatementBuilder.forSubjectAndProperty(q1, p1)
-				.withValue(v).build();
-
-		ItemDocumentBuilder.forItemId(q1).withStatement(s)
-				.build();
-	}
-
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/interfaces/NullEntityIdsTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/interfaces/NullEntityIdsTest.java
@@ -29,11 +29,6 @@ public class NullEntityIdsTest {
 	class TestValueVisitor implements ValueVisitor<String> {
 
 		@Override
-		public String visit(DatatypeIdValue value) {
-			return null;
-		}
-
-		@Override
 		public String visit(EntityIdValue value) {
 			return value.getId();
 		}

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/values/AnyValueConverter.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/values/AnyValueConverter.java
@@ -91,13 +91,6 @@ public class AnyValueConverter implements
 	}
 
 	@Override
-	public Value visit(DatatypeIdValue value) {
-		throw new RuntimeException(
-				"DatatypeIdValue cannot be processed like a value of a user-defined property. "
-						+ "Use getDatatypeIdValueLiteral() to get a Literal for such values.");
-	}
-
-	@Override
 	public Value visit(EntityIdValue value) {
 		return this.entityIdValueConverter.getRdfValue(value,
 				this.currentPropertyIdValue, this.simple);


### PR DESCRIPTION
Intuitively I do not think this should cause much trouble for users - I would be surprised if anybody relies on being able to represent snaks with datatypes as values.