### PR TITLE
Introducing setup so tests do not fail when run after createDirectoryManagerNoConstructor

### DIFF
--- a/wdtk-util/src/test/java/org/wikidata/wdtk/util/DirectoryManagerFactoryTest.java
+++ b/wdtk-util/src/test/java/org/wikidata/wdtk/util/DirectoryManagerFactoryTest.java
@@ -30,6 +30,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
+import org.junit.Before;
 import org.junit.Test;
 
 public class DirectoryManagerFactoryTest {
@@ -82,11 +83,15 @@ public class DirectoryManagerFactoryTest {
 		}
 	}
 
+	@Before
+	public void setup() throws IOException {
+		DirectoryManagerFactory
+				.setDirectoryManagerClass(DirectoryManagerImpl.class);
+	}
+
 	@Test
 	public void createDirectoryManagerString() throws IOException {
 		Path path = Paths.get(System.getProperty("user.dir"));
-		DirectoryManagerFactory
-				.setDirectoryManagerClass(DirectoryManagerImpl.class);
 		DirectoryManager dm = DirectoryManagerFactory.createDirectoryManager(
 				System.getProperty("user.dir"), true);
 		assertTrue(dm instanceof DirectoryManagerImpl);


### PR DESCRIPTION
Currently, tests `createDefaultDirectoryManagerPath` and `createDirectoryManagerIoException` within `DirectoryManagerFactoryTest` fail when run after `createDirectoryManagerNoConstructor`. The reason is that `createDirectoryManagerNoConstructor` changes the `DirectoryManager` to `TestDirectoryManager`, which leads to the other tests to fail when run afterwards.

The proposed fix is to introduce a setup method that always sets the `DirectoryManager` to be `DirectoryManagerImpl` before every test. This pull request also removes the call to set the `DirectoryManager` in `createDirectoryManagerString`, because it is going to be done in the setup method.

Please let me know if you want to discuss the changes more.