### PR TITLE
Update Travis CI to newest JDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ sudo: false
 jdk:
   - openjdk8
   - openjdk11
+  - openjdk13
+  - openjdk15
 
 script:
   - mvn test jacoco:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk:
   - openjdk8
   - openjdk11
   - openjdk13
-  - openjdk15
+  - openjdk14
 
 script:
   - mvn test jacoco:report


### PR DESCRIPTION
This is an update of .travis.yml to make Travis CI compile using the newest versions of OpenJDK.
