### PR TITLE
Two small fixes for PropertyRegister API fetcher

### DIFF
--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/PropertyRegister.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/PropertyRegister.java
@@ -331,11 +331,7 @@ public class PropertyRegister {
 		Map<String, EntityDocument> properties;
 		try {
 			properties = dataFetcher.getEntityDocuments(propertyIds);
-		} catch (MediaWikiApiErrorException e) {
-			logger.error("Error when trying to fetch property data: "
-					+ e.toString());
-			properties = Collections.emptyMap();
-		} catch (IOException e) {
+		} catch (MediaWikiApiErrorException|IOException e) {
 			logger.error("Error when trying to fetch property data: "
 					+ e.toString());
 			properties = Collections.emptyMap();
@@ -353,7 +349,7 @@ public class PropertyRegister {
 			logger.info("Fetched type information for property "
 					+ entry.getKey() + " online: " + datatype);
 
-			if (!DatatypeIdValue.DT_STRING.equals(datatype)) {
+			if (!DatatypeIdValue.DT_STRING.equals(datatype) && !DatatypeIdValue.DT_EXTERNAL_ID.equals(datatype)) {
 				continue;
 			}
 

--- a/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/PropertyRegisterTest.java
+++ b/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/PropertyRegisterTest.java
@@ -190,10 +190,13 @@ public class PropertyRegisterTest {
 	@Test
 	public void testGetMissingPropertyType() {
 		assertNull(this.propertyRegister.getPropertyType(dataObjectFactory
-				.getPropertyIdValue("P10", this.siteIri)));
+				.getPropertyIdValue("P10000", this.siteIri)));
+		final int smallestBefore = this.propertyRegister.smallestUnfetchedPropertyIdNumber;
 		// Check twice to test fast failing on retry
 		assertNull(this.propertyRegister.getPropertyType(dataObjectFactory
-				.getPropertyIdValue("P10", this.siteIri)));
+				.getPropertyIdValue("P10000", this.siteIri)));
+		assertEquals("no requests should be made if the property is known to be missing",
+				smallestBefore, this.propertyRegister.smallestUnfetchedPropertyIdNumber);
 	}
 
 	@Test


### PR DESCRIPTION
This PR fixes two small issues with the current property type fetching code:

* we now fetch the URI pattern for ExternalIDs as well, previously we only tried to fetch it if the property has type String.
* we keep track of properties that are missing, in order to avoid unnecessary requests

The second point is especially relevant if combined with #434, since without that fix a single missing property can potentially cause a lot of API requests to be made (all properties below the missing ID will need to be fetched until `smallestUnfetchedPropertyIdNumber` is large enough to include the missing property id)