### PR TITLE
Add method to fetch the current lag from the Wikibase instance

### DIFF
--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbEditingAction.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbEditingAction.java
@@ -894,4 +894,25 @@ public class WbEditingAction {
 		maxLagBackOffFactor = value;
 	}
 
+	/**
+	 * Retrieves the current lag from the target site, by making an API call.
+	 * 
+	 * @throws MediaWikiApiErrorException
+	 * 		when an unexpected MediaWiki API error happened (not the spurious
+	 *      one normally returned by MediaWiki when retrieving lag).
+	 * @throws IOException
+	 *      when communication with the server failed.
+	 *      
+	 */
+	public double getCurrentLag() throws IOException, MediaWikiApiErrorException {
+		Map<String,String> parameters = new HashMap<>();
+		parameters.put("action", "query");
+		parameters.put("maxlag", "-1");
+		try {
+			this.connection.sendJsonRequest("POST", parameters);
+		} catch (MaxlagErrorException e) {
+			return e.getLag();
+		}
+		throw new IllegalStateException("MediaWiki did not return any maxlag value");
+	}
 }

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/apierrors/MaxlagErrorException.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/apierrors/MaxlagErrorException.java
@@ -32,6 +32,8 @@ package org.wikidata.wdtk.wikibaseapi.apierrors;
 public class MaxlagErrorException extends MediaWikiApiErrorException {
 
 	private static final long serialVersionUID = -4013361654647685959L;
+	
+	protected double lag = 0;
 
 	/**
 	 * Creates a new exception.
@@ -43,5 +45,30 @@ public class MaxlagErrorException extends MediaWikiApiErrorException {
 	public MaxlagErrorException(String errorMessage) {
 		super(MediaWikiApiErrorHandler.ERROR_MAXLAG, errorMessage);
 	}
-
+	
+	/**
+	 * Creates an exception which also stores the lag announced by the server.
+	 * 
+	 * @param errorMessage
+	 *            the error message reported by MediaWiki, or any other
+	 *            meaningful message for the user
+	 * @param lag
+	 *            the value of the reported lag, in seconds
+	 */
+	public MaxlagErrorException(String errorMessage, double lag) {
+		super(MediaWikiApiErrorHandler.ERROR_MAXLAG, errorMessage);
+		this.lag = lag;
+	}
+	
+	/**
+	 * Retrieves the amount of lag announced by the server when this
+	 * error was emitted. May return 0 if the lag was not extracted from
+	 * the server response.
+	 * 
+	 * @return
+	 *    the lag on the target server
+	 */
+	public double getLag() {
+		return lag;
+	}
 }

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnectionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnectionTest.java
@@ -45,6 +45,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.wikidata.wdtk.util.CompressionType;
 import org.wikidata.wdtk.wikibaseapi.apierrors.AssertUserFailedException;
+import org.wikidata.wdtk.wikibaseapi.apierrors.MaxlagErrorException;
 import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -253,6 +254,18 @@ public class BasicApiConnectionTest {
 		URL path = this.getClass().getResource("/error.json");
 		root = mapper.readTree(path.openStream());
 		con.checkErrors(root);
+	}
+	
+	@Test
+	public void testMaxlagError() throws IOException, MediaWikiApiErrorException {
+		JsonNode root;
+		URL path = this.getClass().getResource("/error-maxlag-full.json");
+		root = mapper.readTree(path.openStream());
+		try {
+			con.checkErrors(root);
+		} catch(MaxlagErrorException e) {
+			assertEquals(3.45, e.getLag(), 0.001);
+		}
 	}
 
 	@Test

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WbEditingActionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WbEditingActionTest.java
@@ -1,5 +1,7 @@
 package org.wikidata.wdtk.wikibaseapi;
 
+import static org.junit.Assert.assertEquals;
+
 /*
  * #%L
  * Wikidata Toolkit Wikibase API
@@ -190,6 +192,23 @@ public class WbEditingActionTest {
 		WbEditingAction weea = new WbEditingAction(
 				new MockBasicApiConnection(), Datamodel.SITE_WIKIDATA);
 		weea.wbEditEntity(null, null, null, null, "{}", false, false, 0, null, null);
+	}
+	
+	@Test
+	public void testGetLag() throws IOException, MediaWikiApiErrorException {
+		MockBasicApiConnection con = new MockBasicApiConnection();
+		Map<String, String> params = new HashMap<>();
+		params.put("action", "query");
+		params.put("maxlag", "-1");
+		params.put("format", "json");
+		con.setWebResourceFromPath(params, this.getClass(),
+				"/error-maxlag-full.json",
+				CompressionType.NONE);
+		
+		WbEditingAction weea = new WbEditingAction(
+				con, Datamodel.SITE_WIKIDATA);
+		double lag = weea.getCurrentLag();
+		assertEquals(3.45, lag, 0.001);
 	}
 
 }

--- a/wdtk-wikibaseapi/src/test/resources/error-maxlag-full.json
+++ b/wdtk-wikibaseapi/src/test/resources/error-maxlag-full.json
@@ -1,0 +1,12 @@
+{
+  "error": {
+    "code": "maxlag",
+    "info": "Waiting for all: 3.45 seconds lagged.",
+    "host": "all",
+    "lag": 3.45,
+    "type": "wikibase-queryservice",
+    "queryserviceLag": 626,
+    "*": "See https://www.wikidata.org/w/api.php for API usage. Subscribe to the mediawiki-api-announce mailing list at &lt;https://lists.wikimedia.org/mailman/listinfo/mediawiki-api-announce&gt; for notice of API deprecations and breaking changes."
+  },
+  "servedby": "mw1280"
+}


### PR DESCRIPTION
Initially designed for #469, closes #510.