### PR TITLE
wbSearchEntities expose IOException

### DIFF
--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesAction.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesAction.java
@@ -33,6 +33,7 @@ import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorHandler;
 
 /**
  * Java implementation of the wbsearchentities action.
@@ -174,7 +175,8 @@ public class WbSearchEntitiesAction {
                 }
             }
         } catch (IOException e) {
-            LOGGER.error("Could not retrive data: " + e.toString());
+            MediaWikiApiErrorHandler.throwMediaWikiApiErrorException("IOException", "Error when searching entities");
+            LOGGER.error("Error when searching entities: " + e.toString());
         }
 
         return results;

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesAction.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesAction.java
@@ -33,7 +33,6 @@ import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorHandler;
 
 /**
  * Java implementation of the wbsearchentities action.

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesAction.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesAction.java
@@ -79,7 +79,7 @@ public class WbSearchEntitiesAction {
     }
 
     public List<WbSearchEntitiesResult> wbSearchEntities(WbGetEntitiesSearchData properties)
-            throws MediaWikiApiErrorException {
+            throws MediaWikiApiErrorException, IOException {
         return wbSearchEntities(properties.search, properties.language,
                 properties.strictlanguage, properties.type, properties.limit, properties.offset);
     }
@@ -124,7 +124,7 @@ public class WbSearchEntitiesAction {
      */
     public List<WbSearchEntitiesResult> wbSearchEntities(String search, String language,
                                                          Boolean strictLanguage, String type, Long limit, Long offset)
-            throws MediaWikiApiErrorException {
+            throws MediaWikiApiErrorException, IOException {
 
         Map<String, String> parameters = new HashMap<>();
         parameters.put(ApiConnection.PARAM_ACTION, "wbsearchentities");
@@ -160,23 +160,18 @@ public class WbSearchEntitiesAction {
 
         List<WbSearchEntitiesResult> results = new ArrayList<>();
 
-        try {
-            JsonNode root = this.connection.sendJsonRequest("POST", parameters);
-            JsonNode entities = root.path("search");
-            for (JsonNode entityNode : entities) {
-                try {
-                    JacksonWbSearchEntitiesResult ed = mapper.treeToValue(entityNode,
-                            JacksonWbSearchEntitiesResult.class);
-                    results.add(ed);
-                } catch (JsonProcessingException e) {
-                    LOGGER.error("Error when reading JSON for entity "
-                            + entityNode.path("id").asText("UNKNOWN") + ": "
-                            + e.toString());
-                }
+        JsonNode root = this.connection.sendJsonRequest("POST", parameters);
+        JsonNode entities = root.path("search");
+        for (JsonNode entityNode : entities) {
+            try {
+                JacksonWbSearchEntitiesResult ed = mapper.treeToValue(entityNode,
+                        JacksonWbSearchEntitiesResult.class);
+                results.add(ed);
+            } catch (JsonProcessingException e) {
+                LOGGER.error("Error when reading JSON for entity "
+                        + entityNode.path("id").asText("UNKNOWN") + ": "
+                        + e.toString());
             }
-        } catch (IOException e) {
-            MediaWikiApiErrorHandler.throwMediaWikiApiErrorException("IOException", "Error when searching entities");
-            LOGGER.error("Error when searching entities: " + e.toString());
         }
 
         return results;

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataFetcher.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataFetcher.java
@@ -306,7 +306,7 @@ public class WikibaseDataFetcher {
 	}
 
 	public List<WbSearchEntitiesResult> searchEntities(String search)
-			throws MediaWikiApiErrorException {
+			throws MediaWikiApiErrorException, IOException {
 		WbGetEntitiesSearchData properties = new WbGetEntitiesSearchData();
 		properties.search = search;
 		properties.language = "en";
@@ -314,7 +314,7 @@ public class WikibaseDataFetcher {
 	}
 
 	public List<WbSearchEntitiesResult> searchEntities(String search, String language)
-			throws MediaWikiApiErrorException {
+			throws MediaWikiApiErrorException, IOException {
 		WbGetEntitiesSearchData properties = new WbGetEntitiesSearchData();
 		properties.search = search;
 		properties.language = language;
@@ -322,7 +322,7 @@ public class WikibaseDataFetcher {
 	}
 
 	public List<WbSearchEntitiesResult> searchEntities(String search, Long limit)
-			throws MediaWikiApiErrorException {
+			throws MediaWikiApiErrorException, IOException {
 		WbGetEntitiesSearchData properties = new WbGetEntitiesSearchData();
 		properties.search = search;
 		properties.language = "en";
@@ -331,7 +331,7 @@ public class WikibaseDataFetcher {
 	}
 
 	public List<WbSearchEntitiesResult> searchEntities(String search, String language, Long limit)
-			throws MediaWikiApiErrorException {
+			throws MediaWikiApiErrorException, IOException {
 		WbGetEntitiesSearchData properties = new WbGetEntitiesSearchData();
 		properties.search = search;
 		properties.language = language;
@@ -340,7 +340,7 @@ public class WikibaseDataFetcher {
 	}
 
 	public List<WbSearchEntitiesResult> searchEntities(WbGetEntitiesSearchData properties)
-			throws MediaWikiApiErrorException {
+			throws MediaWikiApiErrorException, IOException {
 		return this.wbSearchEntitiesAction.wbSearchEntities(properties);
 	}
 

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesActionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesActionTest.java
@@ -23,6 +23,7 @@ package org.wikidata.wdtk.wikibaseapi;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -60,7 +61,7 @@ public class WbSearchEntitiesActionTest {
     }
 
     @Test
-    public void testWbSearchEntities() throws MediaWikiApiErrorException {
+    public void testWbSearchEntities() throws MediaWikiApiErrorException, IOException {
         List<WbSearchEntitiesResult> results = action.wbSearchEntities("abc",
                 "en", null, null, null, null);
 
@@ -85,7 +86,7 @@ public class WbSearchEntitiesActionTest {
     }
 
     @Test
-    public void testWbSearchEntitiesEmpty() throws MediaWikiApiErrorException {
+    public void testWbSearchEntitiesEmpty() throws MediaWikiApiErrorException, IOException {
         List<WbSearchEntitiesResult> results = action.wbSearchEntities(
                 "some search string with no results", "en", null, null, null,
                 null);
@@ -94,12 +95,12 @@ public class WbSearchEntitiesActionTest {
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testIdsAndTitles() throws MediaWikiApiErrorException {
+    public void testIdsAndTitles() throws MediaWikiApiErrorException, IOException {
         action.wbSearchEntities(null, "en", null, null, null, null);
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testIdsAndSites() throws MediaWikiApiErrorException {
+    public void testIdsAndSites() throws MediaWikiApiErrorException, IOException {
         action.wbSearchEntities("abc", null, null, null, null, null);
     }
 }


### PR DESCRIPTION
Throwing IOException in wbSearchEntities instead of catching it. Otherwise its not possible to handle connection errors in programs using the library. Fixes #421 .