### PR TITLE
Adds methods to easily create new forms and senses

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Datamodel.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Datamodel.java
@@ -805,6 +805,9 @@ public class Datamodel {
 	/**
 	 * Creates an {@link FormDocument}.
 	 *
+	 * If you plan to add this form to a specific lexeme,
+	 * it might be easier to use {@link LexemeDocument#createForm}.
+	 *
 	 * @param formIdValue
 	 *            the id of the form that data is about
 	 * @param representations
@@ -826,6 +829,9 @@ public class Datamodel {
 
 	/**
 	 * Creates an {@link SenseDocument}.
+	 *
+	 * If you plan to add this sense to a specific lexeme,
+	 * it might be easier to use {@link LexemeDocument#createSense)}.
 	 *
 	 * @param senseIdValue
 	 *            the id of the form that data is about

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/LexemeDocument.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/LexemeDocument.java
@@ -127,4 +127,31 @@ public interface LexemeDocument extends StatementDocument {
 	 */
 	@Override
 	LexemeDocument withoutStatementIds(Set<String> statementIds);
+
+	/**
+	 * Creates a new {@link FormDocument} for this lexeme.
+	 * The form is not added to the {@link LexemeDocument} object,
+	 * it should be done with {@link LexemeDocument#withForm}.
+	 */
+	FormDocument createForm(List<MonolingualTextValue> representations);
+
+	/**
+	 * Adds a {@link FormDocument} to this lexeme.
+	 * The form id should be prefixed with the lexeme id.
+	 */
+	LexemeDocument withForm(FormDocument form);
+
+	/**
+	 * Creates a new {@link SenseDocument} for this Lexeme.
+	 * The form is not added to the {@link LexemeDocument} object,
+	 * it should be done with {@link LexemeDocument#withSense}.
+	 */
+	SenseDocument createSense(List<MonolingualTextValue> glosses);
+
+	/**
+	 * Adds a {@link SenseDocument} to this lexeme.
+	 * The sense id should be prefixed with the lexeme id.
+	 */
+	LexemeDocument withSense(SenseDocument sense);
+
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeDocumentImplTest.java
@@ -23,6 +23,7 @@ package org.wikidata.wdtk.datamodel.implementation;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.*;
 
@@ -212,6 +213,20 @@ public class LexemeDocumentImplTest {
 	}
 
 	@Test
+	public void testWithLexicalCategory() {
+		ItemIdValue newLexicalCategory = new ItemIdValueImpl("Q142", "http://example.com/entity/");
+		LexemeDocument withLexicalCategory = ld1.withLexicalCategory(newLexicalCategory);
+		assertEquals(newLexicalCategory, withLexicalCategory.getLexicalCategory());
+	}
+
+	@Test
+	public void testWithLanguage() {
+		ItemIdValue newLanguage = new ItemIdValueImpl("Q242", "http://example.com/entity/");
+		LexemeDocument withLanguage = ld1.withLanguage(newLanguage);
+		assertEquals(newLanguage, withLanguage.getLanguage());
+	}
+
+	@Test
 	public void testWithLemmaInNewLanguage() {
 		MonolingualTextValue newLemma = new MonolingualTextValueImpl("Foo", "fr");
 		LexemeDocument withLemma = ld1.withLemma(newLemma);
@@ -238,6 +253,40 @@ public class LexemeDocumentImplTest {
 		Statement toRemove = statementGroups.get(0).getStatements().get(0);
 		LexemeDocument withoutStatement = ld1.withoutStatementIds(Collections.singleton(toRemove.getStatementId()));
 		assertNotEquals(withoutStatement, ld1);
+	}
+
+	@Test
+	public void testWithForm() {
+		FormDocument newForm = ld1.createForm(Collections.singletonList(new TermImpl("en", "add1")));
+		assertEquals(lid, newForm.getEntityId().getLexemeId());
+		assertEquals(ld1.getForms().size() + 1, ld1.withForm(newForm).getForms().size());
+		assertEquals(newForm, ld1.withForm(newForm).getForm(newForm.getEntityId()));
+	}
+	@Test(expected = IllegalArgumentException.class)
+	public void testWithWrongFormId() {
+		ld1.withForm(Datamodel.makeFormDocument(
+				Datamodel.makeFormIdValue("L444-F32","http://example.com/entity/"),
+				Collections.singletonList(new TermImpl("en", "add1")),
+				Collections.emptyList(),
+				Collections.emptyList()
+		));
+	}
+
+	@Test
+	public void testWithSense() {
+		SenseDocument newSense = ld1.createSense(Collections.singletonList(new TermImpl("en", "add1")));
+		assertEquals(lid, newSense.getEntityId().getLexemeId());
+		assertEquals(ld1.getSenses().size() + 1, ld1.withSense(newSense).getSenses().size());
+		assertEquals(newSense, ld1.withSense(newSense).getSense(newSense.getEntityId()));
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testWithWrongSenseId() {
+		ld1.withSense(Datamodel.makeSenseDocument(
+				Datamodel.makeSenseIdValue("L444-S32","http://example.com/entity/"),
+				Collections.singletonList(new TermImpl("en", "add1")),
+				Collections.emptyList()
+		));
 	}
 
 	@Test


### PR DESCRIPTION
The `createForm` then `withForm` process is not very nice but a `withNewForm` method would require to return both the new form and the modified lexeme at the same time.