### PR TITLE
Throw IOException instead of returning null when fetching a token.

### DIFF
--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnectionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnectionTest.java
@@ -135,18 +135,18 @@ public class BasicApiConnectionTest {
 	}
 
 	@Test
-	public void testGetToken() throws LoginFailedException, IOException {
+	public void testGetToken() throws LoginFailedException, IOException, MediaWikiApiErrorException {
 		this.con.login("username", "password");
 		assertNotNull(this.con.getOrFetchToken("csrf"));
 	}
 
 	@Test(expected = IOException.class)
-	public void testGetTokenWithoutLogin() throws IOException {
+	public void testGetTokenWithoutLogin() throws IOException, MediaWikiApiErrorException {
 		this.con.getOrFetchToken("csrf");
 	}
 
 	@Test
-	public void testGetLoginToken() throws IOException {
+	public void testGetLoginToken() throws IOException, MediaWikiApiErrorException {
 		assertNotNull(this.con.getOrFetchToken("login"));
 	}
 
@@ -192,7 +192,7 @@ public class BasicApiConnectionTest {
 	}
 
 	@Test
-	public void testLogout() throws IOException, LoginFailedException {
+	public void testLogout() throws IOException, LoginFailedException, MediaWikiApiErrorException {
 		this.con.login("username", "password");
 		this.con.logout();
 		assertEquals("", this.con.username);
@@ -290,7 +290,7 @@ public class BasicApiConnectionTest {
 	}
 
 	@Test
-	public void testClearCookies() throws IOException {
+	public void testClearCookies() throws IOException, MediaWikiApiErrorException {
 		con.cookies.put("Content", "some content");
 		con.clearCookies();
 		assertTrue(con.cookies.keySet().isEmpty());

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnectionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnectionTest.java
@@ -135,18 +135,18 @@ public class BasicApiConnectionTest {
 	}
 
 	@Test
-	public void testGetToken() throws LoginFailedException {
+	public void testGetToken() throws LoginFailedException, IOException {
 		this.con.login("username", "password");
 		assertNotNull(this.con.getOrFetchToken("csrf"));
 	}
 
-	@Test
-	public void testGetTokenWithoutLogin() {
-		assertNull(this.con.getOrFetchToken("csrf"));
+	@Test(expected = IOException.class)
+	public void testGetTokenWithoutLogin() throws IOException {
+		this.con.getOrFetchToken("csrf");
 	}
 
 	@Test
-	public void testGetLoginToken() {
+	public void testGetLoginToken() throws IOException {
 		assertNotNull(this.con.getOrFetchToken("login"));
 	}
 

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WbEditingActionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WbEditingActionTest.java
@@ -85,6 +85,7 @@ public class WbEditingActionTest {
 		params.put("action", "query");
 		params.put("meta", "tokens");
 		params.put("format", "json");
+		params.put("type", "csrf");
 		// This error makes no sense for this action, but that does not matter
 		// here:
 		con.setWebResource(params, "{}");


### PR DESCRIPTION
Closes #460.

This does not affect external interfaces so it should not break anything for users.