### PR TITLE
Expose exceptions

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/JsonDeserializer.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/JsonDeserializer.java
@@ -1,5 +1,3 @@
-package org.wikidata.wdtk.datamodel.helpers;
-
 /*-
  * #%L
  * Wikidata Toolkit Data Model
@@ -20,13 +18,24 @@ package org.wikidata.wdtk.datamodel.helpers;
  * #L%
  */
 
-import java.io.IOException;
+package org.wikidata.wdtk.datamodel.helpers;
 
-import com.fasterxml.jackson.databind.ObjectReader;
-import org.wikidata.wdtk.datamodel.implementation.*;
-import org.wikidata.wdtk.datamodel.interfaces.*;
+import org.wikidata.wdtk.datamodel.implementation.EntityDocumentImpl;
+import org.wikidata.wdtk.datamodel.implementation.EntityRedirectDocumentImpl;
+import org.wikidata.wdtk.datamodel.implementation.ItemDocumentImpl;
+import org.wikidata.wdtk.datamodel.implementation.LexemeDocumentImpl;
+import org.wikidata.wdtk.datamodel.implementation.MediaInfoDocumentImpl;
+import org.wikidata.wdtk.datamodel.implementation.PropertyDocumentImpl;
+import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
+import org.wikidata.wdtk.datamodel.interfaces.EntityRedirectDocument;
+import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
+import org.wikidata.wdtk.datamodel.interfaces.LexemeDocument;
+import org.wikidata.wdtk.datamodel.interfaces.MediaInfoDocument;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectReader;
 
 /**
  * Helper to deserialize datamodel objects from their
@@ -72,55 +81,55 @@ public class JsonDeserializer {
 	
 	/**
 	 * Deserializes a JSON string into an {@link ItemDocument}.
-	 * @throws IOException 
+	 * @throws JsonProcessingException 
 			if the JSON payload is invalid
 	 */
-	public ItemDocument deserializeItemDocument(String json) throws IOException {
+	public ItemDocument deserializeItemDocument(String json) throws JsonProcessingException {
 		return itemReader.readValue(json);
 	}
 	
 	/**
 	 * Deserializes a JSON string into a {@link PropertyDocument}.
-	 * @throws IOException 
+	 * @throws JsonProcessingException 
 			if the JSON payload is invalid
 	 */
-	public PropertyDocument deserializePropertyDocument(String json) throws IOException {
+	public PropertyDocument deserializePropertyDocument(String json) throws JsonProcessingException {
 		return propertyReader.readValue(json);
 	}
 
 	/**
 	 * Deserializes a JSON string into a {@link LexemeDocument}.
-	 * @throws IOException 
+	 * @throws JsonProcessingException 
 			if the JSON payload is invalid
 	 */
-	public LexemeDocument deserializeLexemeDocument(String json) throws IOException {
+	public LexemeDocument deserializeLexemeDocument(String json) throws JsonProcessingException {
 		return lexemeReader.readValue(json);
 	}
 	
 	/**
 	 * Deserializes a JSON string into a {@link MediaInfoDocument}.
-	 * @throws IOException 
+	 * @throws JsonProcessingException 
 			if the JSON payload is invalid
 	 */
-	public MediaInfoDocument deserializeMediaInfoDocument(String json) throws IOException {
+	public MediaInfoDocument deserializeMediaInfoDocument(String json) throws JsonProcessingException {
 		return mediaInfoReader.readValue(json);
 	}
 	
 	/**
 	 * Deserializes a JSON string into a {@link EntityDocument}.
-	 * @throws IOException 
+	 * @throws JsonProcessingException 
 			if the JSON payload is invalid
 	 */
-	public EntityDocument deserializeEntityDocument(String json) throws IOException {
+	public EntityDocument deserializeEntityDocument(String json) throws JsonProcessingException {
 		return entityDocumentReader.readValue(json);
 	}
 
 	/**
 	 * Deserializes a JSON string into a {@link EntityRedirectDocument}.
-	 * @throws IOException
+	 * @throws JsonProcessingException
 	if the JSON payload is invalid
 	 */
-	public EntityRedirectDocument deserializeEntityRedirectDocument(String json) throws IOException {
+	public EntityRedirectDocument deserializeEntityRedirectDocument(String json) throws JsonProcessingException {
 		return entityRedirectReader.readValue(json);
 	}
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/JsonSerializer.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/JsonSerializer.java
@@ -1,5 +1,3 @@
-package org.wikidata.wdtk.datamodel.helpers;
-
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -19,6 +17,8 @@ package org.wikidata.wdtk.datamodel.helpers;
  * limitations under the License.
  * #L%
  */
+
+package org.wikidata.wdtk.datamodel.helpers;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -173,69 +173,54 @@ public class JsonSerializer implements EntityDocumentDumpProcessor {
 	}
 
 	/**
-	 * Serializes the given object in JSON and returns the resulting string. In
-	 * case of errors, null is returned.
+	 * Serializes the given object in JSON and returns the resulting string.
+	 * Throws if the serialization fails.
 	 *
 	 * @param itemDocument
 	 *            object to serialize
-	 * @return JSON serialization or null
+	 * @return JSON serialization
+	 * @throws JsonProcessingException if the object cannot be serialized
 	 */
-	public static String getJsonString(ItemDocument itemDocument) {
-		return jacksonObjectToString(itemDocument);
+	public static String getJsonString(ItemDocument itemDocument) throws JsonProcessingException {
+		return mapper.writeValueAsString(itemDocument);
 	}
 
 	/**
-	 * Serializes the given object in JSON and returns the resulting string. In
-	 * case of errors, null is returned.
+	 * Serializes the given object in JSON and returns the resulting string.
+	 * Throws if the serialization fails.
 	 *
 	 * @param propertyDocument
 	 *            object to serialize
-	 * @return JSON serialization or null
+	 * @return JSON serialization
+	 * @throws JsonProcessingException if the object cannot be serialized
 	 */
-	public static String getJsonString(PropertyDocument propertyDocument) {
-		return jacksonObjectToString(propertyDocument);
+	public static String getJsonString(PropertyDocument propertyDocument) throws JsonProcessingException {
+		return mapper.writeValueAsString(propertyDocument);
 	}
 
 	/**
-	 * Serializes the given object in JSON and returns the resulting string. In
-	 * case of errors, null is returned.
+	 * Serializes the given object in JSON and returns the resulting string.
+	 * Throws if the serialization fails.
 	 *
 	 * @param mediaInfoDocument
 	 *            object to serialize
-	 * @return JSON serialization or null
+	 * @return JSON serialization
+	 * @throws JsonProcessingException if the object cannot be serialized
 	 */
-	public static String getJsonString(MediaInfoDocument mediaInfoDocument) {
-		return jacksonObjectToString(mediaInfoDocument);
+	public static String getJsonString(MediaInfoDocument mediaInfoDocument) throws JsonProcessingException {
+		return mapper.writeValueAsString(mediaInfoDocument);
 	}
 
 	/**
-	 * Serializes the given object in JSON and returns the resulting string. In
-	 * case of errors, null is returned.
+	 * Serializes the given object in JSON and returns the resulting string.
+	 * Throws if the serialization fails.
 	 *
 	 * @param statement
 	 *            object to serialize
-	 * @return JSON serialization or null
+	 * @return JSON serialization
+	 * @throws JsonProcessingException if the object cannot be serialized
 	 */
-	public static String getJsonString(Statement statement) {
-		return jacksonObjectToString(statement);
-	}
-
-	/**
-	 * Serializes the given object in JSON and returns the resulting string. In
-	 * case of errors, null is returned. In particular, this happens if the
-	 * object is not based on a Jackson-annotated class. An error is logged in
-	 * this case.
-	 *
-	 * @param object
-	 *            object to serialize
-	 * @return JSON serialization or null
-	 */
-	protected static String jacksonObjectToString(Object object) {
-		try {
-			return mapper.writeValueAsString(object);
-		} catch (JsonProcessingException e) {
-			logger.error("Failed to serialize JSON data: " + e.toString());
-			return null;
-		}
+	public static String getJsonString(Statement statement) throws JsonProcessingException {
+		return mapper.writeValueAsString(statement);
 	}
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/JsonSerializerTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/JsonSerializerTest.java
@@ -21,7 +21,7 @@
 package org.wikidata.wdtk.datamodel.helpers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -29,6 +29,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 import org.wikidata.wdtk.datamodel.implementation.EntityDocumentImpl;
@@ -37,10 +39,14 @@ import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
+import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
+import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
 import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
@@ -97,7 +103,7 @@ public class JsonSerializerTest {
 	}
 
 	@Test
-	public void testItemDocumentToJson() {
+	public void testItemDocumentToJson() throws JsonProcessingException {
 		ItemDocument id = Datamodel.makeItemDocument(
 				Datamodel.makeWikidataItemIdValue("Q42"),
 				Collections.emptyList(),
@@ -110,7 +116,7 @@ public class JsonSerializerTest {
 	}
 
 	@Test
-	public void testPropertyDocumentToJson() {
+	public void testPropertyDocumentToJson() throws JsonProcessingException {
 		PropertyDocument pd = Datamodel.makePropertyDocument(
 				Datamodel.makeWikidataPropertyIdValue("P1"),
 				Collections. emptyList(),
@@ -123,7 +129,7 @@ public class JsonSerializerTest {
 	}
 
 	@Test
-	public void testStatementToJson() {
+	public void testStatementToJson() throws JsonProcessingException {
 		Statement s = Datamodel.makeStatement(ItemIdValue.NULL,
 				Datamodel.makeNoValueSnak(Datamodel.makeWikidataPropertyIdValue("P1")),
 				Collections.emptyList(), Collections.emptyList(),
@@ -134,14 +140,74 @@ public class JsonSerializerTest {
 
 	@Test
 	public void testJacksonObjectToJsonError() {
-		Object obj = new Object() {
-			@SuppressWarnings("unused")
-			public String getData() {
-				throw new RuntimeException("Test exception");
+		ItemDocument obj = new ItemDocument() {
+
+			@Override
+			public List<StatementGroup> getStatementGroups() {
+				return null;
+			}
+
+			@Override
+			public long getRevisionId() {
+				return 0;
+			}
+
+			@Override
+			public Map<String, MonolingualTextValue> getLabels() {
+				return null;
+			}
+
+			@Override
+			public Map<String, MonolingualTextValue> getDescriptions() {
+				return null;
+			}
+
+			@Override
+			public Map<String, List<MonolingualTextValue>> getAliases() {
+				return null;
+			}
+
+			@Override
+			public ItemDocument withoutStatementIds(Set<String> statementIds) {
+				return null;
+			}
+
+			@Override
+			public ItemDocument withStatement(Statement statement) {
+				return null;
+			}
+
+			@Override
+			public ItemDocument withRevisionId(long newRevisionId) {
+				return null;
+			}
+
+			@Override
+			public ItemDocument withLabel(MonolingualTextValue newLabel) {
+				return null;
+			}
+
+			@Override
+			public ItemDocument withDescription(MonolingualTextValue newDescription) {
+				return null;
+			}
+
+			@Override
+			public ItemDocument withAliases(String language, List<MonolingualTextValue> aliases) {
+				return null;
+			}
+
+			@Override
+			public Map<String, SiteLink> getSiteLinks() {
+				return null;
+			}
+
+			@Override
+			public ItemIdValue getEntityId() {
+				return null;
 			}
 		};
 
-		String result = JsonSerializer.jacksonObjectToString(obj);
-		assertNull(result);
+		assertThrows(JsonProcessingException.class, () -> JsonSerializer.getJsonString(obj));
 	}
 }

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesAction.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesAction.java
@@ -1,5 +1,3 @@
-package org.wikidata.wdtk.wikibaseapi;
-
 /*
  * #%L
  * Wikidata Toolkit Wikibase API
@@ -20,14 +18,14 @@ package org.wikidata.wdtk.wikibaseapi;
  * #L%
  */
 
+package org.wikidata.wdtk.wikibaseapi;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -42,132 +40,130 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class WbSearchEntitiesAction {
 
-    private static final Logger LOGGER = LoggerFactory
-            .getLogger(WbSearchEntitiesAction.class);
+	/**
+	 * Connection to a Wikibase API.
+	 */
+	private final ApiConnection connection;
 
-    /**
-     * Connection to a Wikibase API.
-     */
-    private final ApiConnection connection;
+	/**
+	 * Mapper object used for deserializing JSON data.
+	 */
+	private final ObjectMapper mapper = new ObjectMapper();
 
-    /**
-     * Mapper object used for deserializing JSON data.
-     */
-    private final ObjectMapper mapper = new ObjectMapper();
+	/**
+	 * Creates an object to fetch data from the given ApiConnection. The site
+	 * URI is necessary since it is not contained in the data retrieved from the
+	 * API.
+	 *
+	 * @param connection
+	 *            {@link ApiConnection} Object to send the requests
+	 * @param siteUri
+	 *            the URI identifying the site that is accessed (usually the
+	 *            prefix of entity URIs), e.g.,
+	 *            "http://www.wikidata.org/entity/"
+	 */
+	public WbSearchEntitiesAction(ApiConnection connection, String siteUri) {
+		this.connection = connection;
+	}
 
-    /**
-     * Creates an object to fetch data from the given ApiConnection. The site
-     * URI is necessary since it is not contained in the data retrieved from the
-     * API.
-     *
-     * @param connection
-     *            {@link ApiConnection} Object to send the requests
-     * @param siteUri
-     *            the URI identifying the site that is accessed (usually the
-     *            prefix of entity URIs), e.g.,
-     *            "http://www.wikidata.org/entity/"
-     */
-    public WbSearchEntitiesAction(ApiConnection connection, String siteUri) {
-        this.connection = connection;
-    }
+	public List<WbSearchEntitiesResult> wbSearchEntities(WbGetEntitiesSearchData properties)
+			throws MediaWikiApiErrorException, IOException {
+		return wbSearchEntities(properties.search, properties.language,
+				properties.strictlanguage, properties.type, properties.limit, properties.offset);
+	}
 
-    public List<WbSearchEntitiesResult> wbSearchEntities(WbGetEntitiesSearchData properties)
-            throws MediaWikiApiErrorException, IOException {
-        return wbSearchEntities(properties.search, properties.language,
-                properties.strictlanguage, properties.type, properties.limit, properties.offset);
-    }
+	/**
+	 * Executes the API action "wbsearchentity" for the given parameters.
+	 * Searches for entities using labels and aliases. Returns a label and
+	 * description for the entity in the user language if possible. Returns
+	 * details of the matched term. The matched term text is also present in the
+	 * aliases key if different from the display label.
+	 *
+	 * <p>
+	 * See the <a href=
+	 * "https://www.wikidata.org/w/api.php?action=help&modules=wbsearchentity"
+	 * >online API documentation</a> for further information.
+	 * <p>
+	 *
+	 * @param search
+	 *            (required) search for this text
+	 * @param language
+	 *            (required) search in this language
+	 * @param strictLanguage
+	 *            (optional) whether to disable language fallback
+	 * @param type
+	 *            (optional) search for this type of entity
+	 *            One of the following values: item, property
+	 *            Default: item
+	 * @param limit
+	 *            (optional) maximal number of results
+	 *            no more than 50 (500 for bots) allowed
+	 *            Default: 7
+	 * @param offset
+	 *            (optional) offset where to continue a search
+	 *            Default: 0
+	 *            this parameter is called "continue" in the API (which is a Java keyword)
+	 *
+	 * @return list of matching entities retrieved via the API URL
+	 * @throws MediaWikiApiErrorException
+	 *             if the API returns an error
+	 * @throws IllegalArgumentException
+	 *             if the given combination of parameters does not make sense
+	 * @throws MalformedResponseException
+	 *             if response JSON cannot be parsed
+	 */
+	public List<WbSearchEntitiesResult> wbSearchEntities(String search, String language,
+			Boolean strictLanguage, String type, Long limit, Long offset)
+					throws MediaWikiApiErrorException, IOException {
 
-    /**
-     * Executes the API action "wbsearchentity" for the given parameters.
-     * Searches for entities using labels and aliases. Returns a label and
-     * description for the entity in the user language if possible. Returns
-     * details of the matched term. The matched term text is also present in the
-     * aliases key if different from the display label.
-     *
-     * <p>
-     * See the <a href=
-     * "https://www.wikidata.org/w/api.php?action=help&modules=wbsearchentity"
-     * >online API documentation</a> for further information.
-     * <p>
-     *
-     * @param search
-     *            (required) search for this text
-     * @param language
-     *            (required) search in this language
-     * @param strictLanguage
-     *            (optional) whether to disable language fallback
-     * @param type
-     *            (optional) search for this type of entity
-     *            One of the following values: item, property
-     *            Default: item
-     * @param limit
-     *            (optional) maximal number of results
-     *            no more than 50 (500 for bots) allowed
-     *            Default: 7
-     * @param offset
-     *            (optional) offset where to continue a search
-     *            Default: 0
-     *            this parameter is called "continue" in the API (which is a Java keyword)
-     *
-     * @return list of matching entities retrieved via the API URL
-     * @throws MediaWikiApiErrorException
-     *             if the API returns an error
-     * @throws IllegalArgumentException
-     *             if the given combination of parameters does not make sense
-     */
-    public List<WbSearchEntitiesResult> wbSearchEntities(String search, String language,
-                                                         Boolean strictLanguage, String type, Long limit, Long offset)
-            throws MediaWikiApiErrorException, IOException {
+		Map<String, String> parameters = new HashMap<>();
+		parameters.put(ApiConnection.PARAM_ACTION, "wbsearchentities");
 
-        Map<String, String> parameters = new HashMap<>();
-        parameters.put(ApiConnection.PARAM_ACTION, "wbsearchentities");
+		if (search != null) {
+			parameters.put("search", search);
+		} else {
+			throw new IllegalArgumentException(
+					"Search parameter must be specified for this action.");
+		}
 
-        if (search != null) {
-            parameters.put("search", search);
-        } else {
-            throw new IllegalArgumentException(
-                    "Search parameter must be specified for this action.");
-        }
+		if (language != null) {
+			parameters.put("language", language);
+		} else {
+			throw new IllegalArgumentException(
+					"Language parameter must be specified for this action.");
+		}
+		if (strictLanguage != null) {
+			parameters.put("strictlanguage", Boolean.toString(strictLanguage));
+		}
 
-        if (language != null) {
-            parameters.put("language", language);
-        } else {
-            throw new IllegalArgumentException(
-                    "Language parameter must be specified for this action.");
-        }
-        if (strictLanguage != null) {
-            parameters.put("strictlanguage", Boolean.toString(strictLanguage));
-        }
+		if (type != null) {
+			parameters.put("type", type);
+		}
 
-        if (type != null) {
-            parameters.put("type", type);
-        }
+		if (limit != null) {
+			parameters.put("limit", Long.toString(limit));
+		}
 
-        if (limit != null) {
-            parameters.put("limit", Long.toString(limit));
-        }
+		if (offset != null) {
+			parameters.put("continue", Long.toString(offset));
+		}
 
-        if (offset != null) {
-            parameters.put("continue", Long.toString(offset));
-        }
+		List<WbSearchEntitiesResult> results = new ArrayList<>();
 
-        List<WbSearchEntitiesResult> results = new ArrayList<>();
+		JsonNode root = this.connection.sendJsonRequest("POST", parameters);
+		JsonNode entities = root.path("search");
+		for (JsonNode entityNode : entities) {
+			try {
+				JacksonWbSearchEntitiesResult ed = mapper.treeToValue(entityNode,
+						JacksonWbSearchEntitiesResult.class);
+				results.add(ed);
+			} catch (JsonProcessingException e) {
+				throw new MalformedResponseException(
+						"Error when reading JSON for entity " + entityNode.path("id").asText("UNKNOWN"), e);
+			}
+		}
 
-        JsonNode root = this.connection.sendJsonRequest("POST", parameters);
-        JsonNode entities = root.path("search");
-        for (JsonNode entityNode : entities) {
-            try {
-                JacksonWbSearchEntitiesResult ed = mapper.treeToValue(entityNode,
-                        JacksonWbSearchEntitiesResult.class);
-                results.add(ed);
-            } catch (JsonProcessingException e) {
-                LOGGER.error("Error when reading JSON for entity "
-                        + entityNode.path("id").asText("UNKNOWN") + ": "
-                        + e.toString());
-            }
-        }
-
-        return results;
-    }
+		return results;
+	}
 
 }

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/StatementUpdateTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/StatementUpdateTest.java
@@ -42,6 +42,7 @@ import org.wikidata.wdtk.datamodel.interfaces.Reference;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -215,7 +216,7 @@ public class StatementUpdateTest {
 	}
 
 	@Test
-	public void testAddStatements() {
+	public void testAddStatements() throws JsonProcessingException {
 		// Inserting new P2 statements won't touch existing P1 statement
 		Statement s1 = StatementBuilder.forSubjectAndProperty(Q1, P1)
 				.withValue(Q1).withId("ID-s1").build();


### PR DESCRIPTION
Per #530, but only for three important classes: `JsonSerializer`, `WbGetEntitiesAction`, and `WbSearchEntitiesAction`. There are some spurious exception handlers in dumpfiles/rdf that I have not touched in this pull request.

Calling code within WDTK itself already assumes exceptions. There were no null checks anywhere, so this actually fixes a bug.

This is a breaking change but a very visible one, so there would be no silent failures in apps.