### PR TITLE
Fixing tests in MwDumpFileProcessingTest so they can pass when run in isolation

### DIFF
--- a/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/MwDumpFileProcessingTest.java
+++ b/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/MwDumpFileProcessingTest.java
@@ -459,7 +459,7 @@ public class MwDumpFileProcessingTest {
 	@Test
 	public void testMwRecentCurrentDumpFileProcessing() throws IOException {
 		Path dmPath = Paths.get(System.getProperty("user.dir"));
-		MockDirectoryManager dm = new MockDirectoryManager(dmPath, true);
+		MockDirectoryManager dm = new MockDirectoryManager(dmPath, true, true);
 		mockLocalDumpFile("20140420", 4, DumpContentType.DAILY, dm);
 		mockLocalDumpFile("20140419", 3, DumpContentType.DAILY, dm);
 		mockLocalDumpFile("20140418", 2, DumpContentType.DAILY, dm);
@@ -509,7 +509,7 @@ public class MwDumpFileProcessingTest {
 	@Test
 	public void testMwMostRecentFullDumpFileProcessing() throws IOException {
 		Path dmPath = Paths.get(System.getProperty("user.dir"));
-		MockDirectoryManager dm = new MockDirectoryManager(dmPath, true);
+		MockDirectoryManager dm = new MockDirectoryManager(dmPath, true, true);
 		mockLocalDumpFile("20140418", 2, DumpContentType.FULL, dm);
 
 		DumpProcessingController dpc = new DumpProcessingController(


### PR DESCRIPTION
Similar to #480, there are other tests in MwDumpFileProcessingTest that do not pass when run by themselves, for the same reason as the test mentioned in #480. This pull request proposes the same fixes to these tests.