### PR TITLE
Fixing testMwDailyDumpFileProcessing so it can pass when run by itself

### DIFF
--- a/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/MwDumpFileProcessingTest.java
+++ b/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/MwDumpFileProcessingTest.java
@@ -372,7 +372,7 @@ public class MwDumpFileProcessingTest {
 	@Test
 	public void testMwDailyDumpFileProcessing() throws IOException {
 		Path dmPath = Paths.get(System.getProperty("user.dir"));
-		MockDirectoryManager dm = new MockDirectoryManager(dmPath, true);
+		MockDirectoryManager dm = new MockDirectoryManager(dmPath, true, true);
 		setLocalDumpFile("20140420", DumpContentType.DAILY, dm);
 
 		DumpProcessingController dpc = new DumpProcessingController(


### PR DESCRIPTION
Currently, testMwDailyDumpFileProcessing fails when run by itself, with an exception that it cannot write to wdtk-dumpfiles because it is in read-only mode.

This pull request fixes the test so it can pass when run by itself by making a MockDirectoryManager that resets the file system.