### PR TITLE
Throw IOException correctly instead of swallowing it when fetching entity documents

### DIFF
--- a/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/EditOnlineDataExample.java
+++ b/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/EditOnlineDataExample.java
@@ -226,9 +226,10 @@ public class EditOnlineDataExample {
 	 *
 	 * @param connection
 	 * @throws MediaWikiApiErrorException
+	 * @throws IOException 
 	 */
 	public static void findSomeStringProperties(ApiConnection connection)
-			throws MediaWikiApiErrorException {
+			throws MediaWikiApiErrorException, IOException {
 		WikibaseDataFetcher wbdf = new WikibaseDataFetcher(connection, siteIri);
 		wbdf.getFilter().excludeAllProperties();
 		wbdf.getFilter().setLanguageFilter(Collections.singleton("en"));

--- a/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/FetchOnlineDataExample.java
+++ b/wdtk-examples/src/main/java/org/wikidata/wdtk/examples/FetchOnlineDataExample.java
@@ -1,5 +1,7 @@
 package org.wikidata.wdtk.examples;
 
+import java.io.IOException;
+
 /*
  * #%L
  * Wikidata Toolkit Examples
@@ -35,7 +37,7 @@ import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
 
 public class FetchOnlineDataExample {
 
-	public static void main(String[] args) throws MediaWikiApiErrorException {
+	public static void main(String[] args) throws MediaWikiApiErrorException, IOException {
 		ExampleHelpers.configureLogging();
 		printDocumentation();
 

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/PropertyRegister.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/PropertyRegister.java
@@ -1,5 +1,7 @@
 package org.wikidata.wdtk.rdf;
 
+import java.io.IOException;
+
 /*
  * #%L
  * Wikidata Toolkit RDF
@@ -291,6 +293,7 @@ public class PropertyRegister {
 	 * fetched.
 	 *
 	 * @param property
+	 * @throws IOException 
 	 */
 	protected void fetchPropertyInformation(PropertyIdValue property) {
 		int propertyIdNumber = Integer.parseInt(property.getId().substring(1));
@@ -317,6 +320,10 @@ public class PropertyRegister {
 		try {
 			properties = dataFetcher.getEntityDocuments(propertyIds);
 		} catch (MediaWikiApiErrorException e) {
+			logger.error("Error when trying to fetch property data: "
+					+ e.toString());
+			properties = Collections.emptyMap();
+		} catch (IOException e) {
 			logger.error("Error when trying to fetch property data: "
 					+ e.toString());
 			properties = Collections.emptyMap();

--- a/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/PropertyRegisterTest.java
+++ b/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/PropertyRegisterTest.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -60,7 +61,7 @@ public class PropertyRegisterTest {
 	final DataObjectFactory dataObjectFactory = new DataObjectFactoryImpl();
 
 	@Before
-	public void setUp() throws MediaWikiApiErrorException {
+	public void setUp() throws MediaWikiApiErrorException, IOException {
 		Map<String, EntityDocument> mockResult = new HashMap<String, EntityDocument>();
 		List<StatementGroup> mockStatementGroups = new ArrayList<StatementGroup>();
 

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbGetEntitiesAction.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbGetEntitiesAction.java
@@ -92,10 +92,12 @@ public class WbGetEntitiesAction {
 	 *         the API URL
 	 * @throws MediaWikiApiErrorException
 	 *             if the API returns an error
+	 * @throws IOException
+	 * 			   if we encounter network issues or HTTP 500 errors from Wikibase
 	 */
 	public Map<String, EntityDocument> wbGetEntities(
 			WbGetEntitiesActionData properties)
-			throws MediaWikiApiErrorException {
+			throws MediaWikiApiErrorException, IOException {
 		return wbGetEntities(properties.ids, properties.sites,
 				properties.titles, properties.props, properties.languages,
 				properties.sitefilter);
@@ -144,12 +146,14 @@ public class WbGetEntitiesAction {
 	 *         the API URL
 	 * @throws MediaWikiApiErrorException
 	 *             if the API returns an error
+	 * @throws IOException
+	 *             if we encounter network errors, or HTTP 500 errors on Wikibase's side
 	 * @throws IllegalArgumentException
 	 *             if the given combination of parameters does not make sense
 	 */
 	public Map<String, EntityDocument> wbGetEntities(String ids, String sites,
 			String titles, String props, String languages, String sitefilter)
-			throws MediaWikiApiErrorException {
+			throws MediaWikiApiErrorException, IOException {
 
 		Map<String, String> parameters = new HashMap<String, String>();
 		parameters.put(ApiConnection.PARAM_ACTION, "wbgetentities");
@@ -219,6 +223,7 @@ public class WbGetEntitiesAction {
 			}
 		} catch (IOException e) {
 			logger.error("Could not retrive data: " + e.toString());
+			throw e;
 		}
 
 		return result;

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataFetcher.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataFetcher.java
@@ -1,5 +1,7 @@
 package org.wikidata.wdtk.wikibaseapi;
 
+import java.io.IOException;
+
 /*
  * #%L
  * Wikidata Toolkit Wikibase API
@@ -129,9 +131,10 @@ public class WikibaseDataFetcher {
 	 *            string IDs (e.g., "P31" or "Q42") of requested entity
 	 * @return retrieved entity document or null
 	 * @throws MediaWikiApiErrorException
+	 * @throws IOException 
 	 */
 	public EntityDocument getEntityDocument(String entityId)
-			throws MediaWikiApiErrorException {
+			throws MediaWikiApiErrorException, IOException {
 		return getEntityDocuments(entityId).get(entityId);
 	}
 
@@ -146,9 +149,10 @@ public class WikibaseDataFetcher {
 	 * @return map from IDs for which data could be found to the documents that
 	 *         were retrieved
 	 * @throws MediaWikiApiErrorException
+	 * @throws IOException 
 	 */
 	public Map<String, EntityDocument> getEntityDocuments(String... entityIds)
-			throws MediaWikiApiErrorException {
+			throws MediaWikiApiErrorException, IOException {
 		return getEntityDocuments(Arrays.asList(entityIds));
 	}
 
@@ -163,9 +167,10 @@ public class WikibaseDataFetcher {
 	 * @return map from IDs for which data could be found to the documents that
 	 *         were retrieved
 	 * @throws MediaWikiApiErrorException
+	 * @throws IOException 
 	 */
 	public Map<String, EntityDocument> getEntityDocuments(List<String> entityIds)
-			throws MediaWikiApiErrorException {
+			throws MediaWikiApiErrorException, IOException {
 		Map<String, EntityDocument> result = new HashMap<>();
 		List<String> newEntityIds = new ArrayList<>();
 		newEntityIds.addAll(entityIds);
@@ -201,9 +206,10 @@ public class WikibaseDataFetcher {
 	 * @return document for the entity with this title, or null if no such
 	 *         document exists
 	 * @throws MediaWikiApiErrorException
+	 * @throws IOException 
 	 */
 	public EntityDocument getEntityDocumentByTitle(String siteKey, String title)
-			throws MediaWikiApiErrorException {
+			throws MediaWikiApiErrorException, IOException {
 		return getEntityDocumentsByTitle(siteKey, title).get(title);
 	}
 
@@ -223,9 +229,10 @@ public class WikibaseDataFetcher {
 	 * @return map from titles for which data could be found to the documents
 	 *         that were retrieved
 	 * @throws MediaWikiApiErrorException
+	 * @throws IOException 
 	 */
 	public Map<String, EntityDocument> getEntityDocumentsByTitle(
-			String siteKey, String... titles) throws MediaWikiApiErrorException {
+			String siteKey, String... titles) throws MediaWikiApiErrorException, IOException {
 		return getEntityDocumentsByTitle(siteKey, Arrays.asList(titles));
 	}
 
@@ -245,10 +252,11 @@ public class WikibaseDataFetcher {
 	 * @return map from titles for which data could be found to the documents
 	 *         that were retrieved
 	 * @throws MediaWikiApiErrorException
+	 * @throws IOException 
 	 */
 	public Map<String, EntityDocument> getEntityDocumentsByTitle(
 			String siteKey, List<String> titles)
-			throws MediaWikiApiErrorException {
+			throws MediaWikiApiErrorException, IOException {
 		List<String> newTitles = new ArrayList<>();
 		newTitles.addAll(titles);
 		Map<String, EntityDocument> result = new HashMap<>();
@@ -284,10 +292,11 @@ public class WikibaseDataFetcher {
 	 * @return map of document identifiers or titles to documents retrieved via
 	 *         the API URL
 	 * @throws MediaWikiApiErrorException
+	 * @throws IOException 
 	 */
 	Map<String, EntityDocument> getEntityDocumentMap(int numOfEntities,
 			WbGetEntitiesActionData properties)
-			throws MediaWikiApiErrorException {
+			throws MediaWikiApiErrorException, IOException {
 		if (numOfEntities == 0) {
 			return Collections.emptyMap();
 		}

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WbGetEntitiesActionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WbGetEntitiesActionTest.java
@@ -23,6 +23,7 @@ package org.wikidata.wdtk.wikibaseapi;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -66,7 +67,7 @@ public class WbGetEntitiesActionTest {
 	}
 
 	@Test
-	public void testWbGetEntitiesWithProps() throws MediaWikiApiErrorException {
+	public void testWbGetEntitiesWithProps() throws MediaWikiApiErrorException, IOException {
 		WbGetEntitiesActionData properties = new WbGetEntitiesActionData();
 		properties.ids = "Q6|Q42|P31";
 		properties.props = "datatype|labels|aliases|descriptions|claims|sitelinks";
@@ -79,7 +80,7 @@ public class WbGetEntitiesActionTest {
 	}
 
 	@Test
-	public void testWbGetEntitiesNoProps() throws MediaWikiApiErrorException {
+	public void testWbGetEntitiesNoProps() throws MediaWikiApiErrorException, IOException {
 		WbGetEntitiesActionData properties = new WbGetEntitiesActionData();
 		properties.ids = "Q6|Q42|P31";
 		Map<String, EntityDocument> result1 = action.wbGetEntities(properties);
@@ -91,7 +92,7 @@ public class WbGetEntitiesActionTest {
 	}
 	
 	@Test
-	public void testWbGetEntitiesRedirected() throws MediaWikiApiErrorException {
+	public void testWbGetEntitiesRedirected() throws MediaWikiApiErrorException, IOException {
 		WbGetEntitiesActionData properties = new WbGetEntitiesActionData();
 		properties.ids = "Q32063953";
 		Map<String, EntityDocument> result = action.wbGetEntities(properties);
@@ -101,7 +102,7 @@ public class WbGetEntitiesActionTest {
 
 	@Test
 	public void testWbGetEntitiesPropsFilters()
-			throws MediaWikiApiErrorException {
+			throws MediaWikiApiErrorException, IOException {
 		WbGetEntitiesActionData properties = new WbGetEntitiesActionData();
 		properties.ids = "Q6|Q42|P31";
 		properties.props = "datatype|labels|aliases|descriptions|claims|sitelinks";
@@ -115,32 +116,30 @@ public class WbGetEntitiesActionTest {
 		assertEquals(result1, result2);
 	}
 
-	@Test
-	public void testWbGetEntitiesIoError() throws MediaWikiApiErrorException {
+	@Test(expected = IOException.class)
+	public void testWbGetEntitiesIoError() throws MediaWikiApiErrorException, IOException {
 		WbGetEntitiesActionData properties = new WbGetEntitiesActionData();
 		properties.ids = "Q6|Q42|notmocked";
-		Map<String, EntityDocument> result = action.wbGetEntities(properties);
-
-		assertEquals(Collections.<String, EntityDocument> emptyMap(), result);
+		action.wbGetEntities(properties);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void testIdsAndTitles() throws MediaWikiApiErrorException {
+	public void testIdsAndTitles() throws MediaWikiApiErrorException, IOException {
 		action.wbGetEntities("Q42", null, "Tim Berners Lee", null, null, null);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void testIdsAndSites() throws MediaWikiApiErrorException {
+	public void testIdsAndSites() throws MediaWikiApiErrorException, IOException {
 		action.wbGetEntities("Q42", "enwiki", null, null, null, null);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void testTitlesNoSites() throws MediaWikiApiErrorException {
+	public void testTitlesNoSites() throws MediaWikiApiErrorException, IOException {
 		action.wbGetEntities(null, null, "Tim Berners Lee", null, null, null);
 	}
 
 	@Test(expected = IllegalArgumentException.class)
-	public void testNoTitlesOrIds() throws MediaWikiApiErrorException {
+	public void testNoTitlesOrIds() throws MediaWikiApiErrorException, IOException {
 		action.wbGetEntities(null, "enwiki", null, null, null, null);
 	}
 


### PR DESCRIPTION
I think the best way is to throw the original exception - that is what we do in various other interfaces (such as the `WikibaseDataEditor`).

Closes #402.