### PR TITLE
Call fillCookies for responses

### DIFF
--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnection.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnection.java
@@ -309,6 +309,11 @@ public class BasicApiConnection extends ApiConnection {
 		this.cookies.clear();
 	}
 
+	@Override
+	public void processResponseHeaders(Map<String, List<String>> headerFields) {
+		fillCookies(headerFields);
+	}
+
 	/**
 	 * Reads out the Set-Cookie Header Fields and fills the cookie map of the
 	 * API connection with it.


### PR DESCRIPTION

Forgot to fill cookies for responses in previous commits, thus resulting in login error.

![error1](https://user-images.githubusercontent.com/29347603/83478480-84675380-a4c8-11ea-843f-a05315e92bba.png)