### PR TITLE
Issue 428

### DIFF
--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/ApiConnection.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/ApiConnection.java
@@ -380,6 +380,9 @@ public class ApiConnection {
 		}
 		String value = fetchToken(tokenType);
 		tokens.put(tokenType, value);
+		// TODO if this is null, we could try to recover here:
+		// (1) Check if we are still logged in; maybe log in again
+		// (2) If there is another error, maybe just run the operation again
 		return value;
 	}
 

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/ApiConnection.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/ApiConnection.java
@@ -345,6 +345,7 @@ public class ApiConnection {
 			Map<String, String> params = new HashMap<>();
 			params.put("action", "logout");
 			params.put("format", "json"); // reduce the output
+			params.put("token", fetchToken("csrf"));
 			try {
 				sendJsonRequest("POST", params);
 			} catch (MediaWikiApiErrorException e) {

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/ApiConnection.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/ApiConnection.java
@@ -345,7 +345,7 @@ public class ApiConnection {
 			Map<String, String> params = new HashMap<>();
 			params.put("action", "logout");
 			params.put("format", "json"); // reduce the output
-			params.put("token", fetchToken("csrf"));
+			params.put("token", getOrFetchToken("csrf"));
 			try {
 				sendJsonRequest("POST", params);
 			} catch (MediaWikiApiErrorException e) {

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnection.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnection.java
@@ -57,14 +57,17 @@ public class BasicApiConnection extends ApiConnection {
 	 * 		map of cookies used for this session
 	 * @param loggedIn
 	 * 		true if login succeeded.
+	 * @param tokens
+	 * 		map of tokens used for this session
 	 */
 	@JsonCreator
 	private BasicApiConnection(
 			@JsonProperty("baseUrl") String apiBaseUrl,
 			@JsonProperty("cookies") Map<String, String> cookies,
 			@JsonProperty("username") String username,
-			@JsonProperty("loggedIn") boolean loggedIn) {
-		super(apiBaseUrl, cookies, username, loggedIn);
+			@JsonProperty("loggedIn") boolean loggedIn,
+			@JsonProperty("cookies") Map<String, String> tokens) {
+		super(apiBaseUrl, cookies, username, loggedIn, tokens);
 	}
 	
 	/**

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnection.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnection.java
@@ -66,7 +66,7 @@ public class BasicApiConnection extends ApiConnection {
 			@JsonProperty("cookies") Map<String, String> cookies,
 			@JsonProperty("username") String username,
 			@JsonProperty("loggedIn") boolean loggedIn,
-			@JsonProperty("cookies") Map<String, String> tokens) {
+			@JsonProperty("tokens") Map<String, String> tokens) {
 		super(apiBaseUrl, cookies, username, loggedIn, tokens);
 	}
 	

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbEditingAction.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbEditingAction.java
@@ -690,7 +690,7 @@ public class WbEditingAction {
 		}
 
 		parameters.put("maxlag", Integer.toString(this.maxLag));
-		parameters.put("token", getCsrfToken());
+		parameters.put("token", connection.getOrFetchToken("csrf"));
 
 		if (this.remainingEdits > 0) {
 			this.remainingEdits--;
@@ -712,7 +712,7 @@ public class WbEditingAction {
 			} catch (TokenErrorException e) { // try again with a fresh token
 				lastException = e;
 				connection.clearToken("csrf");
-				parameters.put("token", getCsrfToken());
+				parameters.put("token", connection.getOrFetchToken("csrf"));
 			} catch (MaxlagErrorException e) { // wait for 5 seconds
 				lastException = e;
 				logger.warn(e.getMessage() + " -- pausing for 5 seconds.");
@@ -776,18 +776,6 @@ public class WbEditingAction {
 				.with(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT)
 				.readValue(entityNode);
 	}
-
-	/**
-	 * Returns a CSRF (Cross-Site Request Forgery) token as required to edit
-	 * data.
-	 */
-	private String getCsrfToken() {
-		return connection.getOrFetchToken("csrf");
-		// TODO if this is null, we could try to recover here:
-		// (1) Check if we are still logged in; maybe log in again
-		// (2) If there is another error, maybe just run the operation again
-	}
-
 
 	/**
 	 * Makes sure that we are not editing too fast. The method stores the last

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnectionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnectionTest.java
@@ -137,7 +137,7 @@ public class BasicApiConnectionTest {
 	}
 
 	@Test
-    public void testGetTokenWithoutLogin() throws LoginFailedException {
+	public void testGetTokenWithoutLogin() throws LoginFailedException {
 		assertTrue(this.con.getOrFetchToken("csrf") == null);
 	}
 

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnectionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnectionTest.java
@@ -130,17 +130,17 @@ public class BasicApiConnectionTest {
 
 	@Test
 	public void testGetToken() throws IOException, MediaWikiApiErrorException {
-		assertTrue(this.con.fetchToken("csrf") != null);
+		assertTrue(this.con.getOrFetchToken("csrf") != null);
 	}
 
 	@Test
 	public void testGetLoginToken() throws IOException, MediaWikiApiErrorException {
-		assertTrue(this.con.fetchToken("login") != null);
+		assertTrue(this.con.getOrFetchToken("login") != null);
 	}
 
 	@Test
 	public void testConfirmLogin() throws LoginFailedException, IOException, MediaWikiApiErrorException {
-		String token = this.con.fetchToken("login");
+		String token = this.con.getOrFetchToken("login");
 		this.con.confirmLogin(token, "username", "password");
 	}
 

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnectionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnectionTest.java
@@ -118,7 +118,8 @@ public class BasicApiConnectionTest {
 		params.put("assert", "user");
 		params.put("format", "json");
 		this.con.setWebResource(params, "{}");
-		
+
+		params.clear();
 		params.put("action", "query");
 		params.put("assert", "user");
 		params.put("format", "json");

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnectionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnectionTest.java
@@ -77,6 +77,7 @@ public class BasicApiConnectionTest {
 		params.put("meta", "tokens");
 		params.put("type", "csrf");
 		params.put("format", "json");
+		params.put("assert", "user");
 		this.con.setWebResourceFromPath(params, this.getClass(),
 				"/query-csrf-token-loggedin-response.json", CompressionType.NONE);
 		params.clear();
@@ -117,6 +118,7 @@ public class BasicApiConnectionTest {
 		params.put("action", "logout");
 		params.put("assert", "user");
 		params.put("format", "json");
+		params.put("token", "42307b93c79b0cb558d2dfb4c3c92e0955e06041+\\");
 		this.con.setWebResource(params, "{}");
 
 		params.clear();
@@ -129,12 +131,18 @@ public class BasicApiConnectionTest {
 	}
 
 	@Test
-	public void testGetToken() throws IOException, MediaWikiApiErrorException {
+	public void testGetToken() throws LoginFailedException {
+		this.con.login("username", "password");
 		assertTrue(this.con.getOrFetchToken("csrf") != null);
 	}
 
 	@Test
-	public void testGetLoginToken() throws IOException, MediaWikiApiErrorException {
+    public void testGetTokenWithoutLogin() throws LoginFailedException {
+		assertTrue(this.con.getOrFetchToken("csrf") == null);
+	}
+
+	@Test
+	public void testGetLoginToken() {
 		assertTrue(this.con.getOrFetchToken("login") != null);
 	}
 


### PR DESCRIPTION
This pull request was created to address issue #428.

The proposed solution is to move tokens management into ApiConnection class. The idea is that the ApiConnection keeps track of token requests and store them. This allows reusing the token when necessary, for example for logout operation. To reflect this fact in the API of ApiConnection  a new method *getOrFetchToken* was introduced. I'm not sure about the name, as we can keep *fetchToken* and hide the fact that it may not always cause fetch operation. I prefer a more explicit solution although they are more verbose, that is personal preference.

As tokens are managed, and cached, in ApiConnection the WbEditingAction class does not store the *CSRF* token and instead, it gets it from the ApiConnection.

The tests were also changed to reflect a fact, that *CSRF* can be obtained only after login. This seems to be original intention, based on the resource test file names but was not implemented in tests.

It seems that using the *CSRF* token works with both instances I tested with (1.32.0, 1.34.0-wmf.17), so the change should be backward compatible. But the older version API complain that the token is unknown.
```
API warning [main]: Unrecognized parameter: token.
```