### PR TITLE
Simplifies Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,15 @@
 language: java
 dist: xenial
+sudo: false
 jdk:
   - openjdk8
-  - oraclejdk8
-  - oraclejdk9
-  - oraclejdk11
+  - openjdk11
 
 script:
   - mvn test jacoco:report
 
 after_success:
   - mvn coveralls:report
-
-dist: trusty
-sudo: false
 
 cache:
   directories:


### PR DESCRIPTION
Tests on OpenJDK 8 and 11 (the OpenJDK LTS releases).

Avoids to rely on Oracle JDK distribution