### PR TITLE
Rdf schema updates

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ReferenceImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ReferenceImpl.java
@@ -20,10 +20,7 @@ package org.wikidata.wdtk.datamodel.implementation;
  * #L%
  */
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.*;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;
@@ -57,6 +54,12 @@ public class ReferenceImpl implements Reference {
 	 * which is not specified by the map.
 	 */
 	private final List<String> propertyOrder;
+
+	/**
+	 * The wikidata hash of this reference. Empty string if we don't have knowledge about the hash.fs
+	 */
+	@JsonInclude(JsonInclude.Include.NON_EMPTY)
+	private final String hash;
 	
 	/**
 	 * Constructor.
@@ -75,6 +78,8 @@ public class ReferenceImpl implements Reference {
 			propertyOrder.add(group.getProperty().getId());
 			snaks.put(group.getProperty().getId(), group.getSnaks());
 		}
+
+		hash = "";
 	}
 	
 	/**
@@ -83,12 +88,15 @@ public class ReferenceImpl implements Reference {
 	@JsonCreator
 	protected ReferenceImpl(
 			@JsonProperty("snaks") Map<String, List<SnakImpl>> snaks,
-			@JsonProperty("snaks-order") List<String> propertyOrder) {
+			@JsonProperty("snaks-order") List<String> propertyOrder,
+			@JsonProperty(value = "hash", defaultValue = "") String hash) {
+
 		this.snaks = new HashMap<>(snaks.size());
 		for(Map.Entry<String, List<SnakImpl>> entry : snaks.entrySet()) {
 			this.snaks.put(entry.getKey(), new ArrayList<>(entry.getValue()));
 		}
 		this.propertyOrder = propertyOrder;
+		this.hash = hash;
 	}
 
 	@JsonIgnore
@@ -110,6 +118,11 @@ public class ReferenceImpl implements Reference {
 	@JsonProperty("snaks")
 	public Map<String, List<Snak>> getSnaks() {
 		return Collections.unmodifiableMap(this.snaks);
+	}
+
+	@Override
+	public String getHash() {
+		return hash;
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ReferenceImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ReferenceImpl.java
@@ -56,7 +56,7 @@ public class ReferenceImpl implements Reference {
 	private final List<String> propertyOrder;
 
 	/**
-	 * The wikidata hash of this reference. Empty string if we don't have knowledge about the hash.fs
+	 * The wikidata hash of this reference. null if we don't have knowledge about the hash.
 	 */
 	private final String hash;
 	
@@ -72,13 +72,12 @@ public class ReferenceImpl implements Reference {
 	public ReferenceImpl(List<SnakGroup> groups) {
 		propertyOrder = new ArrayList<>(groups.size());
 		snaks = new HashMap<>(groups.size());
+		hash = null;
 
 		for(SnakGroup group : groups) {
 			propertyOrder.add(group.getProperty().getId());
 			snaks.put(group.getProperty().getId(), group.getSnaks());
 		}
-
-		hash = null;
 	}
 	
 	/**
@@ -88,7 +87,7 @@ public class ReferenceImpl implements Reference {
 	protected ReferenceImpl(
 			@JsonProperty("snaks") Map<String, List<SnakImpl>> snaks,
 			@JsonProperty("snaks-order") List<String> propertyOrder,
-			@JsonProperty(value = "hash") String hash) {
+			@JsonProperty("hash") String hash) {
 
 		this.snaks = new HashMap<>(snaks.size());
 		for(Map.Entry<String, List<SnakImpl>> entry : snaks.entrySet()) {

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ReferenceImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ReferenceImpl.java
@@ -58,7 +58,6 @@ public class ReferenceImpl implements Reference {
 	/**
 	 * The wikidata hash of this reference. Empty string if we don't have knowledge about the hash.fs
 	 */
-	@JsonInclude(JsonInclude.Include.NON_EMPTY)
 	private final String hash;
 	
 	/**
@@ -79,7 +78,7 @@ public class ReferenceImpl implements Reference {
 			snaks.put(group.getProperty().getId(), group.getSnaks());
 		}
 
-		hash = "";
+		hash = null;
 	}
 	
 	/**
@@ -89,7 +88,7 @@ public class ReferenceImpl implements Reference {
 	protected ReferenceImpl(
 			@JsonProperty("snaks") Map<String, List<SnakImpl>> snaks,
 			@JsonProperty("snaks-order") List<String> propertyOrder,
-			@JsonProperty(value = "hash", defaultValue = "") String hash) {
+			@JsonProperty(value = "hash") String hash) {
 
 		this.snaks = new HashMap<>(snaks.size());
 		for(Map.Entry<String, List<SnakImpl>> entry : snaks.entrySet()) {
@@ -121,6 +120,7 @@ public class ReferenceImpl implements Reference {
 	}
 
 	@Override
+	@JsonInclude(JsonInclude.Include.NON_NULL)
 	public String getHash() {
 		return hash;
 	}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/Reference.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/Reference.java
@@ -55,7 +55,7 @@ public interface Reference {
 	 * Since the calculation is hard to reproduce, this is only available if the reference was read
 	 * from a dump that contains the hash.
 	 *
-	 * @return the hash of the reference, if available, otherwise empty string.
+	 * @return the hash of the reference, if available, otherwise null.
 	 */
 	String getHash();
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/Reference.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/Reference.java
@@ -50,7 +50,7 @@ public interface Reference {
 	Iterator<Snak> getAllSnaks();
 
 	/**
-	 * Wikidata calculates a hash for each reference based on the content of the reference.
+	 * Wikibase calculates a hash for each reference based on the content of the reference.
 	 * This hash appears in the RDF serialization of the reference.
 	 * Since the calculation is hard to reproduce, this is only available if the reference was read
 	 * from a dump that contains the hash.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/Reference.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/Reference.java
@@ -48,4 +48,14 @@ public interface Reference {
 	 * @return iterator of snaks
 	 */
 	Iterator<Snak> getAllSnaks();
+
+	/**
+	 * Wikidata calculates a hash for each reference based on the content of the reference.
+	 * This hash appears in the RDF serialization of the reference.
+	 * Since the calculation is hard to reproduce, this is only available if the reference was read
+	 * from a dump that contains the hash.
+	 *
+	 * @return the hash of the reference, if available, otherwise empty string.
+	 */
+	String getHash();
 }

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/AbstractRdfConverter.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/AbstractRdfConverter.java
@@ -219,10 +219,6 @@ abstract public class AbstractRdfConverter {
 				.getUri(Vocabulary.WB_NO_VALUE_PROP), Vocabulary
 				.getPropertyUri(document.getEntityId(),
 						PropertyContext.NO_VALUE));
-		this.rdfWriter.writeTripleUriObject(subject, this.rdfWriter
-				.getUri(Vocabulary.WB_NO_QUALIFIER_VALUE_PROP), Vocabulary
-				.getPropertyUri(document.getEntityId(),
-						PropertyContext.NO_QUALIFIER_VALUE));
 		// TODO something more with NO_VALUE
 	}
 

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/OwlDeclarationBuffer.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/OwlDeclarationBuffer.java
@@ -145,10 +145,6 @@ public class OwlDeclarationBuffer {
 				writeNoValueRestriction(rdfWriter, propertyIdValue.getIri(),
 						Vocabulary.OWL_THING, Vocabulary.getPropertyUri(
 								propertyIdValue, PropertyContext.NO_VALUE));
-				writeNoValueRestriction(rdfWriter, propertyIdValue.getIri(),
-						Vocabulary.OWL_THING, Vocabulary.getPropertyUri(
-								propertyIdValue,
-								PropertyContext.NO_QUALIFIER_VALUE));
 			}
 			if (fullStatements) {
 				rdfWriter.writeTripleValueObject(Vocabulary.getPropertyUri(
@@ -189,10 +185,6 @@ public class OwlDeclarationBuffer {
 				writeNoValueRestriction(rdfWriter, propertyIdValue.getIri(),
 						Vocabulary.XSD_STRING, Vocabulary.getPropertyUri(
 								propertyIdValue, PropertyContext.NO_VALUE));
-				writeNoValueRestriction(rdfWriter, propertyIdValue.getIri(),
-						Vocabulary.XSD_STRING, Vocabulary.getPropertyUri(
-								propertyIdValue,
-								PropertyContext.NO_QUALIFIER_VALUE));
 			}
 			if (fullStatements) {
 				rdfWriter.writeTripleValueObject(Vocabulary.getPropertyUri(

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/ReferenceRdfConverter.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/ReferenceRdfConverter.java
@@ -115,6 +115,10 @@ public class ReferenceRdfConverter {
 			for (Snak snak : snakGroup) {
 				snak.accept(this.snakRdfConverter);
 			}
+			this.snakRdfConverter.setSnakContext(resource, PropertyContext.REFERENCE_SIMPLE);
+			for (Snak snak : snakGroup) {
+				snak.accept(this.snakRdfConverter);
+			}
 		}
 	}
 }

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/SnakRdfConverter.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/SnakRdfConverter.java
@@ -173,13 +173,17 @@ public class SnakRdfConverter implements SnakVisitor<Void> {
 			return null;
 		}
 
+		// SomeValueSnaks only have simple values not full values
+		if (this.currentPropertyContext == PropertyContext.VALUE || this.currentPropertyContext == PropertyContext.QUALIFIER || this.currentPropertyContext == PropertyContext.REFERENCE) {
+			return null;
+		}
+
 		String propertyUri = Vocabulary.getPropertyUri(snak.getPropertyId(),
 				this.currentPropertyContext);
 		Resource bnode = this.rdfWriter.getFreshBNode();
-		addSomeValuesRestriction(bnode, propertyUri, rangeUri);
 		try {
 			this.rdfWriter.writeTripleValueObject(this.currentSubject,
-					RdfWriter.RDF_TYPE, bnode);
+					this.rdfWriter.getUri(propertyUri), bnode);
 		} catch (RDFHandlerException e) {
 			throw new RuntimeException(e.toString(), e);
 		}

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/Vocabulary.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/Vocabulary.java
@@ -544,12 +544,6 @@ public class Vocabulary {
 		}
 
 		md.reset();
-		ArrayList<Integer> hashes = new ArrayList<>();
-		for (SnakGroup snakgroup : reference.getSnakGroups()) {
-			for (Snak snak : snakgroup) {
-				hashes.add(snak.hashCode());
-			}
-		}
 		reference.getSnakGroups().stream()
 				.flatMap(g -> g.getSnaks().stream())
 				.map(Objects::hashCode)

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/Vocabulary.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/Vocabulary.java
@@ -65,7 +65,7 @@ public class Vocabulary {
 
 	public static final String PREFIX_WIKIDATA_NO_VALUE = "http://www.wikidata.org/prop/novalue/";
 
-	public static final String PREFIX_WIKIDATA_NO_QUALIFIER_VALUE = "http://www.wikidata.org/prop/noqualifiervalue/";
+	public static final String PREFIX_WIKIDATA_NO_QUALIFIER_VALUE = PREFIX_WIKIDATA_NO_VALUE;
 
 	public static final String PREFIX_WIKIDATA_VALUE = "http://www.wikidata.org/value/";
 
@@ -224,7 +224,7 @@ public class Vocabulary {
 	 * Class for Wikibase globe coordinates values.
 	 */
 	public static final String WB_GLOBE_COORDINATES_VALUE = PREFIX_WBONTO
-			+ "GlobeCoordinatesValue";
+			+ "GlobecoordinateValue";
 	static {
 		VOCABULARY_TYPES.put(WB_GLOBE_COORDINATES_VALUE, OWL_CLASS);
 	}
@@ -467,8 +467,7 @@ public class Vocabulary {
 	 * Property for connecting Wikibase property entities to their no-value
 	 * classes for qualifiers.
 	 */
-	public static final String WB_NO_QUALIFIER_VALUE_PROP = PREFIX_WBONTO
-			+ "noqualifiervalue";
+	public static final String WB_NO_QUALIFIER_VALUE_PROP = WB_NO_VALUE_PROP;
 	static {
 		VOCABULARY_TYPES.put(WB_NO_QUALIFIER_VALUE_PROP, OWL_OBJECT_PROPERTY);
 	}

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/Vocabulary.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/Vocabulary.java
@@ -27,6 +27,8 @@ import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
 import org.wikidata.wdtk.datamodel.interfaces.*;
+import org.wikidata.wdtk.wikibaseapi.GuidGenerator;
+import org.wikidata.wdtk.wikibaseapi.RandomGuidGenerator;
 
 /**
  * This class contains static methods and constants that define the various OWL
@@ -46,6 +48,8 @@ public class Vocabulary {
 					"Your Java does not support MD5 hashes. You should be concerned.");
 		}
 	}
+
+	private final static GuidGenerator GUID_GENERATOR = new RandomGuidGenerator();
 
 	// Prefixes
 	public static final String PREFIX_WIKIDATA_STATEMENT = "http://www.wikidata.org/entity/statement/";
@@ -489,11 +493,11 @@ public class Vocabulary {
 	 * @return the URI
 	 */
 	public static String getStatementUri(Statement statement) {
-		int i = statement.getStatementId().indexOf('$') + 1;
-		final String id = i <= 0 ? statement.getSubject().getId() : statement.getStatementId().substring(0, i-1);
-		return PREFIX_WIKIDATA_STATEMENT
-				+ id + "-"
-				+ statement.getStatementId().substring(i);
+		String statementId = statement.getStatementId();
+		if (statementId == null || statementId.isEmpty()) {
+			statementId = GUID_GENERATOR.freshStatementId(statement.getSubject().getId());
+		}
+		return PREFIX_WIKIDATA_STATEMENT + statementId.replaceFirst("\\$", "-");
 	}
 
 	/**

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/Vocabulary.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/Vocabulary.java
@@ -493,8 +493,9 @@ public class Vocabulary {
 	 */
 	public static String getStatementUri(Statement statement) {
 		int i = statement.getStatementId().indexOf('$') + 1;
+		final String id = i <= 0 ? statement.getSubject().getId() : statement.getStatementId().substring(0, i-1);
 		return PREFIX_WIKIDATA_STATEMENT
-				+ statement.getSubject().getId() + "-"
+				+ id + "-"
 				+ statement.getStatementId().substring(i);
 	}
 

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/Vocabulary.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/Vocabulary.java
@@ -24,9 +24,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 import org.wikidata.wdtk.datamodel.interfaces.*;
 
@@ -538,11 +536,17 @@ public class Vocabulary {
 
 	public static String getReferenceUri(Reference reference) {
 		md.reset();
+		ArrayList<Integer> hashes = new ArrayList<>();
 		for (SnakGroup snakgroup : reference.getSnakGroups()) {
 			for (Snak snak : snakgroup) {
-				updateMessageDigestWithInt(md, snak.hashCode());
+				hashes.add(snak.hashCode());
 			}
 		}
+		reference.getSnakGroups().stream()
+				.flatMap(g -> g.getSnaks().stream())
+				.map(Objects::hashCode)
+				.sorted()
+				.forEach(i -> updateMessageDigestWithInt(md, i));
 
 		return PREFIX_WIKIDATA_REFERENCE + bytesToHex(md.digest());
 	}

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/Vocabulary.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/Vocabulary.java
@@ -535,6 +535,11 @@ public class Vocabulary {
 	}
 
 	public static String getReferenceUri(Reference reference) {
+		final String hash = reference.getHash();
+		if (!hash.isEmpty()) {
+			return PREFIX_WIKIDATA_REFERENCE + hash;
+		}
+
 		md.reset();
 		ArrayList<Integer> hashes = new ArrayList<>();
 		for (SnakGroup snakgroup : reference.getSnakGroups()) {

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/Vocabulary.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/Vocabulary.java
@@ -535,7 +535,7 @@ public class Vocabulary {
 
 	public static String getReferenceUri(Reference reference) {
 		final String hash = reference.getHash();
-		if (!hash.isEmpty()) {
+		if (hash != null) {
 			return PREFIX_WIKIDATA_REFERENCE + hash;
 		}
 

--- a/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/RdfConverterTest.java
+++ b/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/RdfConverterTest.java
@@ -149,7 +149,7 @@ public class RdfConverterTest {
 	@Test
 	public void testStatementSimpleValue() throws RDFHandlerException,
 			RDFParseException, IOException {
-		Statement statement = objectFactory.createStatement("Q100", "P227");
+		Statement statement = objectFactory.createStatement("Q100", "P227").withStatementId("Q100-id111");
 		this.rdfConverter.writeFullStatement(statement, false);
 		this.rdfWriter.finish();
 		Model model = RdfTestHelpers.parseRdf(this.out.toString());
@@ -165,6 +165,7 @@ public class RdfConverterTest {
 				GlobeCoordinatesValue.GLOBE_EARTH);
 		Statement statement = StatementBuilder
 				.forSubjectAndProperty(ItemIdValue.NULL, PropertyIdValue.NULL)
+				.withId("Q0$test")
 				.withValue(value).build();
 		this.rdfConverter.writeFullStatement(statement, false);
 		this.rdfWriter.finish();
@@ -179,6 +180,7 @@ public class RdfConverterTest {
 		PropertyIdValue pid = dataObjectFactory.getPropertyIdValue("P31", "http://www.wikidata.org/");
 		Statement statement = StatementBuilder
 				.forSubjectAndProperty(ItemIdValue.NULL, pid)
+				.withId("Q0$test")
 				.withNoValue().build();
 		this.rdfConverter.writeFullStatement(statement, false);
 		this.rdfWriter.finish();

--- a/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/TestObjectFactory.java
+++ b/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/TestObjectFactory.java
@@ -154,14 +154,14 @@ public class TestObjectFactory {
 						baseIri)), Collections.<SnakGroup> emptyList());
 		statements1.add(factory.getStatement(claim1,
 				Collections.<Reference> emptyList(), StatementRank.NORMAL,
-				"none"));
+				"Q10$none"));
 		statementGroups.add(factory.getStatementGroup(statements1));
 
 		List<Statement> statements2 = new ArrayList<Statement>();
 		Claim claim2 = factory.getClaim(factory.getItemIdValue("Q10", baseIri),
 				createValueSnakTimeValue("P569"), createQualifiers());
 		statements2.add(factory.getStatement(claim2, createReferences(),
-				StatementRank.NORMAL, "none2"));
+				StatementRank.NORMAL, "Q10$none2"));
 		statementGroups.add(factory.getStatementGroup(statements2));
 		List<Statement> statements3 = new ArrayList<Statement>();
 		Claim claim3 = factory.getClaim(factory.getItemIdValue("Q10", baseIri),
@@ -169,7 +169,7 @@ public class TestObjectFactory {
 				Collections.<SnakGroup> emptyList());
 		statements3.add(factory.getStatement(claim3,
 				Collections.<Reference> emptyList(), StatementRank.NORMAL,
-				"none3"));
+				"Q10$none3"));
 		statementGroups.add(factory.getStatementGroup(statements3));
 		return factory.getItemDocument(factory.getItemIdValue("Q10", baseIri),
 				createLabels(), createDescriptions(), createAliases(),

--- a/wdtk-rdf/src/test/resources/BasicDeclarations.rdf
+++ b/wdtk-rdf/src/test/resources/BasicDeclarations.rdf
@@ -33,7 +33,7 @@
 
 <http://wikiba.se/ontology#Reference> a <http://www.w3.org/2002/07/owl#Class> .
 
-<http://wikiba.se/ontology#GlobeCoordinatesValue> a <http://www.w3.org/2002/07/owl#Class> .
+<http://wikiba.se/ontology#GlobecoordinateValue> a <http://www.w3.org/2002/07/owl#Class> .
 
 <http://wikiba.se/ontology#TimeValue> a <http://www.w3.org/2002/07/owl#Class> .
 
@@ -68,8 +68,6 @@
 <http://wikiba.se/ontology#referenceValue> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://wikiba.se/ontology#novalue> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://wikiba.se/ontology#noqualifiervalue> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://wikiba.se/ontology#rank> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
 

--- a/wdtk-rdf/src/test/resources/EmptyPropertyDocument.rdf
+++ b/wdtk-rdf/src/test/resources/EmptyPropertyDocument.rdf
@@ -9,5 +9,4 @@
 	<http://wikiba.se/ontology#qualifierValue> <http://www.wikidata.org/prop/qualifier/value/P1> ;
 	<http://wikiba.se/ontology#reference> <http://www.wikidata.org/prop/reference/P1> ;
 	<http://wikiba.se/ontology#referenceValue> <http://www.wikidata.org/prop/reference/value/P1> ;
-	<http://wikiba.se/ontology#novalue> <http://www.wikidata.org/prop/novalue/P1>;
-	<http://wikiba.se/ontology#noqualifiervalue> <http://www.wikidata.org/prop/noqualifiervalue/P1> .
+	<http://wikiba.se/ontology#novalue> <http://www.wikidata.org/prop/novalue/P1> .

--- a/wdtk-rdf/src/test/resources/GlobeCoordinatesValue.rdf
+++ b/wdtk-rdf/src/test/resources/GlobeCoordinatesValue.rdf
@@ -1,5 +1,5 @@
 
-<http://www.wikidata.org/value/29def5bc38867d9750430b4f14949f22> a <http://wikiba.se/ontology#GlobeCoordinatesValue> ;
+<http://www.wikidata.org/value/29def5bc38867d9750430b4f14949f22> a <http://wikiba.se/ontology#GlobecoordinateValue> ;
 	<http://wikiba.se/ontology#geoLatitude> "5.1033333333333E1"^^<http://www.w3.org/2001/XMLSchema#double> ;
 	<http://wikiba.se/ontology#geoLongitude> "1.3733333333333E1"^^<http://www.w3.org/2001/XMLSchema#double> ;
 	<http://wikiba.se/ontology#geoPrecision> "1.0E-1"^^<http://www.w3.org/2001/XMLSchema#double> ;

--- a/wdtk-rdf/src/test/resources/InterPropertyLinks.rdf
+++ b/wdtk-rdf/src/test/resources/InterPropertyLinks.rdf
@@ -16,5 +16,3 @@
 <http://www.wikidata.org/P17> <http://wikiba.se/ontology#referenceValue> <http://www.wikidata.org/prop/reference/value/P17> .
 
 <http://www.wikidata.org/P17> <http://wikiba.se/ontology#novalue> <http://www.wikidata.org/prop/novalue/P17> .
-
-<http://www.wikidata.org/P17> <http://wikiba.se/ontology#noqualifiervalue> <http://www.wikidata.org/prop/noqualifiervalue/P17> .

--- a/wdtk-rdf/src/test/resources/ItemDocument.rdf
+++ b/wdtk-rdf/src/test/resources/ItemDocument.rdf
@@ -35,13 +35,6 @@ _:node1a5d5pvl8x1 a <http://www.w3.org/2002/07/owl#Restriction> ;
 	<http://www.w3.org/2002/07/owl#onProperty> <http://www.wikidata.org/P10> ;
 	<http://www.w3.org/2002/07/owl#someValuesFrom> <http://www.w3.org/2002/07/owl#Thing> .
 
-<http://www.wikidata.org/prop/noqualifiervalue/P10> a <http://www.w3.org/2002/07/owl#Class> ;
-	<http://www.w3.org/2002/07/owl#complementOf> _:node1a5d5pvl8x2 .
-
-_:node1a5d5pvl8x2 a <http://www.w3.org/2002/07/owl#Restriction> ;
-	<http://www.w3.org/2002/07/owl#onProperty> <http://www.wikidata.org/P10> ;
-	<http://www.w3.org/2002/07/owl#someValuesFrom> <http://www.w3.org/2002/07/owl#Thing> .
-
 <http://www.wikidata.org/prop/novalue/P569> a <http://www.w3.org/2002/07/owl#Class> ;
 	<http://www.w3.org/2002/07/owl#complementOf> _:node1a5d5pvl8x3 .
 
@@ -49,24 +42,10 @@ _:node1a5d5pvl8x3 a <http://www.w3.org/2002/07/owl#Restriction> ;
 	<http://www.w3.org/2002/07/owl#onProperty> <http://www.wikidata.org/P569> ;
 	<http://www.w3.org/2002/07/owl#someValuesFrom> <http://www.w3.org/2002/07/owl#Thing> .
 
-<http://www.wikidata.org/prop/noqualifiervalue/P569> a <http://www.w3.org/2002/07/owl#Class> ;
-	<http://www.w3.org/2002/07/owl#complementOf> _:node1a5d5pvl8x4 .
-
-_:node1a5d5pvl8x4 a <http://www.w3.org/2002/07/owl#Restriction> ;
-	<http://www.w3.org/2002/07/owl#onProperty> <http://www.wikidata.org/P569> ;
-	<http://www.w3.org/2002/07/owl#someValuesFrom> <http://www.w3.org/2002/07/owl#Thing> .
-	
 <http://www.wikidata.org/prop/novalue/P15> a <http://www.w3.org/2002/07/owl#Class> ;
 	<http://www.w3.org/2002/07/owl#complementOf> _:node1a5d5pvl8x5 .
 
 _:node1a5d5pvl8x5 a <http://www.w3.org/2002/07/owl#Restriction> ;
-	<http://www.w3.org/2002/07/owl#onProperty> <http://www.wikidata.org/P15> ;
-	<http://www.w3.org/2002/07/owl#someValuesFrom> <http://www.w3.org/2002/07/owl#Thing> .
-
-<http://www.wikidata.org/prop/noqualifiervalue/P15> a <http://www.w3.org/2002/07/owl#Class> ;
-	<http://www.w3.org/2002/07/owl#complementOf> _:node1a5d5pvl8x6 .
-
-_:node1a5d5pvl8x6 a <http://www.w3.org/2002/07/owl#Restriction> ;
 	<http://www.w3.org/2002/07/owl#onProperty> <http://www.wikidata.org/P15> ;
 	<http://www.w3.org/2002/07/owl#someValuesFrom> <http://www.w3.org/2002/07/owl#Thing> .
 	
@@ -74,13 +53,6 @@ _:node1a5d5pvl8x6 a <http://www.w3.org/2002/07/owl#Restriction> ;
 	<http://www.w3.org/2002/07/owl#complementOf> _:node1a5d5pvl8x7 .
 
 _:node1a5d5pvl8x7 a <http://www.w3.org/2002/07/owl#Restriction> ;
-	<http://www.w3.org/2002/07/owl#onProperty> <http://www.wikidata.org/P549> ;
-	<http://www.w3.org/2002/07/owl#someValuesFrom> <http://www.w3.org/2001/XMLSchema#string> .
-
-<http://www.wikidata.org/prop/noqualifiervalue/P549> a <http://www.w3.org/2002/07/owl#Class> ;
-	<http://www.w3.org/2002/07/owl#complementOf> _:node1a5d5pvl8x8 .
-
-_:node1a5d5pvl8x8 a <http://www.w3.org/2002/07/owl#Restriction> ;
 	<http://www.w3.org/2002/07/owl#onProperty> <http://www.wikidata.org/P549> ;
 	<http://www.w3.org/2002/07/owl#someValuesFrom> <http://www.w3.org/2001/XMLSchema#string> .
 
@@ -127,8 +99,6 @@ _:node1a5d5pvl8x8 a <http://www.w3.org/2002/07/owl#Restriction> ;
 <http://www.wikidata.org/prop/qualifier/P15> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://www.wikidata.org/prop/reference/P15> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://www.wikidata.org/prop/noqualifiervalue/P10> a <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.wikidata.org/prop/P549> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
 

--- a/wdtk-rdf/src/test/resources/ItemDocument.rdf
+++ b/wdtk-rdf/src/test/resources/ItemDocument.rdf
@@ -115,4 +115,5 @@ _:node1a5d5pvl8x7 a <http://www.w3.org/2002/07/owl#Restriction> ;
 <http://www.wikidata.org/prop/reference/P549> a <http://www.w3.org/2002/07/owl#DatatypeProperty> .
 
 <http://www.wikidata.org/reference/29b7008efe33a96335e456305edfb481> a <http://wikiba.se/ontology#Reference> ;
+    <http://www.wikidata.org/prop/reference/P112> "0306-11-03T13:07:06Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 	<http://www.wikidata.org/prop/reference/value/P112> <http://www.wikidata.org/value/9e335050c59079e3f3c216b8cf077d07> .

--- a/wdtk-rdf/src/test/resources/ItemDocumentUnknownPropertyTypes.rdf
+++ b/wdtk-rdf/src/test/resources/ItemDocumentUnknownPropertyTypes.rdf
@@ -92,4 +92,5 @@ _:node1c3irgg7cx13 a <http://www.w3.org/2002/07/owl#Restriction> ;
 <http://www.wikidata.org/prop/reference/P549> a <http://www.w3.org/2002/07/owl#DatatypeProperty> .
 
 <http://www.wikidata.org/reference/29b7008efe33a96335e456305edfb481> a <http://wikiba.se/ontology#Reference> ;
+    <http://www.wikidata.org/prop/reference/P112> "0306-11-03T13:07:06Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 	<http://www.wikidata.org/prop/reference/value/P112> <http://www.wikidata.org/value/9e335050c59079e3f3c216b8cf077d07> .

--- a/wdtk-rdf/src/test/resources/ItemDocumentUnknownPropertyTypes.rdf
+++ b/wdtk-rdf/src/test/resources/ItemDocumentUnknownPropertyTypes.rdf
@@ -35,13 +35,6 @@ _:node1c3irgg7cx9 a <http://www.w3.org/2002/07/owl#Restriction> ;
 	<http://www.w3.org/2002/07/owl#onProperty> <http://www.wikidata.org/P569> ;
 	<http://www.w3.org/2002/07/owl#someValuesFrom> <http://www.w3.org/2002/07/owl#Thing> .
 
-<http://www.wikidata.org/prop/noqualifiervalue/P569> a <http://www.w3.org/2002/07/owl#Class> ;
-	<http://www.w3.org/2002/07/owl#complementOf> _:node1c3irgg7cx10 .
-
-_:node1c3irgg7cx10 a <http://www.w3.org/2002/07/owl#Restriction> ;
-	<http://www.w3.org/2002/07/owl#onProperty> <http://www.wikidata.org/P569> ;
-	<http://www.w3.org/2002/07/owl#someValuesFrom> <http://www.w3.org/2002/07/owl#Thing> .
-
 <http://www.wikidata.org/prop/P569> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://www.wikidata.org/prop/statement/P569> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -63,13 +56,6 @@ _:node1c3irgg7cx11 a <http://www.w3.org/2002/07/owl#Restriction> ;
 	<http://www.w3.org/2002/07/owl#onProperty> <http://www.wikidata.org/P15> ;
 	<http://www.w3.org/2002/07/owl#someValuesFrom> <http://www.w3.org/2002/07/owl#Thing> .
 
-<http://www.wikidata.org/prop/noqualifiervalue/P15> a <http://www.w3.org/2002/07/owl#Class> ;
-	<http://www.w3.org/2002/07/owl#complementOf> _:node1c3irgg7cx12 .
-
-_:node1c3irgg7cx12 a <http://www.w3.org/2002/07/owl#Restriction> ;
-	<http://www.w3.org/2002/07/owl#onProperty> <http://www.wikidata.org/P15> ;
-	<http://www.w3.org/2002/07/owl#someValuesFrom> <http://www.w3.org/2002/07/owl#Thing> .
-
 <http://www.wikidata.org/prop/P15> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://www.wikidata.org/prop/statement/P15> a <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -88,13 +74,6 @@ _:node1c3irgg7cx12 a <http://www.w3.org/2002/07/owl#Restriction> ;
 	<http://www.w3.org/2002/07/owl#complementOf> _:node1c3irgg7cx13 .
 
 _:node1c3irgg7cx13 a <http://www.w3.org/2002/07/owl#Restriction> ;
-	<http://www.w3.org/2002/07/owl#onProperty> <http://www.wikidata.org/P549> ;
-	<http://www.w3.org/2002/07/owl#someValuesFrom> <http://www.w3.org/2001/XMLSchema#string> .
-
-<http://www.wikidata.org/prop/noqualifiervalue/P549> a <http://www.w3.org/2002/07/owl#Class> ;
-	<http://www.w3.org/2002/07/owl#complementOf> _:node1c3irgg7cx14 .
-
-_:node1c3irgg7cx14 a <http://www.w3.org/2002/07/owl#Restriction> ;
 	<http://www.w3.org/2002/07/owl#onProperty> <http://www.wikidata.org/P549> ;
 	<http://www.w3.org/2002/07/owl#someValuesFrom> <http://www.w3.org/2001/XMLSchema#string> .
 

--- a/wdtk-rdf/src/test/resources/StatementCplx.rdf
+++ b/wdtk-rdf/src/test/resources/StatementCplx.rdf
@@ -1,5 +1,5 @@
-<http://localhost/entity/Q0> <http://www.wikidata.org/prop/P0> <http://www.wikidata.org/entity/statement/Q0-> .
-<http://www.wikidata.org/entity/statement/Q0-> a <http://wikiba.se/ontology#Statement> ;
+<http://localhost/entity/Q0> <http://www.wikidata.org/prop/P0> <http://www.wikidata.org/entity/statement/Q0-test> .
+<http://www.wikidata.org/entity/statement/Q0-test> a <http://wikiba.se/ontology#Statement> ;
 	<http://www.wikidata.org/prop/statement/value/P0> <http://www.wikidata.org/value/ffc4e2c3e1979c0dd53184be282bd01c> ;
 	<http://www.wikidata.org/prop/statement/P0> "Point(13.0 51.0)"^^<http://www.opengis.net/ont/geosparql#wktLiteral> ;
 	<http://wikiba.se/ontology#rank> <http://wikiba.se/ontology#NormalRank> .

--- a/wdtk-rdf/src/test/resources/StatementNoValue.rdf
+++ b/wdtk-rdf/src/test/resources/StatementNoValue.rdf
@@ -1,3 +1,3 @@
-<http://localhost/entity/Q0> <http://www.wikidata.org/prop/P31> <http://www.wikidata.org/entity/statement/Q0-> .
-<http://www.wikidata.org/entity/statement/Q0-> a <http://wikiba.se/ontology#Statement> , <http://www.wikidata.org/prop/novalue/P31> ;
+<http://localhost/entity/Q0> <http://www.wikidata.org/prop/P31> <http://www.wikidata.org/entity/statement/Q0-test> .
+<http://www.wikidata.org/entity/statement/Q0-test> a <http://wikiba.se/ontology#Statement> , <http://www.wikidata.org/prop/novalue/P31> ;
 	<http://wikiba.se/ontology#rank> <http://wikiba.se/ontology#NormalRank> .

--- a/wdtk-rdf/src/test/resources/completeRDFDocument.rdf
+++ b/wdtk-rdf/src/test/resources/completeRDFDocument.rdf
@@ -171,6 +171,7 @@ wdv:9e335050c59079e3f3c216b8cf077d07 a wikibase:TimeValue ;
 <http://www.wikidata.org/prop/reference/P549> a owl:DatatypeProperty .
 
 <http://www.wikidata.org/reference/29b7008efe33a96335e456305edfb481> a wikibase:Reference ;
+    <http://www.wikidata.org/prop/reference/P112> "0306-11-03T13:07:06Z"^^<http://www.w3.org/2001/XMLSchema#dateTime> ;
 	<http://www.wikidata.org/prop/reference/value/P112> wdv:9e335050c59079e3f3c216b8cf077d07 .
 	
 <http://www.wikidata.org/prop/novalue/P10> a owl:Class ;

--- a/wdtk-rdf/src/test/resources/completeRDFDocument.rdf
+++ b/wdtk-rdf/src/test/resources/completeRDFDocument.rdf
@@ -49,7 +49,7 @@ wikibase:geoPrecision a owl:DatatypeProperty .
 
 wikibase:geoLongitude a owl:DatatypeProperty .
 
-wikibase:GlobeCoordinatesValue a owl:Class .
+wikibase:GlobecoordinateValue a owl:Class .
 
 wikibase:Reference a owl:Class .
 
@@ -60,8 +60,6 @@ wikibase:referenceValue a owl:ObjectProperty .
 schema:description a owl:DatatypeProperty .
 
 schema:Article a owl:Class .
-
-wikibase:noqualifiervalue a owl:ObjectProperty .
 
 wikibase:novalue a owl:ObjectProperty .
 
@@ -182,24 +180,10 @@ _:node1a5d6h9m9x1 a owl:Restriction ;
 	owl:onProperty <http://www.wikidata.org/P10> ;
 	owl:someValuesFrom owl:Thing .
 
-<http://www.wikidata.org/prop/noqualifiervalue/P10> a owl:Class ;
-	owl:complementOf _:node1a5d6h9m9x2 .
-
-_:node1a5d6h9m9x2 a owl:Restriction ;
-	owl:onProperty <http://www.wikidata.org/P10> ;
-	owl:someValuesFrom owl:Thing .
-
 <http://www.wikidata.org/prop/novalue/P569> a owl:Class ;
 	owl:complementOf _:node1a5d6h9m9x3 .
 
 _:node1a5d6h9m9x3 a owl:Restriction ;
-	owl:onProperty <http://www.wikidata.org/P569> ;
-	owl:someValuesFrom owl:Thing .
-
-<http://www.wikidata.org/prop/noqualifiervalue/P569> a owl:Class ;
-	owl:complementOf _:node1a5d6h9m9x4 .
-
-_:node1a5d6h9m9x4 a owl:Restriction ;
 	owl:onProperty <http://www.wikidata.org/P569> ;
 	owl:someValuesFrom owl:Thing .
 
@@ -210,23 +194,9 @@ _:node1a5d6h9m9x5 a owl:Restriction ;
 	owl:onProperty <http://www.wikidata.org/P15> ;
 	owl:someValuesFrom owl:Thing .
 
-<http://www.wikidata.org/prop/noqualifiervalue/P15> a owl:Class ;
-	owl:complementOf _:node1a5d6h9m9x6 .
-
-_:node1a5d6h9m9x6 a owl:Restriction ;
-	owl:onProperty <http://www.wikidata.org/P15> ;
-	owl:someValuesFrom owl:Thing .
-
 <http://www.wikidata.org/prop/novalue/P549> a owl:Class ;
 	owl:complementOf _:node1a5d6h9m9x7 .
 
 _:node1a5d6h9m9x7 a owl:Restriction ;
-	owl:onProperty <http://www.wikidata.org/P549> ;
-	owl:someValuesFrom xsd:string .
-
-<http://www.wikidata.org/prop/noqualifiervalue/P549> a owl:Class ;
-	owl:complementOf _:node1a5d6h9m9x8 .
-
-_:node1a5d6h9m9x8 a owl:Restriction ;
 	owl:onProperty <http://www.wikidata.org/P549> ;
 	owl:someValuesFrom xsd:string .

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/RandomGuidGenerator.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/RandomGuidGenerator.java
@@ -43,10 +43,6 @@ public class RandomGuidGenerator implements GuidGenerator {
 	@Override
 	public String freshStatementId(String entityId) {
 		String uuid = UUID.randomUUID().toString().toUpperCase();
-		StringBuilder builder = new StringBuilder();
-		builder.append(entityId);
-		builder.append(STATEMENT_GUID_SEPARATOR);
-		builder.append(uuid);
-		return builder.toString();
+		return entityId + STATEMENT_GUID_SEPARATOR + uuid;
 	}
 }


### PR DESCRIPTION
Improved version of PR #444 bhy @bennofs 

This PR includes a few small changes that make the Wikidata RDF export more similar to what's in the dumps.

Some of these changes are backwards-incompatible, such as the change to how SomeValue claims are exported or the IRI changes. Not sure how we want to deal with that.

The statement id / reference hash changes are not strictly necessary, but also simple and it's nice if the subject IRIs match the full dumps.