### PR TITLE
Throw an exception when credentials have expired.

### DIFF
--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/ApiConnection.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/ApiConnection.java
@@ -184,7 +184,6 @@ public class ApiConnection {
 	 */
 	@JsonIgnore
 	String password = "";
-	
 	/**
 	 * Map of cookies that are currently set.
 	 */

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/ApiConnection.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/ApiConnection.java
@@ -161,6 +161,11 @@ public class ApiConnection {
 	final static String LOGIN_WRONG_TOKEN = "WrongToken";
 
 	/**
+	 * MediaWiki assert= parameter to ensure we are editting while logged in.
+	 */
+	private static final String ASSERT_PARAMETER = "assert";
+
+	/**
 	 * URL to access the Wikibase API.
 	 */
 	final String apiBaseUrl;
@@ -179,7 +184,7 @@ public class ApiConnection {
 	 */
 	@JsonIgnore
 	String password = "";
-
+	
 	/**
 	 * Map of cookies that are currently set.
 	 */
@@ -394,6 +399,9 @@ public class ApiConnection {
 	 */
 	public JsonNode sendJsonRequest(String requestMethod, Map<String,String> parameters) throws IOException, MediaWikiApiErrorException {
 		parameters.put(ApiConnection.PARAM_FORMAT, "json");
+		if (loggedIn) {
+			parameters.put(ApiConnection.ASSERT_PARAMETER, "user");
+		}
 		try (InputStream response = sendRequest(requestMethod, parameters)) {
 			JsonNode root = this.mapper.readTree(response);
 			this.checkErrors(root);
@@ -474,6 +482,24 @@ public class ApiConnection {
 		for (String warning : getWarnings(root)) {
 			logger.warn("API warning " + warning);
 		}
+	}
+	
+	/**
+	 * Checks that the credentials are still valid for the
+	 * user currently logged in. This can fail if (for instance)
+	 * the cookies expired, or were invalidated by a logout from
+	 * a different client.
+	 * 
+	 * This method queries the API and throws {@class AssertUserFailedException}
+	 * if the check failed. This does not update the state of the connection
+	 * object.
+	 * @throws MediaWikiApiErrorException 
+	 * @throws IOException 
+	 */
+	public void checkCredentials() throws IOException, MediaWikiApiErrorException {
+		Map<String,String> parameters = new HashMap<>();
+		parameters.put("action", "query");
+		sendJsonRequest("POST", parameters);
 	}
 
 	/**

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/apierrors/AssertUserFailedException.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/apierrors/AssertUserFailedException.java
@@ -1,0 +1,37 @@
+package org.wikidata.wdtk.wikibaseapi.apierrors;
+
+/*
+ * #%L
+ * Wikidata Toolkit Wikibase API
+ * %%
+ * Copyright (C) 2014 - 2015 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+/**
+ * Exception to indicate that we tried to perform an action while our login
+ * credentials have expired. See
+ * <a href="https://www.mediawiki.org/wiki/API:Assert">MediaWiki documentation</a>.
+ * 
+ * @author Antonin Delpeuch
+ *
+ */
+public class AssertUserFailedException extends MediaWikiApiErrorException {
+
+	public AssertUserFailedException(String errorMessage) {
+		super(MediaWikiApiErrorHandler.ERROR_NO_SUCH_ENTITY, errorMessage);
+	}
+
+}

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/apierrors/AssertUserFailedException.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/apierrors/AssertUserFailedException.java
@@ -31,7 +31,7 @@ package org.wikidata.wdtk.wikibaseapi.apierrors;
 public class AssertUserFailedException extends MediaWikiApiErrorException {
 
 	public AssertUserFailedException(String errorMessage) {
-		super(MediaWikiApiErrorHandler.ERROR_NO_SUCH_ENTITY, errorMessage);
+		super(MediaWikiApiErrorHandler.ERROR_ASSERT_USER_FAILED, errorMessage);
 	}
 
 }

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/apierrors/MediaWikiApiErrorHandler.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/apierrors/MediaWikiApiErrorHandler.java
@@ -33,6 +33,7 @@ public class MediaWikiApiErrorHandler {
 	public final static String ERROR_INVALID_TOKEN = "badtoken";
 	public final static String ERROR_NO_SUCH_ENTITY = "no-such-entity";
 	public final static String ERROR_MAXLAG = "maxlag";
+	private static final String ERROR_ASSERT_USER_FAILED = "assertuserfailed";
 
 	/**
 	 * Creates and throws a suitable {@link MediaWikiApiErrorException} for the
@@ -58,6 +59,8 @@ public class MediaWikiApiErrorHandler {
 			throw new NoSuchEntityErrorException(errorMessage);
 		case ERROR_MAXLAG:
 			throw new MaxlagErrorException(errorMessage);
+		case ERROR_ASSERT_USER_FAILED:
+			throw new AssertUserFailedException(errorMessage);
 		default:
 			throw new MediaWikiApiErrorException(errorCode, errorMessage);
 		}

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/apierrors/MediaWikiApiErrorHandler.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/apierrors/MediaWikiApiErrorHandler.java
@@ -33,7 +33,7 @@ public class MediaWikiApiErrorHandler {
 	public final static String ERROR_INVALID_TOKEN = "badtoken";
 	public final static String ERROR_NO_SUCH_ENTITY = "no-such-entity";
 	public final static String ERROR_MAXLAG = "maxlag";
-	private static final String ERROR_ASSERT_USER_FAILED = "assertuserfailed";
+	public final static String ERROR_ASSERT_USER_FAILED = "assertuserfailed";
 
 	/**
 	 * Creates and throws a suitable {@link MediaWikiApiErrorException} for the

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnectionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnectionTest.java
@@ -76,7 +76,6 @@ public class BasicApiConnectionTest {
 		params.put("action", "query");
 		params.put("meta", "tokens");
 		params.put("type", "csrf");
-		params.put("assert", "user");
 		params.put("format", "json");
 		this.con.setWebResourceFromPath(params, this.getClass(),
 				"/query-csrf-token-loggedin-response.json", CompressionType.NONE);
@@ -331,7 +330,7 @@ public class BasicApiConnectionTest {
 	}
 	
 	@Test(expected = AssertUserFailedException.class)
-	public void testCheckCredentials() throws IOException, MediaWikiApiErrorException {
+	public void testCheckCredentials() throws IOException, MediaWikiApiErrorException, LoginFailedException {
 		// we first login successfully
 		this.con.login("username", "password");
 		assertTrue(this.con.isLoggedIn());

--- a/wdtk-wikibaseapi/src/test/resources/assert-user-failed.json
+++ b/wdtk-wikibaseapi/src/test/resources/assert-user-failed.json
@@ -1,0 +1,1 @@
+{"error":{"code":"assertuserfailed","info":"Assertion that the user is logged in failed.","*":"See https://www.wikidata.org/w/api.php for API usage. Subscribe to the mediawiki-api-announce mailing list at &lt;https://lists.wikimedia.org/mailman/listinfo/mediawiki-api-announce&gt; for notice of API deprecations and breaking changes."},"servedby":"mw1347"}


### PR DESCRIPTION
See https://www.mediawiki.org/wiki/API:Assert.
Fixes #409.