### PR TITLE
Remove unused dependency: Apache HTTP Components

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,6 @@
 		<apacheCommonsCompressVersion>1.20</apacheCommonsCompressVersion>
 		<apacheCommonsLangVersion>3.10</apacheCommonsLangVersion>
 		<apacheCommonsIOVersion>2.6</apacheCommonsIOVersion>
-		<apacheHttpVersion>4.5.12</apacheHttpVersion>
 		<jacksonVersion>2.10.3</jacksonVersion>
 		<junitVersion>4.13</junitVersion>
 		<mockitoVersion>1.10.19</mockitoVersion>

--- a/wdtk-rdf/pom.xml
+++ b/wdtk-rdf/pom.xml
@@ -41,11 +41,6 @@
 		<version>${project.version}</version>
 	</dependency>
 	<dependency>
-		<groupId>org.apache.httpcomponents</groupId>
-		<artifactId>httpclient</artifactId>
-		<version>${apacheHttpVersion}</version>
-	</dependency>        
-	<dependency>
 		<groupId>${project.groupId}</groupId>
 		<artifactId>wdtk-testing</artifactId>
 		<version>${project.version}</version>

--- a/wdtk-wikibaseapi/pom.xml
+++ b/wdtk-wikibaseapi/pom.xml
@@ -27,11 +27,6 @@
 			<version>${project.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>org.apache.httpcomponents</groupId>
-			<artifactId>httpclient</artifactId>
-			<version>${apacheHttpVersion}</version>
-		</dependency>
-		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>wdtk-testing</artifactId>
 			<version>${project.version}</version>


### PR DESCRIPTION
We currently use Java's embedded HTTP client, not Apache HTTP Components, so we can remove this dependency.

We should migrate to a high-level HTTP library (#492), but there is no point in keeping this dependency in the mean time.