### PR TITLE
Fix coveralls upload on Travis, use SVG badge.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ jdk:
   - oraclejdk9
   - oraclejdk11
 
+script:
+  - mvn cobertura:cobertura
+
 after_success:
-  - mvn clean cobertura:cobertura coveralls:cobertura
+  - mvn coveralls:cobertura
 
 dist: trusty
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ jdk:
   - oraclejdk11
 
 script:
-  - mvn cobertura:cobertura
+  - mvn test jacoco:report
 
 after_success:
-  - mvn coveralls:cobertura
+  - mvn coveralls:report
 
 dist: trusty
 sudo: false

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Wikidata Toolkit
 ================
 
 [![Build Status](https://travis-ci.org/Wikidata/Wikidata-Toolkit.png?branch=master)](https://travis-ci.org/Wikidata/Wikidata-Toolkit)
-[![Coverage Status](https://coveralls.io/repos/Wikidata/Wikidata-Toolkit/badge.png?branch=master)](https://coveralls.io/r/Wikidata/Wikidata-Toolkit?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/Wikidata/Wikidata-Toolkit/badge.svg?branch=master)](https://coveralls.io/github/Wikidata/Wikidata-Toolkit?branch=master)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.wikidata.wdtk/wdtk-parent/badge.svg)](http://search.maven.org/#search|ga|1|g%3A%22org.wikidata.wdtk%22)
 [![Project Stats](https://www.openhub.net/p/Wikidata-Toolkit/widgets/project_thin_badge.gif)](https://www.openhub.net/p/Wikidata-Toolkit)
 

--- a/pom.xml
+++ b/pom.xml
@@ -186,21 +186,22 @@
 				<!-- Create code coverage reports and submit them to coveralls.io. -->
 				<groupId>org.eluder.coveralls</groupId>
 				<artifactId>coveralls-maven-plugin</artifactId>
-				<version>2.1.0</version>
+				<version>4.3.0</version>
 			</plugin>
 			<plugin>
 				<!-- Plugin for actually computing code coverage. -->
-				<!-- Change format to html and call mvn cobertura:cobertura to generate HTML report locally. -->
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>cobertura-maven-plugin</artifactId>
-				<version>2.7</version>
-				<configuration>
-					<format>xml</format>
-					<!-- <format>html</format> -->
-					<maxmem>256m</maxmem>
-					<!-- aggregated reports for multi-module projects -->
-					<aggregate>true</aggregate>
-				</configuration>
+				<!-- Call mvn test jacoco:report to generate test coverage -->
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.4</version>
+                                <executions>
+                                        <execution>
+                                                <id>prepare-agent</id>
+                                                <goals>
+                                                        <goal>prepare-agent</goal>
+                                                </goals>
+                                        </execution>
+                                </executions>
 			</plugin>
 			<plugin>
 				<!-- Plugin for creating Javadocs; goal for preparing docs for upload to github: javadoc:aggregate -->

--- a/pom.xml
+++ b/pom.xml
@@ -186,7 +186,7 @@
 				<!-- Create code coverage reports and submit them to coveralls.io. -->
 				<groupId>org.eluder.coveralls</groupId>
 				<artifactId>coveralls-maven-plugin</artifactId>
-				<version>4.3.0</version>
+				<version>2.1.0</version>
 			</plugin>
 			<plugin>
 				<!-- Plugin for actually computing code coverage. -->

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,13 @@
 				<groupId>org.eluder.coveralls</groupId>
 				<artifactId>coveralls-maven-plugin</artifactId>
 				<version>4.3.0</version>
+                                <dependencies>
+                                    <dependency>
+                                        <groupId>javax.xml.bind</groupId>
+                                        <artifactId>jaxb-api</artifactId>
+                                        <version>2.2.3</version>
+                                    </dependency>
+                                </dependencies>
 			</plugin>
 			<plugin>
 				<!-- Plugin for actually computing code coverage. -->


### PR DESCRIPTION
Coverage upload failed because of https://github.com/trautonen/coveralls-maven-plugin/issues/127.
See failing builds: https://travis-ci.org/Wikidata/Wikidata-Toolkit/jobs/566845341#L1823