### PR TITLE
use subListOfEntityIds instead of entityIds

### DIFF
--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataFetcher.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataFetcher.java
@@ -184,7 +184,7 @@ public class WikibaseDataFetcher {
 			}
 			WbGetEntitiesActionData properties = new WbGetEntitiesActionData();
 			properties.ids = ApiConnection.implodeObjects(subListOfEntityIds);
-			result.putAll(getEntityDocumentMap(entityIds.size(), properties));
+			result.putAll(getEntityDocumentMap(subListOfEntityIds.size(), properties));
 			subListOfEntityIds.clear();
 		}
 		return result;


### PR DESCRIPTION
Seems there is a bug with  `WikibaseDataFetcher#getEntityDocuments` , though not deadly (won't lead to any surprising result actually).

```java
public Map<String, EntityDocument> getEntityDocuments(List<String> entityIds)
		throws MediaWikiApiErrorException, IOException {
	Map<String, EntityDocument> result = new HashMap<>();
	List<String> newEntityIds = new ArrayList<>(entityIds);
	boolean moreItems = !newEntityIds.isEmpty();
	while (moreItems) {
		List<String> subListOfEntityIds;
		if (newEntityIds.size() <= maxListSize) {
			subListOfEntityIds = newEntityIds;
			moreItems = false;
		} else {
			subListOfEntityIds = newEntityIds.subList(0, maxListSize);
		}
		WbGetEntitiesActionData properties = new WbGetEntitiesActionData();
		properties.ids = ApiConnection.implodeObjects(subListOfEntityIds);
                // BUG: should be result.putAll(getEntityDocumentMap(subListOfEntityIds.size(), properties));
		result.putAll(getEntityDocumentMap(entityIds.size(), properties));
		subListOfEntityIds.clear();
	}
	return result;
}

```

For comparison, here is `WikibaseDataFetcher#getEntityDocumentsByTitle`:

```java
public Map<String, EntityDocument> getEntityDocumentsByTitle(
		String siteKey, List<String> titles)
		throws MediaWikiApiErrorException, IOException {
	List<String> newTitles = new ArrayList<>(titles);
	Map<String, EntityDocument> result = new HashMap<>();
	boolean moreItems = !newTitles.isEmpty();

	while (moreItems) {
		List<String> subListOfTitles;
		if (newTitles.size() <= maxListSize) {
			subListOfTitles = newTitles;
			moreItems = false;
		} else {
			subListOfTitles = newTitles.subList(0, maxListSize);
		}
		WbGetEntitiesActionData properties = new WbGetEntitiesActionData();
		properties.titles = ApiConnection.implodeObjects(subListOfTitles);
		properties.sites = siteKey;
                // HERE subList is used, which is more logical
		result.putAll(getEntityDocumentMap(subListOfTitles.size(),
				properties));
		subListOfTitles.clear();
	}
	return result;
}
```