### PR TITLE
Support unsupported values (!)

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverter.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverter.java
@@ -349,6 +349,18 @@ public class DatamodelConverter implements SnakVisitor<Snak>,
 				object.getNumericValue(), object.getLowerBound(),
 				object.getUpperBound(), object.getUnit());
 	}
+	
+	/**
+	 * Copies an {@link UnsupportedValue}.
+	 *
+	 * @param object
+	 *            object to copy
+	 * @return copied object
+	 */
+    public UnsupportedValue copy(UnsupportedValue object) {
+    	// unsupported values cannot be copied!
+    	return object;
+    }
 
 	/**
 	 * Copies a {@link Snak}.
@@ -598,6 +610,11 @@ public class DatamodelConverter implements SnakVisitor<Snak>,
 
 	@Override
 	public Value visit(TimeValue value) {
+		return copy(value);
+	}
+	
+	@Override
+	public Value visit(UnsupportedValue value) {
 		return copy(value);
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ToString.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ToString.java
@@ -218,7 +218,7 @@ public class ToString {
 	 * @return a string representation of the object
 	 */
 	public static String toString(UnsupportedValue o) {
-		return "unsupported value of type "+o.getTypeString();
+		return "unsupported value of type "+o.getTypeJsonString();
 	}
 	
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ToString.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ToString.java
@@ -206,6 +206,18 @@ public class ToString {
 		}
 		return str;
 	}
+	
+	/**
+	 * Returns a human-readable string representation of the given object.
+	 *
+	 * @see java.lang.Object#toString()
+	 * @param o
+	 *            the object to represent as string
+	 * @return a string representation of the object
+	 */
+	public static String toString(UnsupportedValue o) {
+		return "unsupported value of type "+o.getTypeString();
+	}
 
 	/**
 	 * Returns a human-readable string representation of the given object.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ToString.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ToString.java
@@ -1,5 +1,7 @@
 package org.wikidata.wdtk.datamodel.helpers;
 
+import org.wikidata.wdtk.datamodel.implementation.UnsupportedEntityIdValueImpl;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -217,6 +219,18 @@ public class ToString {
 	 */
 	public static String toString(UnsupportedValue o) {
 		return "unsupported value of type "+o.getTypeString();
+	}
+	
+	/**
+	 * Returns a human-readable string representation of the given object.
+	 *
+	 * @see java.lang.Object#toString()
+	 * @param o
+	 *            the object to represent as string
+	 * @return a string representation of the object
+	 */
+	public static String toString(UnsupportedEntityIdValue o) {
+		return o.getIri() + " (unsupported)";
 	}
 
 	/**
@@ -690,4 +704,5 @@ public class ToString {
 				"==\n" +
 				"Target: " + o.getTargetId().getIri();
 	}
+
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueImpl.java
@@ -23,6 +23,7 @@ package org.wikidata.wdtk.datamodel.implementation;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.Validate;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;
@@ -34,6 +35,8 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.JsonDeserializer.None;
@@ -77,12 +80,14 @@ public class UnsupportedEntityIdValueImpl extends ValueImpl implements Unsupport
 				String entityType,
 				@JsonProperty("id")
 				String id) {
+			Validate.notNull(id);
 			this.entityType = entityType;
 			this.id = id;
 			contents = new HashMap<>();
 		}
 		
 		@JsonProperty("entity-type")
+		@JsonInclude(Include.NON_NULL)
 		public String getEntityTypeString() {
 			return entityType;
 		}
@@ -154,7 +159,7 @@ public class UnsupportedEntityIdValueImpl extends ValueImpl implements Unsupport
 
 	@Override
 	@JsonIgnore
-	public String getEntityTypeString() {
+	public String getEntityTypeJsonString() {
 		return value.getEntityTypeString();
 	}
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueImpl.java
@@ -1,5 +1,25 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
+/*-
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 - 2019 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.HashMap;
 import java.util.Map;
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueImpl.java
@@ -23,6 +23,7 @@ package org.wikidata.wdtk.datamodel.implementation;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
@@ -116,7 +117,14 @@ public class UnsupportedEntityIdValueImpl extends ValueImpl implements Unsupport
 	@Override
 	@JsonIgnore
 	public String getEntityType() {
-		return ET_UNSUPPORTED;
+		if (value.entityType == null) {
+			return ET_UNSUPPORTED;
+		}
+		String[] parts = value.entityType.split("-");
+		for(int i = 0; i < parts.length; i++) {
+			parts[i] = StringUtils.capitalize(parts[i]);
+		}
+		return "http://www.wikidata.org/ontology#" + StringUtils.join(parts);
 	}
 
 	@Override

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueImpl.java
@@ -1,0 +1,140 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.wikidata.wdtk.datamodel.helpers.Equality;
+import org.wikidata.wdtk.datamodel.helpers.Hash;
+import org.wikidata.wdtk.datamodel.helpers.ToString;
+import org.wikidata.wdtk.datamodel.interfaces.UnsupportedEntityIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.ValueVisitor;
+
+import com.fasterxml.jackson.annotation.JacksonInject;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonDeserializer.None;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * Represents a entity id value of an unsupported type.
+ * We can still "deserialize" it by just storing its
+ * JSON representation, so that it can be serialized
+ * back to its original representation.
+ * This avoids parsing failures on documents containing
+ * these values.
+ * 
+ * @author Antonin Delpeuch
+ */
+@JsonDeserialize(using = None.class)
+public class UnsupportedEntityIdValueImpl extends ValueImpl implements UnsupportedEntityIdValue {
+	
+	private final JacksonIdValue value;
+	private final String siteIri;
+
+	@JsonCreator
+	private UnsupportedEntityIdValueImpl(
+			@JsonProperty("value")
+			JacksonIdValue value,
+			@JacksonInject("siteIri")
+			String siteIri) {
+		super(JSON_VALUE_TYPE_ENTITY_ID);
+		this.value = value;
+		this.siteIri = siteIri;
+	}
+
+	private static class JacksonIdValue {
+		private final String entityType;
+		private final String id;
+		private final Map<String, JsonNode> contents;
+		
+		@JsonCreator
+		private JacksonIdValue(
+				@JsonProperty("entity-type")
+				String entityType,
+				@JsonProperty("id")
+				String id) {
+			this.entityType = entityType;
+			this.id = id;
+			contents = new HashMap<>();
+		}
+		
+		@JsonProperty("entity-type")
+		public String getEntityTypeString() {
+			return entityType;
+		}
+		
+		@JsonProperty("id")
+		public String getId() {
+			return id;
+		}
+		
+		@JsonAnyGetter
+		protected Map<String, JsonNode> getContents() {
+			return contents;
+		}
+		
+		@JsonAnySetter
+		protected void loadContents(String key, JsonNode value) {
+			this.contents.put(key, value);
+		}
+	}
+	
+	@Override
+	public String toString() {
+		return ToString.toString(this);
+	}
+
+	@Override
+	@JsonIgnore
+	public String getEntityType() {
+		return ET_UNSUPPORTED;
+	}
+
+	@Override
+	@JsonIgnore
+	public String getId() {
+		return value.getId();
+	}
+	
+	@JsonProperty("value")
+	protected JacksonIdValue getInnerValue() {
+		return value;
+	}
+
+	@Override
+	@JsonIgnore
+	public String getSiteIri() {
+		return siteIri;
+	}
+
+	@Override
+	@JsonIgnore
+	public String getIri() {
+		return siteIri.concat(value.getId());
+	}
+	
+	@Override
+	public int hashCode() {
+		return Hash.hashCode(this);
+	}
+	
+	@Override
+	public boolean equals(Object other) {
+		return Equality.equalsEntityIdValue(this, other);
+	}
+	
+	@Override
+	public <T> T accept(ValueVisitor<T> valueVisitor) {
+		return valueVisitor.visit(this);
+	}
+
+	@Override
+	@JsonIgnore
+	public String getEntityTypeString() {
+		return value.getEntityTypeString();
+	}
+}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedValueImpl.java
@@ -68,7 +68,7 @@ public class UnsupportedValueImpl extends ValueImpl implements UnsupportedValue 
 
 	@Override
 	@JsonProperty("type")
-	public String getTypeString() {
+	public String getTypeJsonString() {
 		return typeString;
 	}
 	
@@ -110,7 +110,7 @@ public class UnsupportedValueImpl extends ValueImpl implements UnsupportedValue 
 			return false;
 		}
 		UnsupportedValueImpl otherValue = (UnsupportedValueImpl) other;
-		return typeString.equals(otherValue.getTypeString()) &&
+		return typeString.equals(otherValue.getTypeJsonString()) &&
 				contents.equals(otherValue.getContents());
 	}
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedValueImpl.java
@@ -1,5 +1,25 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
+/*-
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 - 2019 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import java.util.HashMap;
 import java.util.Map;
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedValueImpl.java
@@ -1,0 +1,96 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.wikidata.wdtk.datamodel.helpers.ToString;
+import org.wikidata.wdtk.datamodel.interfaces.UnsupportedValue;
+import org.wikidata.wdtk.datamodel.interfaces.ValueVisitor;
+
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonDeserializer.None;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+
+/**
+ * Represents a value with an unsupported datatype.
+ * We can still "deserialize" it by just storing its
+ * JSON representation, so that it can be serialized
+ * back to its original representation.
+ * This avoids parsing failures on documents containing
+ * these values.
+ * 
+ * @author Antonin Delpeuch
+ *
+ */
+@JsonDeserialize(using = None.class)
+public class UnsupportedValueImpl extends ValueImpl implements UnsupportedValue {
+	
+	private final String typeString;
+	private final Map<String, JsonNode> contents; 
+
+	@JsonCreator
+	private UnsupportedValueImpl(
+			@JsonProperty("type")
+			String typeString) {
+		super(typeString);
+		this.typeString = typeString;
+		this.contents = new HashMap<>();
+	}
+
+	@Override
+	public <T> T accept(ValueVisitor<T> valueVisitor) {
+		return valueVisitor.visit(this);
+	}
+
+	@Override
+	@JsonProperty("type")
+	public String getTypeString() {
+		return typeString;
+	}
+	
+	@JsonAnyGetter
+	protected Map<String, JsonNode> getContents() {
+		return contents;
+	}
+	
+	@JsonAnySetter
+	protected void loadContents(String key, JsonNode value) {
+		this.contents.put(key, value);
+	}
+	
+	@Override
+	public String toString() {
+		return ToString.toString(this);
+	}
+	
+	/**
+	 * We do not use the Hash helper as in other datamodel
+	 * classes because this would require exposing the contents
+	 * of the value publicly, which goes against the desired
+	 * opacity of the representation.
+	 */
+	@Override
+	public int hashCode() {
+		return typeString.hashCode() + 31*contents.hashCode();
+	}
+	
+	/**
+	 * We do not use the Equality helper as in other datamodel
+	 * classes because this would require exposing the contents
+	 * of the value publicly, which goes against the desired
+	 * opacity of the representation.
+	 */
+	@Override
+	public boolean equals(Object other) {
+		if (other == null || !(other instanceof UnsupportedValueImpl)) {
+			return false;
+		}
+		UnsupportedValueImpl otherValue = (UnsupportedValueImpl) other;
+		return typeString.equals(otherValue.getTypeString()) &&
+				contents.equals(otherValue.getContents());
+	}
+}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ValueImpl.java
@@ -142,7 +142,7 @@ public abstract class ValueImpl implements Value {
 						try {
 							return getValueClassFromEntityType(valueNode.get("entity-type").asText());
 						} catch (IllegalArgumentException e) {
-							throw new JsonMappingException(jsonParser, e.getMessage(), e);
+							return UnsupportedEntityIdValueImpl.class;
 						}
 					} else if(valueNode.has("id")) {
 						try {

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ValueImpl.java
@@ -168,8 +168,7 @@ public abstract class ValueImpl implements Value {
 			case JSON_VALUE_TYPE_MONOLINGUAL_TEXT:
 				return MonolingualTextValueImpl.class;
 			default:
-				throw new JsonMappingException(jsonParser, "Property values of type \""
-						+ jsonType + "\" are not supported yet.");
+				return UnsupportedValueImpl.class;
 			}
 		}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ValueImpl.java
@@ -150,7 +150,7 @@ public abstract class ValueImpl implements Value {
 									EntityIdValueImpl.guessEntityTypeFromId(valueNode.get("id").asText())
 							);
 						} catch (IllegalArgumentException e) {
-							throw new JsonMappingException(jsonParser, e.getMessage(), e);
+							return UnsupportedEntityIdValueImpl.class;
 						}
 					} else {
 						throw new JsonMappingException(jsonParser, "Unexpected entity id serialization");

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/EntityIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/EntityIdValue.java
@@ -65,7 +65,9 @@ public interface EntityIdValue extends IriIdentifiedValue {
 	 */
 	String ET_SENSE = "http://www.wikidata.org/ontology#Sense";
 	/**
-	 * IRI of the type of an unsupported entity.
+	 * IRI of the type of an unsupported entity, when no type could be
+	 * detected from the JSON representation. The IRI for ids associated
+	 * with type information are constructed using the same format as above.
 	 */
 	String ET_UNSUPPORTED = "http://www.wikidata.org/ontology#Unsupported";
 	

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/EntityIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/EntityIdValue.java
@@ -65,6 +65,11 @@ public interface EntityIdValue extends IriIdentifiedValue {
 	 */
 	String ET_SENSE = "http://www.wikidata.org/ontology#Sense";
 	/**
+	 * IRI of the type of an unsupported entity.
+	 */
+	String ET_UNSUPPORTED = "http://www.wikidata.org/ontology#Unsupported";
+	
+	/**
 	 * The site IRI of "local" identifiers. These are used to mark internal ids
 	 * that are not found on any external site. Components that send data to
 	 * external services or that create data exports should omit such ids, if

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/UnsupportedEntityIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/UnsupportedEntityIdValue.java
@@ -1,5 +1,25 @@
 package org.wikidata.wdtk.datamodel.interfaces;
 
+/*-
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 - 2019 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 /**
  * Represents a entity id value of an unsupported type.
  * We can still "deserialize" it by just storing its

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/UnsupportedEntityIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/UnsupportedEntityIdValue.java
@@ -1,0 +1,18 @@
+package org.wikidata.wdtk.datamodel.interfaces;
+
+/**
+ * Represents a entity id value of an unsupported type.
+ * We can still "deserialize" it by just storing its
+ * JSON representation, so that it can be serialized
+ * back to its original representation.
+ * This avoids parsing failures on documents containing
+ * these values.
+ * 
+ * @author Antonin Delpeuch
+ */
+public interface UnsupportedEntityIdValue extends EntityIdValue {
+	/**
+	 * The type of entity as represented in the JSON serialization.
+	 */
+	public String getEntityTypeString();
+}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/UnsupportedEntityIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/UnsupportedEntityIdValue.java
@@ -34,5 +34,5 @@ public interface UnsupportedEntityIdValue extends EntityIdValue {
 	/**
 	 * The type of entity as represented in the JSON serialization.
 	 */
-	public String getEntityTypeString();
+	public String getEntityTypeJsonString();
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/UnsupportedValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/UnsupportedValue.java
@@ -1,5 +1,25 @@
 package org.wikidata.wdtk.datamodel.interfaces;
 
+/*-
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 - 2019 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 /**
  * Represents a value with an unsupported datatype.
  * We can still "deserialize" it by just storing its

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/UnsupportedValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/UnsupportedValue.java
@@ -39,5 +39,5 @@ public interface UnsupportedValue extends Value {
 	 * @return
 	 * 		the value of "type" in the JSON representation of this value.
 	 */
-	public String getTypeString();
+	public String getTypeJsonString();
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/UnsupportedValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/UnsupportedValue.java
@@ -1,0 +1,23 @@
+package org.wikidata.wdtk.datamodel.interfaces;
+
+/**
+ * Represents a value with an unsupported datatype.
+ * We can still "deserialize" it by just storing its
+ * JSON representation, so that it can be serialized
+ * back to its original representation.
+ * This avoids parsing failures on documents containing
+ * these values.
+ * 
+ * @author Antonin Delpeuch
+ */
+public interface UnsupportedValue extends Value {
+	
+	/**
+	 * Returns the type string found in the JSON representation
+	 * of this value.
+	 * 
+	 * @return
+	 * 		the value of "type" in the JSON representation of this value.
+	 */
+	public String getTypeString();
+}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/ValueVisitor.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/ValueVisitor.java
@@ -93,5 +93,14 @@ public interface ValueVisitor<T> {
 	 * @return the result for this value
 	 */
 	T visit(TimeValue value);
+	
+	/**
+	 * Visits an UnsupportedValue and returns a result
+	 * 
+	 * @param value
+	 *            the value to visit
+	 * @return the result for this value
+	 */
+	T visit(UnsupportedValue value);
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemIdValueImplTest.java
@@ -1,5 +1,18 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+
+import org.junit.Test;
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
+import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.UnsupportedEntityIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.Value;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -22,14 +35,6 @@ package org.wikidata.wdtk.datamodel.implementation;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.junit.Test;
-import org.wikidata.wdtk.datamodel.helpers.Datamodel;
-import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
-import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
-
-import java.io.IOException;
-
-import static org.junit.Assert.*;
 
 public class ItemIdValueImplTest {
 
@@ -43,7 +48,7 @@ public class ItemIdValueImplTest {
 	private final String JSON_ITEM_ID_VALUE_WITHOUT_ID = "{\"type\":\"wikibase-entityid\",\"value\":{\"entity-type\":\"item\",\"numeric-id\":\"42\"}}";
 	private final String JSON_ITEM_ID_VALUE_WITHOUT_NUMERICAL_ID = "{\"type\":\"wikibase-entityid\",\"value\":{\"id\":\"Q42\"}}";
 	private final String JSON_ITEM_ID_VALUE_WRONG_ID = "{\"type\":\"wikibase-entityid\",\"value\":{\"id\":\"W42\"}}";
-	private final String JSON_ITEM_ID_VALUE_WRONG_TYPE = "{\"type\":\"wikibase-entityid\",\"value\":{\"entity-type\":\"foo\",\"numeric-id\":42}}";
+	private final String JSON_ITEM_ID_VALUE_UNSUPPORTED_TYPE = "{\"type\":\"wikibase-entityid\",\"value\":{\"entity-type\":\"foo\",\"numeric-id\":42}}";
 
 	@Test
 	public void entityTypeIsItem() {
@@ -131,10 +136,11 @@ public class ItemIdValueImplTest {
 		mapper.readValue(JSON_ITEM_ID_VALUE_WRONG_ID, ValueImpl.class);
 	}
 
-
-	@Test(expected = JsonMappingException.class)
-	public void testToJavaWrongType() throws IOException {
-		mapper.readValue(JSON_ITEM_ID_VALUE_WRONG_TYPE, ValueImpl.class);
+	@Test
+	public void testToJavaUnsupportedType() throws IOException {
+		Value unsupported = mapper.readValue(JSON_ITEM_ID_VALUE_UNSUPPORTED_TYPE, ValueImpl.class);
+		assertTrue(unsupported instanceof UnsupportedEntityIdValue);
+		assertEquals("foo", ((UnsupportedEntityIdValue)unsupported).getEntityTypeString());
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemIdValueImplTest.java
@@ -48,7 +48,8 @@ public class ItemIdValueImplTest {
 	private final String JSON_ITEM_ID_VALUE_WITHOUT_ID = "{\"type\":\"wikibase-entityid\",\"value\":{\"entity-type\":\"item\",\"numeric-id\":\"42\"}}";
 	private final String JSON_ITEM_ID_VALUE_WITHOUT_NUMERICAL_ID = "{\"type\":\"wikibase-entityid\",\"value\":{\"id\":\"Q42\"}}";
 	private final String JSON_ITEM_ID_VALUE_WRONG_ID = "{\"type\":\"wikibase-entityid\",\"value\":{\"id\":\"W42\"}}";
-	private final String JSON_ITEM_ID_VALUE_UNSUPPORTED_TYPE = "{\"type\":\"wikibase-entityid\",\"value\":{\"entity-type\":\"foo\",\"numeric-id\":42}}";
+	private final String JSON_ITEM_ID_VALUE_UNSUPPORTED_TYPE = "{\"type\":\"wikibase-entityid\",\"value\":{\"entity-type\":\"foo\",\"numeric-id\":42,\"id\":\"F42\"}}";
+	private final String JSON_ITEM_ID_VALUE_UNSUPPORTED_NO_ID = "{\"type\":\"wikibase-entityid\",\"value\":{}}";
 
 	@Test
 	public void entityTypeIsItem() {
@@ -130,17 +131,23 @@ public class ItemIdValueImplTest {
 	public void testToJavaWithoutNumericalId() throws IOException {
 		assertEquals(item1, mapper.readValue(JSON_ITEM_ID_VALUE_WITHOUT_NUMERICAL_ID, ValueImpl.class));
 	}
-
-	@Test(expected = JsonMappingException.class)
+	
+	@Test
 	public void testToJavaWrongID() throws IOException {
-		mapper.readValue(JSON_ITEM_ID_VALUE_WRONG_ID, ValueImpl.class);
+		Value unsupported = mapper.readValue(JSON_ITEM_ID_VALUE_WRONG_ID, ValueImpl.class);
+		assertTrue(unsupported instanceof UnsupportedEntityIdValue);
 	}
 
 	@Test
 	public void testToJavaUnsupportedType() throws IOException {
 		Value unsupported = mapper.readValue(JSON_ITEM_ID_VALUE_UNSUPPORTED_TYPE, ValueImpl.class);
 		assertTrue(unsupported instanceof UnsupportedEntityIdValue);
-		assertEquals("foo", ((UnsupportedEntityIdValue)unsupported).getEntityTypeString());
+		assertEquals("foo", ((UnsupportedEntityIdValue)unsupported).getEntityTypeJsonString());
+	}
+	
+	@Test(expected = JsonMappingException.class)
+	public void testToJavaUnsupportedWithoutId() throws IOException {
+		mapper.readValue(JSON_ITEM_ID_VALUE_UNSUPPORTED_NO_ID, ValueImpl.class);
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SnakImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SnakImplTest.java
@@ -55,7 +55,9 @@ public class SnakImplTest {
 	private final String JSON_SOMEVALUE_SNAK = "{\"snaktype\":\"somevalue\",\"property\":\"P42\"}";
 	private final String JSON_VALUE_SNAK = "{\"snaktype\":\"value\",\"property\":\"P42\",\"datatype\":\"wikibase-property\",\"datavalue\":{\"value\":{\"id\":\"P42\",\"numeric-id\":42,\"entity-type\":\"property\"},\"type\":\"wikibase-entityid\"}}";
 	private final String JSON_MONOLINGUAL_TEXT_VALUE_SNAK = "{\"snaktype\":\"value\",\"property\":\"P42\",\"datatype\":\"monolingualtext\",\"datavalue\":{\"value\":{\"language\":\"en\",\"text\":\"foo\"},\"type\":\"monolingualtext\"}}";
-
+	private final String JSON_SNAK_UNKNOWN_ID = "{\"snaktype\":\"value\",\"property\":\"P42\",\"datatype\":\"wikibase-funkyid\",\"datavalue\":{\"value\":{\"id\":\"FUNKY42\",\"entity-type\":\"funky\"},\"type\":\"wikibase-entityid\"}}";
+	private final String JSON_SNAK_UNKNOWN_DATAVALUE = "{\"snaktype\":\"value\",\"property\":\"P42\",\"datatype\":\"groovy\",\"datavalue\":{\"foo\":\"bar\",\"type\":\"groovyvalue\"}}";
+	
 	@Test
 	public void fieldsAreCorrect() {
 		assertEquals(vs1.getPropertyId(), p1);
@@ -161,5 +163,17 @@ public class SnakImplTest {
 	public void testMonolingualTextValueSnakToJson() throws JsonProcessingException {
 		JsonComparator.compareJsonStrings(JSON_MONOLINGUAL_TEXT_VALUE_SNAK, mapper.writeValueAsString(vsmt1));
 		JsonComparator.compareJsonStrings(JSON_MONOLINGUAL_TEXT_VALUE_SNAK, mapper.writeValueAsString(vsmt2));
+	}
+	
+	@Test
+	public void testDeserializeUnknownIdSnak() throws IOException {
+		// We only require deserialization not to fail here
+		mapper.readValue(JSON_SNAK_UNKNOWN_ID, SnakImpl.class);
+	}
+	
+	@Test
+	public void testDeserializeUnknownDatavalueSnak() throws IOException {
+		// We only require deserialization not to fail here
+		mapper.readValue(JSON_SNAK_UNKNOWN_DATAVALUE, SnakImpl.class);
 	}
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueTest.java
@@ -60,7 +60,7 @@ public class UnsupportedEntityIdValueTest {
 		Value otherValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_1, ValueImpl.class);
 		assertEquals(firstValue, otherValue);
 		assertNotEquals(secondValue, otherValue);
-		assertEquals(firstValue, noType);
+		assertNotEquals(firstValue, noType);
 		assertNotEquals(noType, secondValue);
 	}
 	
@@ -105,8 +105,8 @@ public class UnsupportedEntityIdValueTest {
 	
 	@Test
 	public void testGetEntityType() {
-		assertEquals(EntityIdValue.ET_UNSUPPORTED, firstValue.getEntityType());
-		assertEquals(EntityIdValue.ET_UNSUPPORTED, secondValue.getEntityType());
+		assertEquals("http://www.wikidata.org/ontology#Funky", firstValue.getEntityType());
+		assertEquals("http://www.wikidata.org/ontology#Shiny", secondValue.getEntityType());
 		assertEquals(EntityIdValue.ET_UNSUPPORTED, noType.getEntityType());
 	}
 	

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueTest.java
@@ -22,6 +22,7 @@ package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
 
@@ -29,6 +30,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.helpers.ToString;
+import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.UnsupportedEntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.Value;
 
@@ -41,14 +43,16 @@ public class UnsupportedEntityIdValueTest {
 	private final ObjectMapper mapper = new DatamodelMapper("http://www.wikidata.org/entity/");
 
 	private final String JSON_UNSUPPORTED_VALUE_1 = "{\"type\":\"wikibase-entityid\",\"value\":{\"entity-type\":\"funky\",\"id\":\"Z343\"}}";
-	private final String JSON_UNSUPPORTED_VALUE_2 = "{\"type\":\"wikibase-entityid\",\"value\":{\"entity-type\":\"shiny\",\"id\":\"P8989\",\"foo\":\"bar\"}}";
+	private final String JSON_UNSUPPORTED_VALUE_2 = "{\"type\":\"wikibase-entityid\",\"value\":{\"entity-type\":\"shiny\",\"id\":\"R8989\",\"foo\":\"bar\"}}";
+	private final String JSON_UNSUPPORTED_VALUE_NO_TYPE = "{\"type\":\"wikibase-entityid\",\"value\":{\"id\":\"Z343\"}}";
 	
-	private UnsupportedEntityIdValue firstValue, secondValue;
+	private UnsupportedEntityIdValue firstValue, secondValue, noType;
 	
 	@Before
-	public void deserializeFirstValue() throws JsonParseException, JsonMappingException, IOException {
+	public void deserializeValues() throws JsonParseException, JsonMappingException, IOException {
 		firstValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_1, UnsupportedEntityIdValueImpl.class);
 		secondValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_2, UnsupportedEntityIdValueImpl.class);
+		noType = mapper.readValue(JSON_UNSUPPORTED_VALUE_NO_TYPE, UnsupportedEntityIdValueImpl.class);
 	}
 	
 	@Test
@@ -56,6 +60,8 @@ public class UnsupportedEntityIdValueTest {
 		Value otherValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_1, ValueImpl.class);
 		assertEquals(firstValue, otherValue);
 		assertNotEquals(secondValue, otherValue);
+		assertEquals(firstValue, noType);
+		assertNotEquals(noType, secondValue);
 	}
 	
 	@Test
@@ -68,6 +74,7 @@ public class UnsupportedEntityIdValueTest {
 	public void testSerialize() throws JsonProcessingException {
 		JsonComparator.compareJsonStrings(JSON_UNSUPPORTED_VALUE_1, mapper.writeValueAsString(firstValue));
 		JsonComparator.compareJsonStrings(JSON_UNSUPPORTED_VALUE_2, mapper.writeValueAsString(secondValue));
+		JsonComparator.compareJsonStrings(JSON_UNSUPPORTED_VALUE_NO_TYPE, mapper.writeValueAsString(noType));
 	}
 	
 	@Test
@@ -78,7 +85,35 @@ public class UnsupportedEntityIdValueTest {
 	
 	@Test
 	public void testGetTypeString() {
-		assertEquals("funky", firstValue.getEntityTypeString());
-		assertEquals("shiny", secondValue.getEntityTypeString());
+		assertEquals("funky", firstValue.getEntityTypeJsonString());
+		assertEquals("shiny", secondValue.getEntityTypeJsonString());
+	}
+	
+	@Test
+	public void testGetIri() {
+		assertEquals("http://www.wikidata.org/entity/Z343", firstValue.getIri());
+		assertEquals("http://www.wikidata.org/entity/R8989", secondValue.getIri());
+		assertEquals("http://www.wikidata.org/entity/Z343", noType.getIri());
+	}
+	
+	@Test
+	public void testGetId() {
+		assertEquals("Z343", firstValue.getId());
+		assertEquals("R8989", secondValue.getId());
+		assertEquals("Z343", noType.getId());
+	}
+	
+	@Test
+	public void testGetEntityType() {
+		assertEquals(EntityIdValue.ET_UNSUPPORTED, firstValue.getEntityType());
+		assertEquals(EntityIdValue.ET_UNSUPPORTED, secondValue.getEntityType());
+		assertEquals(EntityIdValue.ET_UNSUPPORTED, noType.getEntityType());
+	}
+	
+	@Test
+	public void testGetEntityTypeString() {
+		assertEquals("funky", firstValue.getEntityTypeJsonString());
+		assertEquals("shiny", secondValue.getEntityTypeJsonString());
+		assertNull(noType.getEntityTypeJsonString());
 	}
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueTest.java
@@ -1,0 +1,64 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
+import org.wikidata.wdtk.datamodel.helpers.ToString;
+import org.wikidata.wdtk.datamodel.interfaces.UnsupportedEntityIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.Value;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class UnsupportedEntityIdValueTest {
+	private final ObjectMapper mapper = new DatamodelMapper("http://www.wikidata.org/entity/");
+
+	private final String JSON_UNSUPPORTED_VALUE_1 = "{\"type\":\"wikibase-entityid\",\"value\":{\"entity-type\":\"funky\",\"id\":\"Z343\"}}";
+	private final String JSON_UNSUPPORTED_VALUE_2 = "{\"type\":\"wikibase-entityid\",\"value\":{\"entity-type\":\"shiny\",\"id\":\"P8989\",\"foo\":\"bar\"}}";
+	
+	private UnsupportedEntityIdValue firstValue, secondValue;
+	
+	@Before
+	public void deserializeFirstValue() throws JsonParseException, JsonMappingException, IOException {
+		firstValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_1, UnsupportedEntityIdValueImpl.class);
+		secondValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_2, UnsupportedEntityIdValueImpl.class);
+	}
+	
+	@Test
+	public void testEquals() throws JsonParseException, JsonMappingException, IOException {
+		Value otherValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_1, ValueImpl.class);
+		assertEquals(firstValue, otherValue);
+		assertNotEquals(secondValue, otherValue);
+	}
+	
+	@Test
+	public void testHash() throws JsonParseException, JsonMappingException, IOException {
+		Value otherValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_2, ValueImpl.class);
+		assertEquals(secondValue.hashCode(), otherValue.hashCode());
+	}
+	
+	@Test
+	public void testSerialize() throws JsonProcessingException {
+		JsonComparator.compareJsonStrings(JSON_UNSUPPORTED_VALUE_1, mapper.writeValueAsString(firstValue));
+		JsonComparator.compareJsonStrings(JSON_UNSUPPORTED_VALUE_2, mapper.writeValueAsString(secondValue));
+	}
+	
+	@Test
+	public void testToString() {
+		assertEquals(ToString.toString(firstValue), firstValue.toString());
+		assertEquals(ToString.toString(secondValue), secondValue.toString());
+	}
+	
+	@Test
+	public void testGetTypeString() {
+		assertEquals("funky", firstValue.getEntityTypeString());
+		assertEquals("shiny", secondValue.getEntityTypeString());
+	}
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueTest.java
@@ -1,5 +1,25 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
+/*-
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 - 2019 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedValueImplTest.java
@@ -1,5 +1,25 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
+/*-
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 - 2019 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
 import org.wikidata.wdtk.datamodel.helpers.ToString;
 import org.wikidata.wdtk.datamodel.interfaces.UnsupportedValue;
 import org.wikidata.wdtk.datamodel.interfaces.Value;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedValueImplTest.java
@@ -1,0 +1,62 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
+import org.wikidata.wdtk.datamodel.helpers.ToString;
+import org.wikidata.wdtk.datamodel.interfaces.UnsupportedValue;
+import org.wikidata.wdtk.datamodel.interfaces.Value;
+
+import static org.junit.Assert.*;
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class UnsupportedValueImplTest {
+	private final ObjectMapper mapper = new ObjectMapper();
+
+	private final String JSON_UNSUPPORTED_VALUE_1 = "{\"type\":\"funky\",\"value\":\"groovy\"}";
+	private final String JSON_UNSUPPORTED_VALUE_2 = "{\"type\":\"shiny\",\"number\":42}";
+	
+	private UnsupportedValue firstValue, secondValue;
+	
+	@Before
+	public void deserializeFirstValue() throws JsonParseException, JsonMappingException, IOException {
+		firstValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_1, UnsupportedValueImpl.class);
+		secondValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_2, UnsupportedValueImpl.class);
+	}
+	
+	@Test
+	public void testEquals() throws JsonParseException, JsonMappingException, IOException {
+		Value otherValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_1, ValueImpl.class);
+		assertEquals(firstValue, otherValue);
+		assertNotEquals(secondValue, otherValue);
+	}
+	
+	@Test
+	public void testHash() throws JsonParseException, JsonMappingException, IOException {
+		Value otherValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_2, ValueImpl.class);
+		assertEquals(secondValue.hashCode(), otherValue.hashCode());
+	}
+	
+	@Test
+	public void testSerialize() throws JsonProcessingException {
+		JsonComparator.compareJsonStrings(JSON_UNSUPPORTED_VALUE_1, mapper.writeValueAsString(firstValue));
+		JsonComparator.compareJsonStrings(JSON_UNSUPPORTED_VALUE_2, mapper.writeValueAsString(secondValue));
+	}
+	
+	@Test
+	public void testToString() {
+		assertEquals(ToString.toString(firstValue), firstValue.toString());
+		assertEquals(ToString.toString(secondValue), secondValue.toString());
+	}
+	
+	@Test
+	public void testGetTypeString() {
+		assertEquals("funky", firstValue.getTypeString());
+		assertEquals("shiny", secondValue.getTypeString());
+	}
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedValueImplTest.java
@@ -76,7 +76,7 @@ public class UnsupportedValueImplTest {
 	
 	@Test
 	public void testGetTypeString() {
-		assertEquals("funky", firstValue.getTypeString());
-		assertEquals("shiny", secondValue.getTypeString());
+		assertEquals("funky", firstValue.getTypeJsonString());
+		assertEquals("shiny", secondValue.getTypeJsonString());
 	}
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/interfaces/NullEntityIdsTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/interfaces/NullEntityIdsTest.java
@@ -58,6 +58,11 @@ public class NullEntityIdsTest {
 			return null;
 		}
 
+		@Override
+		public String visit(UnsupportedValue value) {
+			return null;
+		}
+
 	}
 
 	@Test

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/PropertyRegister.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/PropertyRegister.java
@@ -200,6 +200,8 @@ public class PropertyRegister {
 	 * Returns the IRI of the primitive Type of an Property for
 	 * {@link EntityIdValue} objects.
 	 *
+	 * @todo this really ought to be exposed by the wdtk-datamodel
+	 * module and reused here. The same heuristic is implemented in {@class EntityIdValueImpl}.
 	 * @param propertyIdValue
 	 * @param value
 	 */

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/PropertyRegister.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/PropertyRegister.java
@@ -210,10 +210,18 @@ public class PropertyRegister {
 			return DatatypeIdValue.DT_ITEM;
 		case 'P':
 			return DatatypeIdValue.DT_PROPERTY;
+		case 'L':
+			if (value.getId().contains("F")) {
+				return DatatypeIdValue.DT_FORM;
+			} else if(value.getId().contains("S")) {
+				return DatatypeIdValue.DT_SENSE;
+			}
+			return DatatypeIdValue.DT_LEXEME;
 		default:
-			logger.warn("Could not determine Type of "
-					+ propertyIdValue.getId()
-					+ ". It is not a valid EntityDocument Id");
+			logger.warn("Could not determine datatype of "+ propertyIdValue.getId() + ".");
+			logger.warn("Example value "+value.getId()+ " is not recognized as a valid entity id.");
+			logger.warn("Perhaps this is a newly introduced datatype not supported by this version of wdtk.");
+			logger.warn("Consider upgrading the library to a newer version.");
 			return null;
 		}
 	}

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/values/AnyValueConverter.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/values/AnyValueConverter.java
@@ -23,7 +23,6 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.GlobeCoordinatesValue;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/values/AnyValueConverter.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/values/AnyValueConverter.java
@@ -31,6 +31,7 @@ import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.QuantityValue;
 import org.wikidata.wdtk.datamodel.interfaces.StringValue;
 import org.wikidata.wdtk.datamodel.interfaces.TimeValue;
+import org.wikidata.wdtk.datamodel.interfaces.UnsupportedValue;
 import org.wikidata.wdtk.datamodel.interfaces.ValueVisitor;
 import org.wikidata.wdtk.rdf.OwlDeclarationBuffer;
 import org.wikidata.wdtk.rdf.PropertyRegister;
@@ -50,6 +51,7 @@ public class AnyValueConverter implements
 		ValueConverter<org.wikidata.wdtk.datamodel.interfaces.Value>,
 		ValueVisitor<Value> {
 
+	final private RdfWriter rdfWriter;
 	final EntityIdValueConverter entityIdValueConverter;
 	final StringValueConverter stringValueConverter;
 	final TimeValueConverter timeValueConverter;
@@ -67,6 +69,7 @@ public class AnyValueConverter implements
 			OwlDeclarationBuffer rdfConversionBuffer,
 			PropertyRegister propertyRegister) {
 
+		this.rdfWriter = rdfWriter;
 		this.entityIdValueConverter = new EntityIdValueConverter(rdfWriter,
 				propertyRegister, rdfConversionBuffer);
 		this.stringValueConverter = new StringValueConverter(rdfWriter,
@@ -133,6 +136,11 @@ public class AnyValueConverter implements
 		this.globeCoordinatesValueConverter.writeAuxiliaryTriples();
 		this.timeValueConverter.writeAuxiliaryTriples();
 		this.quantityValueConverter.writeAuxiliaryTriples();
+	}
+
+	@Override
+	public Value visit(UnsupportedValue value) {
+		return this.rdfWriter.getFreshBNode();
 	}
 
 }

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/values/EntityIdValueConverter.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/values/EntityIdValueConverter.java
@@ -42,6 +42,11 @@ public class EntityIdValueConverter extends
 			PropertyIdValue propertyIdValue, boolean simple) {
 		String datatype = this.propertyRegister
 				.setPropertyTypeFromEntityIdValue(propertyIdValue, value);
+		
+		if(datatype == null) {
+			// we failed to guess the datatype: represent the value by a blank node
+			return this.rdfWriter.getFreshBNode();
+		}
 
 		switch (datatype) {
 		case DatatypeIdValue.DT_ITEM:
@@ -53,11 +58,11 @@ public class EntityIdValueConverter extends
 				this.rdfConversionBuffer.addObjectProperty(propertyIdValue);
 				return this.rdfWriter.getUri(value.getIri());
 			} else {
-				return null; // or blank node
+				return null;
 			}
 		default:
 			logIncompatibleValueError(propertyIdValue, datatype, "entity");
-			return null;
+			return this.rdfWriter.getFreshBNode();
 		}
 	}
 }

--- a/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/PropertyRegisterTest.java
+++ b/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/PropertyRegisterTest.java
@@ -173,11 +173,32 @@ public class PropertyRegisterTest {
 
 	@Test
 	public void testSetPropertyTypeFromEntityIdValue() {
+		PropertyIdValue pid = this.dataObjectFactory
+				.getPropertyIdValue("P1001", this.siteIri);
 		assertEquals(this.propertyRegister.setPropertyTypeFromEntityIdValue(
-				this.dataObjectFactory
-						.getPropertyIdValue("P1001", this.siteIri),
+				pid,
 				this.dataObjectFactory.getItemIdValue("Q20", this.siteIri)),
 				DatatypeIdValue.DT_ITEM);
+		
+		assertEquals(this.propertyRegister.setPropertyTypeFromEntityIdValue(
+				pid,
+				this.dataObjectFactory.getPropertyIdValue("P58", this.siteIri)),
+				DatatypeIdValue.DT_PROPERTY);
+		
+		assertEquals(this.propertyRegister.setPropertyTypeFromEntityIdValue(
+				pid,
+				this.dataObjectFactory.getLexemeIdValue("L343", this.siteIri)),
+				DatatypeIdValue.DT_LEXEME);
+		
+		assertEquals(this.propertyRegister.setPropertyTypeFromEntityIdValue(
+				pid,
+				this.dataObjectFactory.getFormIdValue("L343-F1", this.siteIri)),
+				DatatypeIdValue.DT_FORM);
+		
+		assertEquals(this.propertyRegister.setPropertyTypeFromEntityIdValue(
+				pid,
+				this.dataObjectFactory.getSenseIdValue("L343-S34", this.siteIri)),
+				DatatypeIdValue.DT_SENSE);
 	}
 
 	@Test


### PR DESCRIPTION
This adds the fallback classes discussed in #422. I chose the word `Unsupported` rather than `Unknown` since I felt that the latter could be mistaken with the notion of SomeValue/NoValue snaks (users should not try to create a SomeValue snak by instantiating these fallback classes and using it as snak value…)

This also fixes issue #407, which was actually a genuine issue. Postmortem for that one:
- The warning message in the `wdtk-rdf` module was really not informative at all, so it made it harder to debug
- The code that infers a datatype from an entity value had not been updated when lexeme support was added - but really that code should not live in the `wdtk-rdf` module, it duplicates things we already have (but do not expose) in the `wdtk-datamodel` module. That code is now updated but we should really consider removing this duplication by exposing this ugly (but useful) heuristic in the datamodel module.