### PR TITLE
Restore Coveralls integration with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,21 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-java@v1
+
+      - name: Setup Java
+        uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
-      - uses: actions/cache@v2
+
+      - name: Restore dependency cache
+        uses: actions/cache@v2
         with:
           path: ~/.m2
           key: ${{ runner.os }}-${{ matrix.java }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-${{ matrix.java }}-m2
-      - run: mvn --batch-mode --update-snapshots verify
+
+      - name: Run tests
+        run: mvn --batch-mode --update-snapshots verify
+
+      - name: Submit test coverage to Coveralls
+        run: mvn jacoco:report coveralls:report -DrepoToken=${{ secrets.COVERALLS_TOKEN }} -DpullRequest=${{ github.event.number }} -DserviceBuildNumber=${{ env.GITHUB_RUN_ID }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 Wikidata Toolkit
 ================
 
-[![Build status](https://github.com/Wikidata/Wikidata-Toolkit/workflows/Java%20CI/badge.svg)](https://github.com/Wikidata/Wikidata-Toolkit/actions)
+![Build status](https://github.com/Wikidata/Wikidata-Toolkit/workflows/Java%20CI/badge.svg)
+[![Coverage Status](https://coveralls.io/repos/github/Wikidata/Wikidata-Toolkit/badge.svg?branch=master)](https://coveralls.io/github/Wikidata/Wikidata-Toolkit?branch=master)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.wikidata.wdtk/wdtk-parent/badge.svg)](http://search.maven.org/#search|ga|1|g%3A%22org.wikidata.wdtk%22)
 [![Project Stats](https://www.openhub.net/p/Wikidata-Toolkit/widgets/project_thin_badge.gif)](https://www.openhub.net/p/Wikidata-Toolkit)
 


### PR DESCRIPTION
This is an attempt to re-enable Coveralls integration after #518.