### PR TITLE
Do not wrap MediaWikiApiErrorException as IOException in logout method

### DIFF
--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnection.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnection.java
@@ -347,11 +347,7 @@ public class BasicApiConnection extends ApiConnection {
 			params.put("action", "logout");
 			params.put("token", getOrFetchToken("csrf"));
 			params.put("format", "json"); // reduce the output
-			try {
-				sendJsonRequest("POST", params);
-			} catch (MediaWikiApiErrorException e) {
-				throw new IOException(e.getMessage(), e); //TODO: we should throw a better exception
-			}
+			sendJsonRequest("POST", params);
 
 			this.loggedIn = false;
 			this.username = "";


### PR DESCRIPTION
Closes #561.