### PR TITLE
RDF: improve decimal and coordinate value export

### DIFF
--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/values/GlobeCoordinatesValueConverter.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/values/GlobeCoordinatesValueConverter.java
@@ -105,9 +105,9 @@ public class GlobeCoordinatesValueConverter extends
 					.append("> ");
 		}
 		builder.append("Point(");
-		builder.append(value.getLatitude());
-		builder.append(" ");
 		builder.append(value.getLongitude());
+		builder.append(" ");
+		builder.append(value.getLatitude());
 		builder.append(")");
 		return this.rdfWriter.getLiteral(builder.toString(),
 				RdfWriter.OGC_LOCATION);

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/values/QuantityValueConverter.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/values/QuantityValueConverter.java
@@ -52,7 +52,7 @@ public class QuantityValueConverter extends
 			if (simple) {
 				this.rdfConversionBuffer.addDatatypeProperty(propertyIdValue);
 				return this.rdfWriter.getLiteral(value.getNumericValue()
-						.toString(), RdfWriter.XSD_DECIMAL);
+						.toPlainString(), RdfWriter.XSD_DECIMAL);
 			} else {
 				IRI valueUri = this.rdfWriter.getUri(Vocabulary.getQuantityValueUri(value));
 
@@ -73,16 +73,16 @@ public class QuantityValueConverter extends
 		this.rdfWriter.writeTripleValueObject(resource, RdfWriter.RDF_TYPE,
 				RdfWriter.WB_QUANTITY_VALUE);
 		this.rdfWriter.writeTripleLiteralObject(resource,
-				RdfWriter.WB_QUANTITY_AMOUNT, value.getNumericValue().toString(),
+				RdfWriter.WB_QUANTITY_AMOUNT, value.getNumericValue().toPlainString(),
 				RdfWriter.XSD_DECIMAL);
 		if(value.getLowerBound() != null) {
 			this.rdfWriter.writeTripleLiteralObject(resource,
-					RdfWriter.WB_QUANTITY_LOWER_BOUND, value.getLowerBound().toString(),
+					RdfWriter.WB_QUANTITY_LOWER_BOUND, value.getLowerBound().toPlainString(),
 					RdfWriter.XSD_DECIMAL);
 		}
 		if(value.getUpperBound() != null) {
 			this.rdfWriter.writeTripleLiteralObject(resource,
-					RdfWriter.WB_QUANTITY_UPPER_BOUND, value.getUpperBound().toString(),
+					RdfWriter.WB_QUANTITY_UPPER_BOUND, value.getUpperBound().toPlainString(),
 					RdfWriter.XSD_DECIMAL);
 		}
 		String unitIri = ("1".equals(value.getUnit()))

--- a/wdtk-rdf/src/test/resources/StatementCplx.rdf
+++ b/wdtk-rdf/src/test/resources/StatementCplx.rdf
@@ -1,5 +1,5 @@
 <http://localhost/entity/Q0> <http://www.wikidata.org/prop/P0> <http://www.wikidata.org/entity/statement/Q0-> .
 <http://www.wikidata.org/entity/statement/Q0-> a <http://wikiba.se/ontology#Statement> ;
 	<http://www.wikidata.org/prop/statement/value/P0> <http://www.wikidata.org/value/ffc4e2c3e1979c0dd53184be282bd01c> ;
-	<http://www.wikidata.org/prop/statement/P0> "Point(51.0 13.0)"^^<http://www.opengis.net/ont/geosparql#wktLiteral> ;
+	<http://www.wikidata.org/prop/statement/P0> "Point(13.0 51.0)"^^<http://www.opengis.net/ont/geosparql#wktLiteral> ;
 	<http://wikiba.se/ontology#rank> <http://wikiba.se/ontology#NormalRank> .


### PR DESCRIPTION
Coordinates in the RDF produced by Wikidata for CoordinateValues are in the wrong order, according to the spec. The Wikidata RDF dump has them in the correct order. Fixing this is of course backwards incompatible, but there seems to be no other way. Or do we want to differ from the spec forever?

For decimals, we previously generated scientific notation in some cases, which is not permissible for `xsd:decimal`.