### PR TITLE
Return null in getBestStatements if there are none

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StatementGroupImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StatementGroupImpl.java
@@ -99,6 +99,7 @@ public class StatementGroupImpl extends AbstractList<Statement> implements State
 				bestStatements.add(statement);
 			}
 		}
+		if (bestStatements.size() == 0) return null;
 		return new StatementGroupImpl(bestStatements);
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/StatementGroup.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/StatementGroup.java
@@ -45,7 +45,7 @@ public interface StatementGroup extends Collection<Statement> {
 	 * These are the statements with rank {@link StatementRank::PREFERRED }
 	 * if they exists or the one with rank {@link StatementRank::NORMAL }
 	 *
-	 * @return a subset of the current StatementGroup
+	 * @return a subset of the current StatementGroup, or null if there are no best statements
 	 */
 	StatementGroup getBestStatements();
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementGroupTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementGroupTest.java
@@ -44,6 +44,8 @@ public class StatementGroupTest {
 			Collections.emptyList(), Collections.emptyList(), subject);
 	private Statement statementEmptyId = new StatementImpl("", StatementRank.NORMAL, mainSnak,
 			Collections.emptyList(), Collections.emptyList(), subject);
+	private Statement statementDeprecrated = new StatementImpl("DepId", StatementRank.DEPRECATED, mainSnak,
+			Collections.emptyList(), Collections.emptyList(), subject);
 	private StatementGroup sg1 = new StatementGroupImpl(Collections.singletonList(statement1));
 	private StatementGroup sg2 = new StatementGroupImpl(Collections.singletonList(statement1));
 
@@ -76,6 +78,14 @@ public class StatementGroupTest {
 		assertEquals(
 				new StatementGroupImpl(Collections.singletonList(statement1)),
 				new StatementGroupImpl(Collections.singletonList(statement1)).getBestStatements()
+		);
+	}
+
+	@Test
+	public void getBestStatementsEmpty() {
+		assertNull(
+				new StatementGroupImpl(Collections.singletonList(statementDeprecrated)).getBestStatements()
+
 		);
 	}
 


### PR DESCRIPTION
StatementGroup requires at least one statement, so calling
getBestStatements if there are no best statements previously would throw
a "non-empty list of statements must be provided" validation error.

--- 

Another solution may be to remove the assertation that statement groups cannot be empty. 
Then we could return an empty statement group instead of null.

Having no best statement can happen if there is only a deprecrated
statement in the statement group.