### PR TITLE
Enable change of entity id in document builders.

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/EntityDocumentBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/EntityDocumentBuilder.java
@@ -47,7 +47,7 @@ import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocument;
 public abstract class EntityDocumentBuilder<T extends EntityDocumentBuilder<T, O>, O extends TermedStatementDocument>
 		extends AbstractDataObjectBuilder<T, O> {
 
-	final EntityIdValue entityIdValue;
+	EntityIdValue entityIdValue;
 	final ArrayList<MonolingualTextValue> labels = new ArrayList<>();
 	final ArrayList<MonolingualTextValue> descriptions = new ArrayList<>();
 	final ArrayList<MonolingualTextValue> aliases = new ArrayList<>();
@@ -96,6 +96,19 @@ public abstract class EntityDocumentBuilder<T extends EntityDocumentBuilder<T, O
 	 */
 	public T withRevisionId(long revisionId) {
 		this.revisionId = revisionId;
+		return getThis();
+	}
+	
+	/**
+	 * Changes the entity value id for the constructed document.
+	 * See {@link EntityDocument#getEntityId()}.
+	 * 
+	 * @param entityId
+	 *          the entity id
+	 * @return builder object to continue construction
+	 */
+	public T withEntityId(EntityIdValue entityId) {
+		this.entityIdValue = entityId;
 		return getThis();
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ItemDocumentBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ItemDocumentBuilder.java
@@ -23,6 +23,8 @@ package org.wikidata.wdtk.datamodel.helpers;
 import java.util.Arrays;
 import java.util.HashMap;
 
+import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
+import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
@@ -122,6 +124,22 @@ public class ItemDocumentBuilder extends
 			ItemIdValue... badges) {
 		withSiteLink(factory.getSiteLink(title, siteKey, Arrays.asList(badges)));
 		return this;
+	}
+	
+	/**
+	 * Changes the entity value id for the constructed document.
+	 * See {@link EntityDocument#getEntityId()}.
+	 * 
+	 * @param entityId
+	 *          the entity id, which must be an ItemIdValue
+	 * @return builder object to continue construction
+	 */
+	@Override
+	public ItemDocumentBuilder withEntityId(EntityIdValue entityId) {
+		if (!(entityId instanceof ItemIdValue)) {
+			throw new IllegalArgumentException("The entity id of an ItemDocument must be an ItemIdValue.");
+		}
+		return super.withEntityId(entityId);
 	}
 
 	@Override

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/PropertyDocumentBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/PropertyDocumentBuilder.java
@@ -21,6 +21,8 @@ package org.wikidata.wdtk.datamodel.helpers;
  */
 
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
+import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
@@ -102,6 +104,22 @@ public class PropertyDocumentBuilder extends
 			PropertyIdValue propertyIdValue, String datatypeId) {
 		return forPropertyIdAndDatatype(propertyIdValue,
 				factory.getDatatypeIdValue(datatypeId));
+	}
+	
+	/**
+	 * Changes the entity value id for the constructed document.
+	 * See {@link EntityDocument#getEntityId()}.
+	 * 
+	 * @param entityId
+	 *          the entity id, which must be an ItemIdValue
+	 * @return builder object to continue construction
+	 */
+	@Override
+	public PropertyDocumentBuilder withEntityId(EntityIdValue entityId) {
+		if (!(entityId instanceof PropertyIdValue)) {
+			throw new IllegalArgumentException("The entity id of a PropertyDocument must be an PropertyIdValue.");
+		}
+		return super.withEntityId(entityId);
 	}
 
 	/**

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/ItemDocumentBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/ItemDocumentBuilderTest.java
@@ -30,6 +30,7 @@ import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
@@ -117,6 +118,26 @@ public class ItemDocumentBuilderTest {
 		
 		ItemDocument withAlias = ItemDocumentBuilder.fromItemDocument(initial).withAlias(alias3).build();
 		assertEquals(withAlias.getAliases().get("fr"), Arrays.asList(alias1, alias2, alias3));
+	}
+	
+	@Test
+	public void testChangeOfSubjectId() {
+		MonolingualTextValue label = Datamodel.makeMonolingualTextValue("pleutre",
+				"fr");
+		ItemDocument initial = Datamodel.makeItemDocument(i,
+				Collections.singletonList(label), Collections.emptyList(), Collections.emptyList(),
+				Collections.singletonList(sg),
+				Collections.emptyMap(), 4567);
+		
+		ItemDocument copy = ItemDocumentBuilder.fromItemDocument(initial).withEntityId(ItemIdValue.NULL).build();
+		
+		assertEquals(ItemIdValue.NULL, copy.getEntityId());
+		assertEquals(label, copy.findLabel("fr"));
+	}
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidChangeOfSubjectId() {
+		ItemDocumentBuilder.forItemId(ItemIdValue.NULL).withRevisionId(1234).withEntityId(PropertyIdValue.NULL);
 	}
 
 	@Test(expected = IllegalStateException.class)

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/ItemDocumentBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/ItemDocumentBuilderTest.java
@@ -132,7 +132,7 @@ public class ItemDocumentBuilderTest {
 		ItemDocument copy = ItemDocumentBuilder.fromItemDocument(initial).withEntityId(ItemIdValue.NULL).build();
 		
 		assertEquals(ItemIdValue.NULL, copy.getEntityId());
-		assertEquals(label, copy.findLabel("fr"));
+		assertEquals("pleutre", copy.findLabel("fr"));
 	}
 	
 	@Test(expected = IllegalArgumentException.class)

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/PropertyDocumentBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/PropertyDocumentBuilderTest.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
@@ -73,5 +74,10 @@ public class PropertyDocumentBuilderTest {
 		
 		PropertyDocument withAlias = PropertyDocumentBuilder.fromPropertyDocument(initial).withAlias(alias).build();
 		assertEquals(withAlias.getAliases().get("en"), Collections.singletonList(alias));
+	}
+	
+	@Test(expected = IllegalArgumentException.class)
+	public void testInvalidSubjectId() {
+		PropertyDocumentBuilder.forPropertyIdAndDatatype(PropertyIdValue.NULL, DatatypeIdValue.DT_EXTERNAL_ID).withEntityId(ItemIdValue.NULL);
 	}
 }


### PR DESCRIPTION
Closes #440.

For typing reasons it is easier to introduce the modifying methods on Builder objects instead of the original documents.