### PR TITLE
Improvements to export of RDF time values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
 		<mockitoVersion>1.10.19</mockitoVersion>
 		<rdf4jVersion>2.5.2</rdf4jVersion>
 		<slf4jVersion>1.7.26</slf4jVersion>
+		<threetenVersion>1.5.0</threetenVersion>
 	</properties>
 
 	<dependencies>

--- a/wdtk-datamodel/pom.xml
+++ b/wdtk-datamodel/pom.xml
@@ -41,6 +41,11 @@
 			<artifactId>jackson-databind</artifactId>
 			<version>${jacksonVersion}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.threeten</groupId>
+			<artifactId>threeten-extra</artifactId>
+			<version>${threetenVersion}</version>
+		</dependency>
 	</dependencies>
 	
 	<build>

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TimeValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TimeValueImpl.java
@@ -34,6 +34,7 @@ import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.TimeValue;
 import org.wikidata.wdtk.datamodel.interfaces.ValueVisitor;
 
+import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.util.Optional;
 
@@ -222,14 +223,18 @@ public class TimeValueImpl extends ValueImpl implements TimeValue {
 				&& this.getPrecision() >= TimeValue.PREC_DAY
 				&& this.value.year > Integer.MIN_VALUE && this.value.year < Integer.MAX_VALUE
 		) {
-			final JulianDate julian = JulianDate.of((int) this.value.year, this.value.month, this.value.day);
-			final LocalDate date = LocalDate.from(julian);
-			return Optional.of(new TimeValueImpl(
-					date.getYear(), (byte)date.getMonth().getValue(), (byte)date.getDayOfMonth(),
-					this.value.hour, this.value.minute, this.value.second,
-					(byte)this.value.precision, this.value.before, this.value.after,
-					this.value.timezone, TimeValue.CM_GREGORIAN_PRO
-			));
+			try {
+				final JulianDate julian = JulianDate.of((int) this.value.year, this.value.month, this.value.day);
+				final LocalDate date = LocalDate.from(julian);
+				return Optional.of(new TimeValueImpl(
+						date.getYear(), (byte) date.getMonth().getValue(), (byte) date.getDayOfMonth(),
+						this.value.hour, this.value.minute, this.value.second,
+						(byte) this.value.precision, this.value.before, this.value.after,
+						this.value.timezone, TimeValue.CM_GREGORIAN_PRO
+				));
+			} catch(DateTimeException e) {
+				return Optional.empty();
+			}
 
 		}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TimeValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TimeValueImpl.java
@@ -20,7 +20,13 @@ package org.wikidata.wdtk.datamodel.implementation;
  * #L%
  */
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import org.apache.commons.lang3.Validate;
+import org.threeten.extra.chrono.JulianDate;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;
@@ -28,11 +34,8 @@ import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.TimeValue;
 import org.wikidata.wdtk.datamodel.interfaces.ValueVisitor;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.time.LocalDate;
+import java.util.Optional;
 
 /**
  * Jackson implementation of {@link TimeValue}.
@@ -205,6 +208,32 @@ public class TimeValueImpl extends ValueImpl implements TimeValue {
 	@Override
 	public String toString() {
 		return ToString.toString(this);
+	}
+
+	@Override
+	public Optional<TimeValue> toGregorian() {
+		// already in Gregorian calendar
+		if (this.getPreferredCalendarModel().equals(TimeValue.CM_GREGORIAN_PRO)) {
+			return Optional.of(this);
+		}
+
+		// convert Julian
+		if (this.getPreferredCalendarModel().equals(TimeValue.CM_JULIAN_PRO)
+				&& this.getPrecision() >= TimeValue.PREC_DAY
+				&& this.value.year > Integer.MIN_VALUE && this.value.year < Integer.MAX_VALUE
+		) {
+			final JulianDate julian = JulianDate.of((int) this.value.year, this.value.month, this.value.day);
+			final LocalDate date = LocalDate.from(julian);
+			return Optional.of(new TimeValueImpl(
+					date.getYear(), (byte)date.getMonth().getValue(), (byte)date.getDayOfMonth(),
+					this.value.hour, this.value.minute, this.value.second,
+					(byte)this.value.precision, this.value.before, this.value.after,
+					this.value.timezone, TimeValue.CM_GREGORIAN_PRO
+			));
+
+		}
+
+		return Optional.empty();
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/TimeValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/TimeValue.java
@@ -20,6 +20,8 @@ package org.wikidata.wdtk.datamodel.interfaces;
  * #L%
  */
 
+import java.util.Optional;
+
 /**
  * Time values represent points and intervals in time, and additional
  * information about their format. Information includes a specific time point,
@@ -278,5 +280,14 @@ public interface TimeValue extends Value {
 	 *         precision
 	 */
 	int getAfterTolerance();
+
+	/**
+	 * Convert the value to the Gregorian calendar, if possible.
+	 * This conversion can fail if not enough information is available
+	 * (for example, we need at least day precision to convert from Julian to Gregorian).
+	 *
+	 * @return a TimeValue that uses the Gregorian calendar, or {@ref Optional::empty} if the conversion failed.
+	 */
+	Optional<TimeValue> toGregorian();
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TimeValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TimeValueImplTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.TimeValue;
 
 import java.io.IOException;
+import java.util.NoSuchElementException;
 
 public class TimeValueImplTest {
 
@@ -149,6 +150,25 @@ public class TimeValueImplTest {
 	@Test
 	public void testToJava() throws IOException {
 		assertEquals(t1, mapper.readValue(JSON_TIME_VALUE, ValueImpl.class));
+	}
+
+	@Test
+	public void testJulianToGregorian() {
+		final TimeValue tJulian = new TimeValueImpl(1143, (byte)10, (byte) 5, (byte) 1, (byte) 2,
+				(byte) 0, TimeValue.PREC_MINUTE, 0, 1, 0,
+				TimeValue.CM_JULIAN_PRO);
+		final TimeValue gregorian = tJulian.toGregorian().orElseThrow(NoSuchElementException::new);
+		assertEquals(1143, gregorian.getYear());
+		assertEquals(10, gregorian.getMonth());
+		assertEquals(12, gregorian.getDay());
+		assertEquals(1, gregorian.getHour());
+		assertEquals(2, gregorian.getMinute());
+		assertEquals(0, gregorian.getSecond());
+		assertEquals(TimeValue.PREC_MINUTE, gregorian.getPrecision());
+		assertEquals(0, gregorian.getBeforeTolerance());
+		assertEquals(1, gregorian.getAfterTolerance());
+		assertEquals(0, gregorian.getTimezoneOffset());
+		assertEquals(TimeValue.CM_GREGORIAN_PRO, gregorian.getPreferredCalendarModel());
 	}
 
 }

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/Vocabulary.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/Vocabulary.java
@@ -554,6 +554,7 @@ public class Vocabulary {
 		md.update(value.getHour());
 		md.update(value.getMinute());
 		md.update(value.getSecond());
+		md.update(value.getPrecision());
 		updateMessageDigestWithString(md, value.getPreferredCalendarModel());
 		updateMessageDigestWithInt(md, value.getBeforeTolerance());
 		updateMessageDigestWithInt(md, value.getAfterTolerance());

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/values/TimeValueConverter.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/values/TimeValueConverter.java
@@ -33,6 +33,8 @@ import org.wikidata.wdtk.rdf.PropertyRegister;
 import org.wikidata.wdtk.rdf.RdfWriter;
 import org.wikidata.wdtk.rdf.Vocabulary;
 
+import java.time.Month;
+
 public class TimeValueConverter extends BufferedValueConverter<TimeValue> {
 
 	public TimeValueConverter(RdfWriter rdfWriter,
@@ -133,7 +135,7 @@ public class TimeValueConverter extends BufferedValueConverter<TimeValue> {
 			yearZero = true;
 		}
 
-		// map negative dates from ISO 8601 to XSD 1.1
+		// map negative dates from historical numbering to XSD 1.1
 		if (year < 0 && value.getPrecision() >= TimeValue.PREC_YEAR) {
 			year++;
 		}
@@ -151,14 +153,9 @@ public class TimeValueConverter extends BufferedValueConverter<TimeValue> {
 
 		if (value.getPrecision() >= TimeValue.PREC_DAY && !yearZero) {
 			int maxDays = Byte.MAX_VALUE;
-			if (month == 2) {
-				maxDays = 29;
-			} else if (month <= 12) {
-				if (month % 2 == 1 && month <= 7 || month % 2 == 0 && month >= 8) {
-					maxDays = 31;
-				} else {
-					maxDays = 30;
-				}
+			if (month > 0 && month < 13) {
+				boolean leap =  (year % 4L) == 0L && (year % 100L != 0L || year % 400L == 0L);
+				maxDays = Month.of(month).length(leap);
 			}
 			if (day > maxDays) {
 				day = (byte)maxDays;

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/values/TimeValueConverter.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/values/TimeValueConverter.java
@@ -115,13 +115,41 @@ public class TimeValueConverter extends BufferedValueConverter<TimeValue> {
 
 		long year = value.getYear();
 
-		//Year normalization
+		//Year, month and day normalization
 		if (year == 0 || (year < 0 && value.getPrecision() >= TimeValue.PREC_YEAR)) {
 			year--;
 		}
 
-		String timestamp = String.format("%04d-%02d-%02dT%02d:%02d:%02dZ",
-				year, value.getMonth(), value.getDay(),
+		byte month = value.getMonth();
+		byte day = value.getDay();
+
+		if (value.getPrecision() < TimeValue.PREC_MONTH || month == 0) {
+			month = 1;
+		}
+
+		if (value.getPrecision() < TimeValue.PREC_DAY || day == 0) {
+			day = 1;
+		}
+
+		if (value.getPrecision() >= TimeValue.PREC_DAY) {
+			int maxDays = Byte.MAX_VALUE;
+			if (month == 2) {
+				maxDays = 29;
+			} else if (month <= 12) {
+				if (month % 2 == 1 && month <= 7 || month % 2 == 0 && month >= 8) {
+					maxDays = 31;
+				} else {
+					maxDays = 30;
+				}
+			}
+			if (day > maxDays) {
+				day = (byte)maxDays;
+			}
+		}
+
+		String minus = year < 0 ? "-" : "";
+		String timestamp = String.format("%s%04d-%02d-%02dT%02d:%02d:%02dZ",
+				minus, Math.abs(year), month, day,
 				value.getHour(), value.getMinute(), value.getSecond());
 		return rdfWriter.getLiteral(timestamp, RdfWriter.XSD_DATETIME);
 	}

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/values/TimeValueConverter.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/values/TimeValueConverter.java
@@ -111,6 +111,8 @@ public class TimeValueConverter extends BufferedValueConverter<TimeValue> {
 	 * @return the RDF literal
 	 */
 	private static Literal getTimeLiteral(TimeValue value, RdfWriter rdfWriter) {
+		value = value.toGregorian().orElse(value);
+
 		long year = value.getYear();
 
 		//Year normalization

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/values/TimeValueConverter.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/values/TimeValueConverter.java
@@ -128,13 +128,6 @@ public class TimeValueConverter extends BufferedValueConverter<TimeValue> {
 		  and astronomical year numbering, where the year 1 BCE is represented as +0000 and the year 44 BCE
 		  is represented as -0043.
 		*/
-
-		boolean yearZero = false;
-		// year zero is undefined
-		if (year == 0) {
-			yearZero = true;
-		}
-
 		// map negative dates from historical numbering to XSD 1.1
 		if (year < 0 && value.getPrecision() >= TimeValue.PREC_YEAR) {
 			year++;
@@ -151,7 +144,7 @@ public class TimeValueConverter extends BufferedValueConverter<TimeValue> {
 			day = 1;
 		}
 
-		if (value.getPrecision() >= TimeValue.PREC_DAY && !yearZero) {
+		if (value.getPrecision() >= TimeValue.PREC_DAY && year != 0) {
 			int maxDays = Byte.MAX_VALUE;
 			if (month > 0 && month < 13) {
 				boolean leap =  (year % 4L) == 0L && (year % 100L != 0L || year % 400L == 0L);
@@ -166,7 +159,7 @@ public class TimeValueConverter extends BufferedValueConverter<TimeValue> {
 		String timestamp = String.format("%s%04d-%02d-%02dT%02d:%02d:%02dZ",
 				minus, Math.abs(year), month, day,
 				value.getHour(), value.getMinute(), value.getSecond());
-		if (yearZero) {
+		if (year == 0) {
 			return rdfWriter.getLiteral("+" + timestamp);
 		}
 		return rdfWriter.getLiteral(timestamp, RdfWriter.XSD_DATETIME);

--- a/wdtk-rdf/src/test/resources/ItemDocument.rdf
+++ b/wdtk-rdf/src/test/resources/ItemDocument.rdf
@@ -11,9 +11,9 @@
 	<http://wikiba.se/ontology#rank> <http://wikiba.se/ontology#NormalRank> .
 
 <http://www.wikidata.org/entity/statement/Q10-none2> a <http://wikiba.se/ontology#Statement> , <http://wikiba.se/ontology#BestRank> ;
-	<http://www.wikidata.org/prop/statement/value/P569> <http://www.wikidata.org/value/ec11d94e4f5bb7b00a79196734f49066> ;
+	<http://www.wikidata.org/prop/statement/value/P569> <http://www.wikidata.org/value/9e335050c59079e3f3c216b8cf077d07> ;
 	<http://www.wikidata.org/prop/statement/P569> "0306-11-03T13:07:06Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-	<http://www.wikidata.org/prop/qualifier/value/P15> <http://www.wikidata.org/value/ec11d94e4f5bb7b00a79196734f49066> ;
+	<http://www.wikidata.org/prop/qualifier/value/P15> <http://www.wikidata.org/value/9e335050c59079e3f3c216b8cf077d07> ;
 	<http://www.wikidata.org/prop/qualifier/P15> "0306-11-03T13:07:06Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 	<http://www.w3.org/ns/prov#wasDerivedFrom> <http://www.wikidata.org/reference/29b7008efe33a96335e456305edfb481> ;
 	<http://wikiba.se/ontology#rank> <http://wikiba.se/ontology#NormalRank> .
@@ -22,7 +22,7 @@
 	<http://www.wikidata.org/prop/statement/P549> "TestString" ;
 	<http://wikiba.se/ontology#rank> <http://wikiba.se/ontology#NormalRank> .
 
-<http://www.wikidata.org/value/ec11d94e4f5bb7b00a79196734f49066> a <http://wikiba.se/ontology#TimeValue> ;
+<http://www.wikidata.org/value/9e335050c59079e3f3c216b8cf077d07> a <http://wikiba.se/ontology#TimeValue> ;
 	<http://wikiba.se/ontology#timeValue> "0306-11-03T13:07:06Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 	<http://wikiba.se/ontology#timePrecision> "32"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	<http://wikiba.se/ontology#timeTimezone> "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -145,4 +145,4 @@ _:node1a5d5pvl8x8 a <http://www.w3.org/2002/07/owl#Restriction> ;
 <http://www.wikidata.org/prop/reference/P549> a <http://www.w3.org/2002/07/owl#DatatypeProperty> .
 
 <http://www.wikidata.org/reference/29b7008efe33a96335e456305edfb481> a <http://wikiba.se/ontology#Reference> ;
-	<http://www.wikidata.org/prop/reference/value/P112> <http://www.wikidata.org/value/ec11d94e4f5bb7b00a79196734f49066> .
+	<http://www.wikidata.org/prop/reference/value/P112> <http://www.wikidata.org/value/9e335050c59079e3f3c216b8cf077d07> .

--- a/wdtk-rdf/src/test/resources/ItemDocumentUnknownPropertyTypes.rdf
+++ b/wdtk-rdf/src/test/resources/ItemDocumentUnknownPropertyTypes.rdf
@@ -11,9 +11,9 @@
 	<http://wikiba.se/ontology#rank> <http://wikiba.se/ontology#NormalRank> .
 
 <http://www.wikidata.org/entity/statement/Q10-none2> a <http://wikiba.se/ontology#Statement> , <http://wikiba.se/ontology#BestRank> ;
-	<http://www.wikidata.org/prop/statement/value/P569> <http://www.wikidata.org/value/ec11d94e4f5bb7b00a79196734f49066> ;
+	<http://www.wikidata.org/prop/statement/value/P569> <http://www.wikidata.org/value/9e335050c59079e3f3c216b8cf077d07> ;
 	<http://www.wikidata.org/prop/statement/P569> "0306-11-03T13:07:06Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
-	<http://www.wikidata.org/prop/qualifier/value/P15> <http://www.wikidata.org/value/ec11d94e4f5bb7b00a79196734f49066> ;
+	<http://www.wikidata.org/prop/qualifier/value/P15> <http://www.wikidata.org/value/9e335050c59079e3f3c216b8cf077d07> ;
 	<http://www.wikidata.org/prop/qualifier/P15> "0306-11-03T13:07:06Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 	<http://www.w3.org/ns/prov#wasDerivedFrom> <http://www.wikidata.org/reference/29b7008efe33a96335e456305edfb481> ;
 	<http://wikiba.se/ontology#rank> <http://wikiba.se/ontology#NormalRank> .
@@ -22,7 +22,7 @@
 	<http://www.wikidata.org/prop/statement/P549> "TestString" ;
 	<http://wikiba.se/ontology#rank> <http://wikiba.se/ontology#NormalRank> .
 
-<http://www.wikidata.org/value/ec11d94e4f5bb7b00a79196734f49066> a <http://wikiba.se/ontology#TimeValue> ;
+<http://www.wikidata.org/value/9e335050c59079e3f3c216b8cf077d07> a <http://wikiba.se/ontology#TimeValue> ;
 	<http://wikiba.se/ontology#timeValue> "0306-11-03T13:07:06Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 	<http://wikiba.se/ontology#timePrecision> "32"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	<http://wikiba.se/ontology#timeTimezone> "0"^^<http://www.w3.org/2001/XMLSchema#int> ;
@@ -113,4 +113,4 @@ _:node1c3irgg7cx14 a <http://www.w3.org/2002/07/owl#Restriction> ;
 <http://www.wikidata.org/prop/reference/P549> a <http://www.w3.org/2002/07/owl#DatatypeProperty> .
 
 <http://www.wikidata.org/reference/29b7008efe33a96335e456305edfb481> a <http://wikiba.se/ontology#Reference> ;
-	<http://www.wikidata.org/prop/reference/value/P112> <http://www.wikidata.org/value/ec11d94e4f5bb7b00a79196734f49066> .
+	<http://www.wikidata.org/prop/reference/value/P112> <http://www.wikidata.org/value/9e335050c59079e3f3c216b8cf077d07> .

--- a/wdtk-rdf/src/test/resources/TimeValue.rdf
+++ b/wdtk-rdf/src/test/resources/TimeValue.rdf
@@ -1,5 +1,5 @@
 
-<http://www.wikidata.org/value/916df1a6567186e91bd43adc424eeec0> a <http://wikiba.se/ontology#TimeValue> ;
+<http://www.wikidata.org/value/c0d63bd8e4e71569494de00985d094c2> a <http://wikiba.se/ontology#TimeValue> ;
 	<http://wikiba.se/ontology#timeValue> "2008-01-01T00:00:00Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 	<http://wikiba.se/ontology#timePrecision> "9"^^<http://www.w3.org/2001/XMLSchema#int> ;
 	<http://wikiba.se/ontology#timeTimezone> "0"^^<http://www.w3.org/2001/XMLSchema#int> ;

--- a/wdtk-rdf/src/test/resources/completeRDFDocument.rdf
+++ b/wdtk-rdf/src/test/resources/completeRDFDocument.rdf
@@ -99,9 +99,9 @@ wikibase:badge a owl:ObjectProperty .
 	wikibase:rank wikibase:NormalRank .
 
 <http://www.wikidata.org/entity/statement/Q10-none2> a wikibase:Statement , <http://wikiba.se/ontology#BestRank> ;
-	<http://www.wikidata.org/prop/statement/value/P569> wdv:ec11d94e4f5bb7b00a79196734f49066 ;
+	<http://www.wikidata.org/prop/statement/value/P569> wdv:9e335050c59079e3f3c216b8cf077d07 ;
 	<http://www.wikidata.org/prop/statement/P569> "0306-11-03T13:07:06Z"^^xsd:dateTime ;
-	<http://www.wikidata.org/prop/qualifier/value/P15> wdv:ec11d94e4f5bb7b00a79196734f49066 ;
+	<http://www.wikidata.org/prop/qualifier/value/P15> wdv:9e335050c59079e3f3c216b8cf077d07 ;
 	<http://www.wikidata.org/prop/qualifier/P15> "0306-11-03T13:07:06Z"^^xsd:dateTime ;
 	prov:wasDerivedFrom <http://www.wikidata.org/reference/29b7008efe33a96335e456305edfb481> ;
 	wikibase:rank wikibase:NormalRank .
@@ -110,7 +110,7 @@ wikibase:badge a owl:ObjectProperty .
 	<http://www.wikidata.org/prop/statement/P549> "TestString" ;
 	wikibase:rank wikibase:NormalRank .
 
-wdv:ec11d94e4f5bb7b00a79196734f49066 a wikibase:TimeValue ;
+wdv:9e335050c59079e3f3c216b8cf077d07 a wikibase:TimeValue ;
 	wikibase:timeValue "0306-11-03T13:07:06Z"^^xsd:dateTime ;
 	wikibase:timePrecision "32"^^xsd:int ;
 	wikibase:timeTimezone "0"^^xsd:int ;
@@ -173,7 +173,7 @@ wdv:ec11d94e4f5bb7b00a79196734f49066 a wikibase:TimeValue ;
 <http://www.wikidata.org/prop/reference/P549> a owl:DatatypeProperty .
 
 <http://www.wikidata.org/reference/29b7008efe33a96335e456305edfb481> a wikibase:Reference ;
-	<http://www.wikidata.org/prop/reference/value/P112> wdv:ec11d94e4f5bb7b00a79196734f49066 .
+	<http://www.wikidata.org/prop/reference/value/P112> wdv:9e335050c59079e3f3c216b8cf077d07 .
 	
 <http://www.wikidata.org/prop/novalue/P10> a owl:Class ;
 	owl:complementOf _:node1a5d6h9m9x1 .


### PR DESCRIPTION
I've recently looked a bit at differences between WIkidata-Toolkit's RDF generation and the data in the Wikidata RDF dumps. I noticed quite a few differences in how dates are treated, which this PR removes. 

One issue that's not part of this PR yet is handling of year 0, as I still need to look into how that works exactly. Also the year adjustment for years < 0 is unclear to me, I found that most often I had to add one instead of subtract one to get the year that wikidata has in its dumps (I will change that when I have looked into that difference more throughly). 