### PR TITLE
Comprehensive entity editing

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/AliasUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/AliasUpdateBuilder.java
@@ -48,6 +48,7 @@ public class AliasUpdateBuilder {
 			Validate.isTrue(
 					base.stream().map(v -> v.getLanguageCode()).distinct().count() <= 1,
 					"Base document aliases must have the same language code.");
+			Validate.isTrue(base.stream().distinct().count() == base.size(), "Base document aliases must be unique.");
 			this.base = new ArrayList<>(base);
 			languageCode = base.stream().map(v -> v.getLanguageCode()).findFirst().orElse(null);
 		} else
@@ -153,7 +154,6 @@ public class AliasUpdateBuilder {
 		} else if (!removed.contains(alias) && (base == null || base.contains(alias))) {
 			removed.add(alias);
 		}
-		removed.add(alias);
 		languageCode = alias.getLanguageCode();
 		return this;
 	}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/AliasUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/AliasUpdateBuilder.java
@@ -1,0 +1,235 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.helpers;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+import org.apache.commons.lang3.Validate;
+import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+
+/**
+ * Builder for incremental construction of {@link AliasUpdate} objects.
+ */
+public class AliasUpdateBuilder {
+
+	private String languageCode;
+	private final List<MonolingualTextValue> base;
+	private List<MonolingualTextValue> recreated;
+	private final List<MonolingualTextValue> added = new ArrayList<>();
+	private final Set<MonolingualTextValue> removed = new HashSet<>();
+
+	private AliasUpdateBuilder(List<MonolingualTextValue> base) {
+		if (base != null) {
+			for (MonolingualTextValue alias : base) {
+				Objects.requireNonNull(alias, "Base document aliases cannot be null.");
+			}
+			Validate.isTrue(
+					base.stream().map(v -> v.getLanguageCode()).distinct().count() <= 1,
+					"Base document aliases must have the same language code.");
+			this.base = new ArrayList<>(base);
+			languageCode = base.stream().map(v -> v.getLanguageCode()).findFirst().orElse(null);
+		} else
+			this.base = null;
+	}
+
+	/**
+	 * Creates new builder object for constructing alias update.
+	 * 
+	 * @return update builder object
+	 */
+	public static AliasUpdateBuilder create() {
+		return new AliasUpdateBuilder(null);
+	}
+
+	/**
+	 * Creates new builder object for constructing update of given base revision
+	 * aliases. Provided aliases will be used to check correctness of changes.
+	 * <p>
+	 * Since all changes will be checked after the {@link AliasUpdate} is passed to
+	 * {@link TermedDocumentUpdateBuilder} anyway, it is usually unnecessary to use
+	 * this method. It is simpler to initialize the builder with {@link #create()}.
+	 * 
+	 * @param aliases
+	 *            aliases from base revision of the document
+	 * @return update builder object
+	 * @throws NullPointerException
+	 *             if {@code aliases} or any of its items is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if there are duplicate items in {@code aliases}
+	 */
+	public static AliasUpdateBuilder forAliases(List<MonolingualTextValue> aliases) {
+		Objects.requireNonNull(aliases, "Base document alias collection cannot be null.");
+		return new AliasUpdateBuilder(aliases);
+	}
+
+	/**
+	 * Adds new alias. This operation can be repeated to add multiple aliases in one
+	 * update. It can be combined with {@link #remove(MonolingualTextValue)}.
+	 * Attempt to add the same alias twice or to add alias already present in base
+	 * document (if available) is silently ignored. Adding previously removed alias
+	 * cancels the removal. If {@link #recreate(List)} was called before, this
+	 * method will add the alias to the end of the new alias list.
+	 * 
+	 * @param alias
+	 *            new alias
+	 * @return {@code this} (fluent method)
+	 * @throws NullPointerException
+	 *             if {@code alias} is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if the alias has language code inconsistent with other aliases
+	 */
+	public AliasUpdateBuilder add(MonolingualTextValue alias) {
+		Objects.requireNonNull(alias, "Alias cannot be null.");
+		if (languageCode != null) {
+			Validate.isTrue(languageCode.equals(alias.getLanguageCode()), "Inconsistent language codes.");
+		}
+		if (recreated != null) {
+			if (!recreated.contains(alias)) {
+				recreated.add(alias);
+				if (recreated.equals(base)) {
+					recreated = null;
+				}
+			}
+		} else if (removed.contains(alias)) {
+			removed.remove(alias);
+		} else if (!added.contains(alias) && (base == null || !base.contains(alias))) {
+			added.add(alias);
+		}
+		languageCode = alias.getLanguageCode();
+		return this;
+	}
+
+	/**
+	 * Removed existing alias. This operation can be repeated to remove multiple
+	 * aliases in one update. It can be combined with
+	 * {@link #add(MonolingualTextValue)}. Attempt to remove the same alias twice or
+	 * to remove alias not present in base document (if available) is silently
+	 * ignored. Removing previously added alias cancels the addition. If
+	 * {@link #recreate(List)} was called before, this method will remove the alias
+	 * from the new alias list.
+	 * 
+	 * @param alias
+	 *            removed alias
+	 * @return {@code this} (fluent method)
+	 * @throws NullPointerException
+	 *             if {@code alias} is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if the alias has language code inconsistent with other aliases
+	 */
+	public AliasUpdateBuilder remove(MonolingualTextValue alias) {
+		Objects.requireNonNull(alias, "Alias cannot be null.");
+		if (languageCode != null) {
+			Validate.isTrue(languageCode.equals(alias.getLanguageCode()), "Inconsistent language codes.");
+		}
+		if (recreated != null) {
+			recreated.remove(alias);
+			if (recreated.equals(base)) {
+				recreated = null;
+			}
+		} else if (added.contains(alias)) {
+			added.remove(alias);
+		} else if (!removed.contains(alias) && (base == null || base.contains(alias))) {
+			removed.add(alias);
+		}
+		removed.add(alias);
+		languageCode = alias.getLanguageCode();
+		return this;
+	}
+
+	/**
+	 * Replaces current alias list with completely new alias list. Any previous
+	 * changes are discarded. To remove all aliases, pass empty list to this method.
+	 * If the new alias list is identical (including order) to base document alias
+	 * list (if provided), the update will be empty.
+	 * 
+	 * @param aliases
+	 *            new list of aliases
+	 * @return {@code this} (fluent method)
+	 * @throws NullPointerException
+	 *             if {@code aliases} or any of its items is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if some alias has inconsistent language code or there are
+	 *             duplicates
+	 */
+	public AliasUpdateBuilder recreate(List<MonolingualTextValue> aliases) {
+		Objects.requireNonNull(aliases, "Alias list cannot be null.");
+		for (MonolingualTextValue alias : aliases) {
+			Objects.requireNonNull(alias, "Aliases cannot be null.");
+		}
+		Validate.isTrue(
+				aliases.stream().map(v -> v.getLanguageCode()).distinct().count() <= 1,
+				"Aliases must have the same language code.");
+		Validate.isTrue(
+				aliases.stream().map(v -> v.getText()).distinct().count() == aliases.size(),
+				"All aliases must be unique.");
+		if (languageCode != null && !aliases.isEmpty()) {
+			Validate.isTrue(languageCode.equals(aliases.get(0).getLanguageCode()), "Inconsistent language codes.");
+		}
+		added.clear();
+		removed.clear();
+		if (!aliases.equals(base)) {
+			recreated = new ArrayList<>(aliases);
+		} else {
+			recreated = null;
+		}
+		if (!aliases.isEmpty()) {
+			languageCode = aliases.get(0).getLanguageCode();
+		}
+		return this;
+	}
+
+	/**
+	 * Replays all changes in provided update into this builder object. Changes are
+	 * performed as if by calling {@link #add(MonolingualTextValue)},
+	 * {@link #remove(MonolingualTextValue)}, and {@link #recreate(List)} methods.
+	 * 
+	 * @param update
+	 *            alias update to replay
+	 * @return {@code this} (fluent method)
+	 * @throws NullPointerException
+	 *             if {@code update} is {@code null}
+	 */
+	public AliasUpdateBuilder append(AliasUpdate update) {
+		Objects.requireNonNull(update, "Alias update cannot be null.");
+		update.getRecreated().ifPresent(this::recreate);
+		for (MonolingualTextValue alias : update.getRemoved()) {
+			remove(alias);
+		}
+		for (MonolingualTextValue alias : update.getAdded()) {
+			add(alias);
+		}
+		return this;
+	}
+
+	/**
+	 * Creates new {@link AliasUpdate} object with contents of this builder object.
+	 * 
+	 * @return constructed object
+	 */
+	public AliasUpdate build() {
+		return Datamodel.makeAliasUpdate(recreated, added, removed);
+	}
+
+}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Datamodel.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Datamodel.java
@@ -947,8 +947,8 @@ public class Datamodel {
 	 * 
 	 * @param entityId
 	 *            ID of the sense that is to be updated
-	 * @param document
-	 *            sense revision to be updated or {@code null} if not available
+	 * @param revisionId
+	 *            base sense revision to be updated or zero if not available
 	 * @param glosses
 	 *            changes in sense glosses or {@code null} for no change
 	 * @param statements
@@ -961,10 +961,10 @@ public class Datamodel {
 	 */
 	public static SenseUpdate makeSenseUpdate(
 			SenseIdValue entityId,
-			SenseDocument document,
+			long revisionId,
 			TermUpdate glosses,
 			StatementUpdate statements) {
-		return factory.getSenseUpdate(entityId, document, glosses, statements);
+		return factory.getSenseUpdate(entityId, revisionId, glosses, statements);
 	}
 
 	/**
@@ -973,8 +973,8 @@ public class Datamodel {
 	 * 
 	 * @param entityId
 	 *            ID of the form that is to be updated
-	 * @param document
-	 *            form revision to be updated or {@code null} if not available
+	 * @param revisionId
+	 *            base form revision to be updated or zero if not available
 	 * @param representations
 	 *            changes in form representations or {@code null} for no change
 	 * @param grammaticalFeatures
@@ -989,11 +989,11 @@ public class Datamodel {
 	 */
 	public static FormUpdate makeFormUpdate(
 			FormIdValue entityId,
-			FormDocument document,
+			long revisionId,
 			TermUpdate representations,
 			Collection<ItemIdValue> grammaticalFeatures,
 			StatementUpdate statements) {
-		return factory.getFormUpdate(entityId, document, representations, grammaticalFeatures, statements);
+		return factory.getFormUpdate(entityId, revisionId, representations, grammaticalFeatures, statements);
 	}
 
 	/**
@@ -1002,8 +1002,8 @@ public class Datamodel {
 	 * 
 	 * @param entityId
 	 *            ID of the lexeme that is to be updated
-	 * @param document
-	 *            lexeme revision to be updated or {@code null} if not available
+	 * @param revisionId
+	 *            base lexeme revision to be updated or zero if not available
 	 * @param language
 	 *            new lexeme language or {@code null} for no change
 	 * @param lexicalCategory
@@ -1032,7 +1032,7 @@ public class Datamodel {
 	 */
 	public static LexemeUpdate makeLexemeUpdate(
 			LexemeIdValue entityId,
-			LexemeDocument document,
+			long revisionId,
 			ItemIdValue language,
 			ItemIdValue lexicalCategory,
 			TermUpdate lemmas,
@@ -1043,7 +1043,7 @@ public class Datamodel {
 			Collection<FormDocument> addedForms,
 			Collection<FormUpdate> updatedForms,
 			Collection<FormIdValue> removedForms) {
-		return factory.getLexemeUpdate(entityId, document, language, lexicalCategory, lemmas, statements,
+		return factory.getLexemeUpdate(entityId, revisionId, language, lexicalCategory, lemmas, statements,
 				addedSenses, updatedSenses, removedSenses, addedForms, updatedForms, removedForms);
 	}
 
@@ -1053,8 +1053,8 @@ public class Datamodel {
 	 * 
 	 * @param entityId
 	 *            ID of the media that is to be updated
-	 * @param document
-	 *            media revision to be updated or {@code null} if not available
+	 * @param revisionId
+	 *            base media revision to be updated or zero if not available
 	 * @param labels
 	 *            changes in entity labels or {@code null} for no change
 	 * @param statements
@@ -1067,10 +1067,10 @@ public class Datamodel {
 	 */
 	public static MediaInfoUpdate makeMediaInfoUpdate(
 			MediaInfoIdValue entityId,
-			MediaInfoDocument document,
+			long revisionId,
 			TermUpdate labels,
 			StatementUpdate statements) {
-		return factory.getMediaInfoUpdate(entityId, document, labels, statements);
+		return factory.getMediaInfoUpdate(entityId, revisionId, labels, statements);
 	}
 
 	/**
@@ -1079,8 +1079,8 @@ public class Datamodel {
 	 * 
 	 * @param entityId
 	 *            ID of the item that is to be updated
-	 * @param document
-	 *            item revision to be updated or {@code null} if not available
+	 * @param revisionId
+	 *            base item revision to be updated or zero if not available
 	 * @param labels
 	 *            changes in entity labels or {@code null} for no change
 	 * @param descriptions
@@ -1101,14 +1101,14 @@ public class Datamodel {
 	 */
 	public static ItemUpdate makeItemUpdate(
 			ItemIdValue entityId,
-			ItemDocument document,
+			long revisionId,
 			TermUpdate labels,
 			TermUpdate descriptions,
 			Map<String, List<MonolingualTextValue>> aliases,
 			StatementUpdate statements,
 			Collection<SiteLink> modifiedSiteLinks,
 			Collection<String> removedSiteLinks) {
-		return factory.getItemUpdate(entityId, document, labels, descriptions, aliases,
+		return factory.getItemUpdate(entityId, revisionId, labels, descriptions, aliases,
 				statements, modifiedSiteLinks, removedSiteLinks);
 	}
 
@@ -1118,9 +1118,8 @@ public class Datamodel {
 	 * 
 	 * @param entityId
 	 *            ID of the property entity that is to be updated
-	 * @param document
-	 *            property entity revision to be updated or {@code null} if not
-	 *            available
+	 * @param revisionId
+	 *            base property revision to be updated or zero if not available
 	 * @param labels
 	 *            changes in entity labels or {@code null} for no change
 	 * @param descriptions
@@ -1137,12 +1136,12 @@ public class Datamodel {
 	 */
 	public static PropertyUpdate makePropertyUpdate(
 			PropertyIdValue entityId,
-			PropertyDocument document,
+			long revisionId,
 			TermUpdate labels,
 			TermUpdate descriptions,
 			Map<String, List<MonolingualTextValue>> aliases,
 			StatementUpdate statements) {
-		return factory.getPropertyUpdate(entityId, document, labels, descriptions, aliases, statements);
+		return factory.getPropertyUpdate(entityId, revisionId, labels, descriptions, aliases, statements);
 	}
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Datamodel.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Datamodel.java
@@ -21,6 +21,7 @@ package org.wikidata.wdtk.datamodel.helpers;
  */
 
 import java.math.BigDecimal;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -896,4 +897,252 @@ public class Datamodel {
 												List<StatementGroup> statementGroups) {
 		return factory.getMediaInfoDocument(mediaInfoIdValue, labels, statementGroups, 0);
 	}
+
+	/**
+	 * Creates new {@link TermUpdate}. It might be more convenient to
+	 * use {@link TermUpdateBuilder}.
+	 * 
+	 * @param modified
+	 *            added or changed values
+	 * @param removed
+	 *            language codes of removed values
+	 * @return new {@link TermUpdate}
+	 * @throws NullPointerException
+	 *             if any required parameter is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if any parameters or their combination is invalid
+	 */
+	public static TermUpdate makeTermUpdate(
+			Collection<MonolingualTextValue> modified,
+			Collection<String> removed) {
+		return factory.getTermUpdate(modified, removed);
+	}
+
+	/**
+	 * Creates new {@link StatementUpdate}. It might be more convenient to use
+	 * {@link StatementUpdateBuilder}.
+	 * 
+	 * @param added
+	 *            added statements
+	 * @param replaced
+	 *            replaced statements
+	 * @param removed
+	 *            IDs of removed statements
+	 * @return new {@link StatementUpdate}
+	 * @throws NullPointerException
+	 *             if any required parameter is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if any parameters or their combination is invalid
+	 */
+	public static StatementUpdate makeStatementUpdate(
+			Collection<Statement> added,
+			Collection<Statement> replaced,
+			Collection<String> removed) {
+		return factory.getStatementUpdate(added, replaced, removed);
+	}
+
+	/**
+	 * Creates new {@link SenseUpdate}. It might be more convenient to use
+	 * {@link SenseUpdateBuilder}.
+	 * 
+	 * @param entityId
+	 *            ID of the sense that is to be updated
+	 * @param document
+	 *            sense revision to be updated or {@code null} if not available
+	 * @param glosses
+	 *            changes in sense glosses or {@code null} for no change
+	 * @param statements
+	 *            changes in entity statements, possibly empty
+	 * @return new {@link SenseUpdate}
+	 * @throws NullPointerException
+	 *             if any required parameter is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if any parameters or their combination is invalid
+	 */
+	public static SenseUpdate makeSenseUpdate(
+			SenseIdValue entityId,
+			SenseDocument document,
+			TermUpdate glosses,
+			StatementUpdate statements) {
+		return factory.getSenseUpdate(entityId, document, glosses, statements);
+	}
+
+	/**
+	 * Creates new {@link FormUpdate}. It might be more convenient to use
+	 * {@link FormUpdateBuilder}.
+	 * 
+	 * @param entityId
+	 *            ID of the form that is to be updated
+	 * @param document
+	 *            form revision to be updated or {@code null} if not available
+	 * @param representations
+	 *            changes in form representations or {@code null} for no change
+	 * @param grammaticalFeatures
+	 *            new grammatical features of the form or {@code null} for no change
+	 * @param statements
+	 *            changes in entity statements, possibly empty
+	 * @return new {@link FormUpdate}
+	 * @throws NullPointerException
+	 *             if any required parameter is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if any parameters or their combination is invalid
+	 */
+	public static FormUpdate makeFormUpdate(
+			FormIdValue entityId,
+			FormDocument document,
+			TermUpdate representations,
+			Collection<ItemIdValue> grammaticalFeatures,
+			StatementUpdate statements) {
+		return factory.getFormUpdate(entityId, document, representations, grammaticalFeatures, statements);
+	}
+
+	/**
+	 * Creates new {@link LexemeUpdate}. It might be more convenient to use
+	 * {@link LexemeUpdateBuilder}.
+	 * 
+	 * @param entityId
+	 *            ID of the lexeme that is to be updated
+	 * @param document
+	 *            lexeme revision to be updated or {@code null} if not available
+	 * @param language
+	 *            new lexeme language or {@code null} for no change
+	 * @param lexicalCategory
+	 *            new lexical category of the lexeme or {@code null} for no change
+	 * @param lemmas
+	 *            changes in lemmas or {@code null} for no change
+	 * @param statements
+	 *            changes in entity statements, possibly empty
+	 * @param addedSenses
+	 *            added senses
+	 * @param updatedSenses
+	 *            updated senses
+	 * @param removedSenses
+	 *            IDs of removed senses
+	 * @param addedForms
+	 *            added forms
+	 * @param updatedForms
+	 *            updated forms
+	 * @param removedForms
+	 *            IDs of removed forms
+	 * @return new {@link LexemeUpdate}
+	 * @throws NullPointerException
+	 *             if any required parameter is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if any parameters or their combination is invalid
+	 */
+	public static LexemeUpdate makeLexemeUpdate(
+			LexemeIdValue entityId,
+			LexemeDocument document,
+			ItemIdValue language,
+			ItemIdValue lexicalCategory,
+			TermUpdate lemmas,
+			StatementUpdate statements,
+			Collection<SenseDocument> addedSenses,
+			Collection<SenseUpdate> updatedSenses,
+			Collection<SenseIdValue> removedSenses,
+			Collection<FormDocument> addedForms,
+			Collection<FormUpdate> updatedForms,
+			Collection<FormIdValue> removedForms) {
+		return factory.getLexemeUpdate(entityId, document, language, lexicalCategory, lemmas, statements,
+				addedSenses, updatedSenses, removedSenses, addedForms, updatedForms, removedForms);
+	}
+
+	/**
+	 * Creates new {@link MediaInfoUpdate}. It might be more convenient to use
+	 * {@link MediaInfoUpdateBuilder}.
+	 * 
+	 * @param entityId
+	 *            ID of the media that is to be updated
+	 * @param document
+	 *            media revision to be updated or {@code null} if not available
+	 * @param labels
+	 *            changes in entity labels or {@code null} for no change
+	 * @param statements
+	 *            changes in entity statements, possibly empty
+	 * @return new {@link MediaInfoUpdate}
+	 * @throws NullPointerException
+	 *             if any required parameter is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if any parameters or their combination is invalid
+	 */
+	public static MediaInfoUpdate makeMediaInfoUpdate(
+			MediaInfoIdValue entityId,
+			MediaInfoDocument document,
+			TermUpdate labels,
+			StatementUpdate statements) {
+		return factory.getMediaInfoUpdate(entityId, document, labels, statements);
+	}
+
+	/**
+	 * Creates new {@link ItemUpdate}. It might be more convenient to use
+	 * {@link ItemUpdateBuilder}.
+	 * 
+	 * @param entityId
+	 *            ID of the item that is to be updated
+	 * @param document
+	 *            item revision to be updated or {@code null} if not available
+	 * @param labels
+	 *            changes in entity labels or {@code null} for no change
+	 * @param descriptions
+	 *            changes in entity descriptions or {@code null} for no change
+	 * @param aliases
+	 *            changes in entity aliases, possibly empty
+	 * @param statements
+	 *            changes in entity statements, possibly empty
+	 * @param modifiedSiteLinks
+	 *            added or replaced site links
+	 * @param removedSiteLinks
+	 *            site keys of removed site links
+	 * @return new {@link ItemUpdate}
+	 * @throws NullPointerException
+	 *             if any required parameter is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if any parameters or their combination is invalid
+	 */
+	public static ItemUpdate makeItemUpdate(
+			ItemIdValue entityId,
+			ItemDocument document,
+			TermUpdate labels,
+			TermUpdate descriptions,
+			Map<String, List<MonolingualTextValue>> aliases,
+			StatementUpdate statements,
+			Collection<SiteLink> modifiedSiteLinks,
+			Collection<String> removedSiteLinks) {
+		return factory.getItemUpdate(entityId, document, labels, descriptions, aliases,
+				statements, modifiedSiteLinks, removedSiteLinks);
+	}
+
+	/**
+	 * Creates new {@link PropertyUpdate}. It might be more convenient to use
+	 * {@link PropertyUpdateBuilder}.
+	 * 
+	 * @param entityId
+	 *            ID of the property entity that is to be updated
+	 * @param document
+	 *            property entity revision to be updated or {@code null} if not
+	 *            available
+	 * @param labels
+	 *            changes in entity labels or {@code null} for no change
+	 * @param descriptions
+	 *            changes in entity descriptions or {@code null} for no change
+	 * @param aliases
+	 *            changes in entity aliases, possibly empty
+	 * @param statements
+	 *            changes in entity statements, possibly empty
+	 * @return new {@link PropertyUpdate}
+	 * @throws NullPointerException
+	 *             if any required parameter is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if any parameters or their combination is invalid
+	 */
+	public static PropertyUpdate makePropertyUpdate(
+			PropertyIdValue entityId,
+			PropertyDocument document,
+			TermUpdate labels,
+			TermUpdate descriptions,
+			Map<String, List<MonolingualTextValue>> aliases,
+			StatementUpdate statements) {
+		return factory.getPropertyUpdate(entityId, document, labels, descriptions, aliases, statements);
+	}
+
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Datamodel.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Datamodel.java
@@ -25,9 +25,51 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.wikidata.wdtk.datamodel.implementation.DataObjectFactoryImpl;
-import org.wikidata.wdtk.datamodel.interfaces.*;
+import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.Claim;
+import org.wikidata.wdtk.datamodel.interfaces.DataObjectFactory;
+import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
+import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
+import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.FormUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.GlobeCoordinatesValue;
+import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
+import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.ItemUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.LexemeDocument;
+import org.wikidata.wdtk.datamodel.interfaces.LexemeIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.LexemeUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.MediaInfoDocument;
+import org.wikidata.wdtk.datamodel.interfaces.MediaInfoIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.MediaInfoUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+import org.wikidata.wdtk.datamodel.interfaces.NoValueSnak;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.QuantityValue;
+import org.wikidata.wdtk.datamodel.interfaces.Reference;
+import org.wikidata.wdtk.datamodel.interfaces.SenseDocument;
+import org.wikidata.wdtk.datamodel.interfaces.SenseIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.SenseUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
+import org.wikidata.wdtk.datamodel.interfaces.Snak;
+import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
+import org.wikidata.wdtk.datamodel.interfaces.SomeValueSnak;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
+import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
+import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
+import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.StringValue;
+import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.TimeValue;
+import org.wikidata.wdtk.datamodel.interfaces.Value;
+import org.wikidata.wdtk.datamodel.interfaces.ValueSnak;
 
 /**
  * This class contains static methods to create WDTK data objects. This is the
@@ -917,6 +959,72 @@ public class Datamodel {
 			Collection<String> removed) {
 		return factory.getTermUpdate(modified, removed);
 	}
+	
+
+	/**
+	 * Creates new {@link AliasUpdate}. Callers should specify either
+	 * {@code recreated} parameter or {@code added} and {@code removed} parameters,
+	 * because combination of the two update approaches is not possible. To remove
+	 * all aliases, pass empty list in {@code recreated} parameter.
+	 * <p>
+	 * In most cases, it is more convenient to use {@link #makeAliasUpdate(List)},
+	 * {@link #makeAliasUpdate(List, Collection)}, or {@link AliasUpdateBuilder}.
+	 * 
+	 * @param recreated
+	 *            new list of aliases that completely replaces the old ones or
+	 *            {@code null} to not recreate aliases
+	 * @param added
+	 *            aliases added in this update or empty collection for no additions
+	 * @param removed
+	 *            aliases removed in this update or empty collection for no removals
+	 * @return new {@link AliasUpdate}
+	 * @throws NullPointerException
+	 *             if {@code added}, {@code removed}, or any alias is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if given invalid combination of parameters
+	 */
+	public static AliasUpdate makeAliasUpdate(
+			List<MonolingualTextValue> recreated,
+			List<MonolingualTextValue> added,
+			Collection<MonolingualTextValue> removed) {
+		return factory.getAliasUpdate(recreated, added, removed);
+	}
+
+	/**
+	 * Creates new {@link AliasUpdate} that completely replaces all aliases.
+	 * 
+	 * @param recreated
+	 *            new list of aliases that completely replaces the old ones
+	 * @return new {@link AliasUpdate}
+	 * @throws NullPointerException
+	 *             if the parameter or any alias is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if language codes are inconsistent or there are alias duplicates
+	 */
+	public static AliasUpdate makeAliasUpdate(List<MonolingualTextValue> recreated) {
+		Objects.requireNonNull(recreated, "New list of aliases must be provided.");
+		return factory.getAliasUpdate(recreated, Collections.emptyList(), Collections.emptyList());
+	}
+
+	/**
+	 * Creates new {@link AliasUpdate} that adds and/or removes some of the aliases.
+	 * It might be more convenient to use {@link AliasUpdateBuilder}.
+	 * 
+	 * @param added
+	 *            aliases to add
+	 * @param removed
+	 *            aliases to remove
+	 * @return new {@link AliasUpdate}
+	 * @throws NullPointerException
+	 *             if any parameter or any alias is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if language codes are inconsistent or there are alias duplicates
+	 */
+	public static AliasUpdate makeAliasUpdate(
+			List<MonolingualTextValue> added,
+			Collection<MonolingualTextValue> removed) {
+		return factory.getAliasUpdate(null, added, removed);
+	}
 
 	/**
 	 * Creates new {@link StatementUpdate}. It might be more convenient to use
@@ -1104,7 +1212,7 @@ public class Datamodel {
 			long revisionId,
 			TermUpdate labels,
 			TermUpdate descriptions,
-			Map<String, List<MonolingualTextValue>> aliases,
+			Map<String, AliasUpdate> aliases,
 			StatementUpdate statements,
 			Collection<SiteLink> modifiedSiteLinks,
 			Collection<String> removedSiteLinks) {
@@ -1139,7 +1247,7 @@ public class Datamodel {
 			long revisionId,
 			TermUpdate labels,
 			TermUpdate descriptions,
-			Map<String, List<MonolingualTextValue>> aliases,
+			Map<String, AliasUpdate> aliases,
 			StatementUpdate statements) {
 		return factory.getPropertyUpdate(entityId, revisionId, labels, descriptions, aliases, statements);
 	}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/EntityUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/EntityUpdateBuilder.java
@@ -56,11 +56,11 @@ public abstract class EntityUpdateBuilder {
 	 * @throws NullPointerException
 	 *             if {@code entityId} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code entityId} is not a valid ID
+	 *             if {@code entityId} is as placeholder ID
 	 */
 	protected EntityUpdateBuilder(EntityIdValue entityId) {
 		Objects.requireNonNull(entityId, "Entity ID cannot be null.");
-		Validate.isTrue(entityId.isValid(), "Entity ID must be valid.");
+		Validate.isTrue(!entityId.isPlaceholder(), "Cannot create update for placeholder entity ID.");
 		this.entityId = entityId;
 		baseRevision = null;
 	}
@@ -74,11 +74,11 @@ public abstract class EntityUpdateBuilder {
 	 * @throws NullPointerException
 	 *             if {@code revision} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code revision} does not have valid ID
+	 *             if {@code revision} has a placeholder ID
 	 */
 	protected EntityUpdateBuilder(EntityDocument revision) {
 		Objects.requireNonNull(revision, "Base entity revision cannot be null.");
-		Validate.isTrue(revision.getEntityId().isValid(), "Entity ID must be valid.");
+		Validate.isTrue(!revision.getEntityId().isPlaceholder(), "Cannot create update for placeholder entity ID.");
 		entityId = revision.getEntityId();
 		baseRevision = revision;
 	}
@@ -96,7 +96,8 @@ public abstract class EntityUpdateBuilder {
 	 * @throws NullPointerException
 	 *             if {@code entityId} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code entityId} is of unrecognized type
+	 *             if {@code entityId} is of unrecognized type or it's a placeholder
+	 *             ID
 	 */
 	public static EntityUpdateBuilder forEntityId(EntityIdValue entityId) {
 		return StatementDocumentUpdateBuilder.forEntityId(entityId);
@@ -119,7 +120,8 @@ public abstract class EntityUpdateBuilder {
 	 * @throws NullPointerException
 	 *             if {@code revision} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code revision} is of unrecognized type
+	 *             if {@code revision} is of unrecognized type or its ID is a
+	 *             placeholder ID
 	 */
 	public static EntityUpdateBuilder forBaseRevision(EntityDocument revision) {
 		if (revision instanceof StatementDocument) {

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/EntityUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/EntityUpdateBuilder.java
@@ -124,6 +124,7 @@ public abstract class EntityUpdateBuilder {
 	 *             placeholder ID
 	 */
 	public static EntityUpdateBuilder forBaseRevision(EntityDocument revision) {
+		Objects.requireNonNull(revision, "Base entity revision cannot be null.");
 		if (revision instanceof StatementDocument) {
 			return StatementDocumentUpdateBuilder.forBaseRevision((StatementDocument) revision);
 		}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/EntityUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/EntityUpdateBuilder.java
@@ -45,6 +45,7 @@ import org.wikidata.wdtk.datamodel.interfaces.StatementDocument;
 public abstract class EntityUpdateBuilder {
 
 	private final EntityIdValue entityId;
+	private final long baseRevisionId;
 	private final EntityDocument baseRevision;
 
 	/**
@@ -53,15 +54,19 @@ public abstract class EntityUpdateBuilder {
 	 * 
 	 * @param entityId
 	 *            ID of the entity that is to be updated
+	 * @param revisionId
+	 *            ID of the base entity revision to be updated or zero if not
+	 *            available
 	 * @throws NullPointerException
 	 *             if {@code entityId} is {@code null}
 	 * @throws IllegalArgumentException
 	 *             if {@code entityId} is as placeholder ID
 	 */
-	protected EntityUpdateBuilder(EntityIdValue entityId) {
+	protected EntityUpdateBuilder(EntityIdValue entityId, long revisionId) {
 		Objects.requireNonNull(entityId, "Entity ID cannot be null.");
 		Validate.isTrue(!entityId.isPlaceholder(), "Cannot create update for placeholder entity ID.");
 		this.entityId = entityId;
+		this.baseRevisionId = revisionId;
 		baseRevision = null;
 	}
 
@@ -81,6 +86,31 @@ public abstract class EntityUpdateBuilder {
 		Validate.isTrue(!revision.getEntityId().isPlaceholder(), "Cannot create update for placeholder entity ID.");
 		entityId = revision.getEntityId();
 		baseRevision = revision;
+		baseRevisionId = baseRevision.getRevisionId();
+	}
+
+	/**
+	 * Creates new builder object for constructing update of entity with given
+	 * revision ID.
+	 * <p>
+	 * Supported entity IDs include {@link ItemIdValue}, {@link PropertyIdValue},
+	 * {@link LexemeIdValue}, {@link FormIdValue}, {@link SenseIdValue}, and
+	 * {@link MediaInfoIdValue}.
+	 * 
+	 * @param entityId
+	 *            ID of the entity that is to be updated
+	 * @param revisionId
+	 *            ID of the base entity revision to be updated or zero if not
+	 *            available
+	 * @return builder object matching entity type
+	 * @throws NullPointerException
+	 *             if {@code entityId} is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if {@code entityId} is of unrecognized type or it's a placeholder
+	 *             ID
+	 */
+	public static EntityUpdateBuilder forBaseRevisionId(EntityIdValue entityId, long revisionId) {
+		return StatementDocumentUpdateBuilder.forBaseRevisionId(entityId, revisionId);
 	}
 
 	/**
@@ -100,7 +130,7 @@ public abstract class EntityUpdateBuilder {
 	 *             ID
 	 */
 	public static EntityUpdateBuilder forEntityId(EntityIdValue entityId) {
-		return StatementDocumentUpdateBuilder.forEntityId(entityId);
+		return forBaseRevisionId(entityId, 0);
 	}
 
 	/**
@@ -149,6 +179,17 @@ public abstract class EntityUpdateBuilder {
 	 */
 	EntityDocument getBaseRevision() {
 		return baseRevision;
+	}
+
+	/**
+	 * Returns base entity revision ID, upon which this update is built. If no base
+	 * revision nor base revision ID was provided when this builder was constructed,
+	 * this method returns zero.
+	 * 
+	 * @return base entity revision ID
+	 */
+	long getBaseRevisionId() {
+		return baseRevisionId;
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/EntityUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/EntityUpdateBuilder.java
@@ -22,8 +22,6 @@ package org.wikidata.wdtk.datamodel.helpers;
 import java.util.Objects;
 
 import org.apache.commons.lang3.Validate;
-import org.wikidata.wdtk.datamodel.implementation.DataObjectFactoryImpl;
-import org.wikidata.wdtk.datamodel.interfaces.DataObjectFactory;
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.EntityUpdate;
@@ -45,8 +43,6 @@ import org.wikidata.wdtk.datamodel.interfaces.StatementDocument;
  * Builder for incremental construction of {@link EntityUpdate} objects.
  */
 public abstract class EntityUpdateBuilder {
-
-	static DataObjectFactory factory = new DataObjectFactoryImpl();
 
 	private final EntityIdValue entityId;
 	private final EntityDocument baseRevision;

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Equality.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Equality.java
@@ -689,7 +689,7 @@ public class Equality {
 
 	private static boolean equalsEntityUpdate(EntityUpdate o1, EntityUpdate o2) {
 		return Objects.equals(o1.getEntityId(), o2.getEntityId())
-				&& Objects.equals(o1.getBaseRevision(), o2.getBaseRevision());
+				&& o1.getBaseRevisionId() == o2.getBaseRevisionId();
 	}
 
 	private static boolean equalsStatementDocumentUpdate(StatementDocumentUpdate o1, StatementDocumentUpdate o2) {

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Equality.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Equality.java
@@ -40,7 +40,7 @@ import java.util.Objects;
 public class Equality {
 
 	/**
-	 * Returns true if the parameters are two {@link EntityIdValue} objects with
+	 * Returns {@code true} if the parameters are two {@link EntityIdValue} objects with
 	 * exactly the same data. It does not matter if they are different
 	 * implementations of the interface as long as their content is the same.
 	 *
@@ -48,7 +48,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsEntityIdValue(EntityIdValue o1, Object o2) {
 		if (o2 == null) {
@@ -68,7 +68,7 @@ public class Equality {
 	}
 
 	/**
-	 * Returns true if the parameters are two {@link DatatypeIdValue} objects
+	 * Returns {@code true} if the parameters are two {@link DatatypeIdValue} objects
 	 * with exactly the same data. It does not matter if they are different
 	 * implementations of the interface as long as their content is the same.
 	 *
@@ -76,7 +76,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsDatatypeIdValue(DatatypeIdValue o1, Object o2) {
 		if (o2 == null) {
@@ -90,7 +90,7 @@ public class Equality {
 	}
 
 	/**
-	 * Returns true if the parameters are two {@link TimeValue} objects with
+	 * Returns {@code true} if the parameters are two {@link TimeValue} objects with
 	 * exactly the same data. It does not matter if they are different
 	 * implementations of the interface as long as their content is the same.
 	 *
@@ -98,7 +98,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsTimeValue(TimeValue o1, Object o2) {
 		if (o2 == null) {
@@ -126,7 +126,7 @@ public class Equality {
 	}
 
 	/**
-	 * Returns true if the parameters are two {@link GlobeCoordinatesValue}
+	 * Returns {@code true} if the parameters are two {@link GlobeCoordinatesValue}
 	 * objects with exactly the same data. It does not matter if they are
 	 * different implementations of the interface as long as their content is
 	 * the same.
@@ -135,7 +135,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsGlobeCoordinatesValue(GlobeCoordinatesValue o1,
 			Object o2) {
@@ -156,7 +156,7 @@ public class Equality {
 	}
 
 	/**
-	 * Returns true if the parameters are two {@link StringValue} objects with
+	 * Returns {@code true} if the parameters are two {@link StringValue} objects with
 	 * exactly the same data. It does not matter if they are different
 	 * implementations of the interface as long as their content is the same.
 	 *
@@ -164,7 +164,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsStringValue(StringValue o1, Object o2) {
 		if (o2 == null) {
@@ -178,7 +178,7 @@ public class Equality {
 	}
 
 	/**
-	 * Returns true if the parameters are two {@link MonolingualTextValue}
+	 * Returns {@code true} if the parameters are two {@link MonolingualTextValue}
 	 * objects with exactly the same data. It does not matter if they are
 	 * different implementations of the interface as long as their content is
 	 * the same.
@@ -187,7 +187,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsMonolingualTextValue(MonolingualTextValue o1,
 			Object o2) {
@@ -206,7 +206,7 @@ public class Equality {
 	}
 
 	/**
-	 * Returns true if the parameters are two {@link QuantityValue} objects with
+	 * Returns {@code true} if the parameters are two {@link QuantityValue} objects with
 	 * exactly the same data. It does not matter if they are different
 	 * implementations of the interface as long as their content is the same.
 	 *
@@ -214,7 +214,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsQuantityValue(QuantityValue o1, Object o2) {
 		if (o2 == null) {
@@ -234,7 +234,7 @@ public class Equality {
 	}
 
 	/**
-	 * Returns true if the parameters are two {@link ValueSnak} objects with
+	 * Returns {@code true} if the parameters are two {@link ValueSnak} objects with
 	 * exactly the same data. It does not matter if they are different
 	 * implementations of the interface as long as their content is the same.
 	 *
@@ -242,7 +242,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsValueSnak(ValueSnak o1, Object o2) {
 		if (o2 == null) {
@@ -257,7 +257,7 @@ public class Equality {
 	}
 
 	/**
-	 * Returns true if the parameters are two {@link SomeValueSnak} objects with
+	 * Returns {@code true} if the parameters are two {@link SomeValueSnak} objects with
 	 * exactly the same data. It does not matter if they are different
 	 * implementations of the interface as long as their content is the same.
 	 *
@@ -265,7 +265,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsSomeValueSnak(SomeValueSnak o1, Object o2) {
 		if (o2 == null) {
@@ -279,7 +279,7 @@ public class Equality {
 	}
 
 	/**
-	 * Returns true if the parameters are two {@link NoValueSnak} objects with
+	 * Returns {@code true} if the parameters are two {@link NoValueSnak} objects with
 	 * exactly the same data. It does not matter if they are different
 	 * implementations of the interface as long as their content is the same.
 	 *
@@ -287,7 +287,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsNoValueSnak(NoValueSnak o1, Object o2) {
 		if (o2 == null) {
@@ -301,7 +301,7 @@ public class Equality {
 	}
 
 	/**
-	 * Returns true if the parameters are two {@link SnakGroup} objects with
+	 * Returns {@code true} if the parameters are two {@link SnakGroup} objects with
 	 * exactly the same data. It does not matter if they are different
 	 * implementations of the interface as long as their content is the same.
 	 *
@@ -309,7 +309,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsSnakGroup(SnakGroup o1, Object o2) {
 		if (o2 == null) {
@@ -323,7 +323,7 @@ public class Equality {
 	}
 
 	/**
-	 * Returns true if the parameters are two {@link Claim} objects with exactly
+	 * Returns {@code true} if the parameters are two {@link Claim} objects with exactly
 	 * the same data. It does not matter if they are different implementations
 	 * of the interface as long as their content is the same.
 	 *
@@ -331,7 +331,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsClaim(Claim o1, Object o2) {
 		if (o2 == null) {
@@ -350,7 +350,7 @@ public class Equality {
 	}
 
 	/**
-	 * Returns true if the parameters are two {@link Reference} objects with
+	 * Returns {@code true} if the parameters are two {@link Reference} objects with
 	 * exactly the same data. It does not matter if they are different
 	 * implementations of the interface as long as their content is the same.
 	 *
@@ -358,7 +358,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsReference(Reference o1, Object o2) {
 		if (o2 == null) {
@@ -372,7 +372,7 @@ public class Equality {
 	}
 
 	/**
-	 * Returns true if the parameters are two {@link Statement} objects with
+	 * Returns {@code true} if the parameters are two {@link Statement} objects with
 	 * exactly the same data. It does not matter if they are different
 	 * implementations of the interface as long as their content is the same.
 	 *
@@ -380,7 +380,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsStatement(Statement o1, Object o2) {
 		if (o2 == null) {
@@ -402,7 +402,7 @@ public class Equality {
 	}
 
 	/**
-	 * Returns true if the parameters are two {@link StatementGroup} objects
+	 * Returns {@code true} if the parameters are two {@link StatementGroup} objects
 	 * with exactly the same data. It does not matter if they are different
 	 * implementations of the interface as long as their content is the same.
 	 * Note that this includes the statement id, so that two statement objects
@@ -413,7 +413,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsStatementGroup(StatementGroup o1, Object o2) {
 		if (o2 == null) {
@@ -427,7 +427,7 @@ public class Equality {
 	}
 
 	/**
-	 * Returns true if the parameters are two {@link SiteLink} objects with
+	 * Returns {@code true} if the parameters are two {@link SiteLink} objects with
 	 * exactly the same data. It does not matter if they are different
 	 * implementations of the interface as long as their content is the same.
 	 *
@@ -435,7 +435,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsSiteLink(SiteLink o1, Object o2) {
 		if (o2 == null) {
@@ -454,7 +454,7 @@ public class Equality {
 	}
 
 	/**
-	 * Returns true if the parameters are two {@link PropertyDocument} objects
+	 * Returns {@code true} if the parameters are two {@link PropertyDocument} objects
 	 * with exactly the same data. It does not matter if they are different
 	 * implementations of the interface as long as their content is the same.
 	 *
@@ -462,7 +462,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsPropertyDocument(PropertyDocument o1, Object o2) {
 		if (o2 == o1) {
@@ -479,7 +479,7 @@ public class Equality {
 	}
 
 	/**
-	 * Returns true if the parameters are two {@link ItemDocument} objects with
+	 * Returns {@code true} if the parameters are two {@link ItemDocument} objects with
 	 * exactly the same data. It does not matter if they are different
 	 * implementations of the interface as long as their content is the same.
 	 *
@@ -487,7 +487,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsItemDocument(ItemDocument o1, Object o2) {
 		if (o2 == o1) {
@@ -504,7 +504,7 @@ public class Equality {
 	}
 
 	/**
-	 * Returns true if the parameters are two {@link LexemeDocument} objects with
+	 * Returns {@code true} if the parameters are two {@link LexemeDocument} objects with
 	 * exactly the same data. It does not matter if they are different
 	 * implementations of the interface as long as their content is the same.
 	 *
@@ -512,7 +512,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsLexemeDocument(LexemeDocument o1, Object o2) {
 		if (o2 == o1) {
@@ -533,7 +533,7 @@ public class Equality {
 	}
 
 	/**
-	 * Returns true if the parameters are two {@link FormDocument} objects with
+	 * Returns {@code true} if the parameters are two {@link FormDocument} objects with
 	 * exactly the same data. It does not matter if they are different
 	 * implementations of the interface as long as their content is the same.
 	 *
@@ -541,7 +541,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsFormDocument(FormDocument o1, Object o2) {
 		if (o2 == o1) {
@@ -559,7 +559,7 @@ public class Equality {
 	}
 
 	/**
-	 * Returns true if the parameters are two {@link SenseDocument} objects with
+	 * Returns {@code true} if the parameters are two {@link SenseDocument} objects with
 	 * exactly the same data. It does not matter if they are different
 	 * implementations of the interface as long as their content is the same.
 	 *
@@ -567,7 +567,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsSenseDocument(SenseDocument o1, Object o2) {
 		if (o2 == o1) {
@@ -584,7 +584,7 @@ public class Equality {
 	}
 
 	/**
-	 * Returns true if the parameters are two {@link MediaInfoDocument} objects with
+	 * Returns {@code true} if the parameters are two {@link MediaInfoDocument} objects with
 	 * exactly the same data. It does not matter if they are different
 	 * implementations of the interface as long as their content is the same.
 	 *
@@ -592,7 +592,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsMediaInfoDocument(MediaInfoDocument o1, Object o2) {
 		if (o2 == o1) {
@@ -617,7 +617,7 @@ public class Equality {
 	}
 
 	/**
-	 * Returns true if the parameters are two {@link EntityRedirectDocument} objects with
+	 * Returns {@code true} if the parameters are two {@link EntityRedirectDocument} objects with
 	 * exactly the same data. It does not matter if they are different
 	 * implementations of the interface as long as their content is the same.
 	 *
@@ -625,7 +625,7 @@ public class Equality {
 	 *            the first object to compare
 	 * @param o2
 	 *            the second object to compare
-	 * @return true if both objects are equal
+	 * @return {@code true} if both objects are equal
 	 */
 	public static boolean equalsEntityRedirectDocument(EntityRedirectDocument o1, Object o2) {
 		if (o2 == o1) {
@@ -639,4 +639,221 @@ public class Equality {
 				&& o1.getTargetId().equals(other.getTargetId())
 				&& o1.getRevisionId() == other.getRevisionId();
 	}
+
+	/**
+	 * Returns {@code true} if the two {@link TermUpdate} objects contain exactly
+	 * the same data. It does not matter whether they are different implementations
+	 * of the interface as long as their content is the same.
+	 *
+	 * @param o1
+	 *            the first object to compare
+	 * @param o2
+	 *            the second object to compare
+	 * @return {@code true} if both objects are equal
+	 */
+	public static boolean equalsTermUpdate(TermUpdate o1, Object o2) {
+		if (o2 == o1) {
+			return true;
+		}
+		if (!(o2 instanceof TermUpdate)) {
+			return false;
+		}
+		TermUpdate other = (TermUpdate) o2;
+		return Objects.equals(o1.getModifiedTerms(), other.getModifiedTerms())
+				&& Objects.equals(o1.getRemovedTerms(), other.getRemovedTerms());
+	}
+
+	/**
+	 * Returns {@code true} if the two {@link StatementUpdate} objects contain
+	 * exactly the same data. It does not matter whether they are different
+	 * implementations of the interface as long as their content is the same.
+	 *
+	 * @param o1
+	 *            the first object to compare
+	 * @param o2
+	 *            the second object to compare
+	 * @return {@code true} if both objects are equal
+	 */
+	public static boolean equalsStatementUpdate(StatementUpdate o1, Object o2) {
+		if (o2 == o1) {
+			return true;
+		}
+		if (!(o2 instanceof StatementUpdate)) {
+			return false;
+		}
+		StatementUpdate other = (StatementUpdate) o2;
+		return Objects.equals(o1.getAddedStatements(), other.getAddedStatements())
+				&& Objects.equals(o1.getReplacedStatements(), other.getReplacedStatements())
+				&& Objects.equals(o1.getRemovedStatements(), other.getRemovedStatements());
+	}
+
+	private static boolean equalsEntityUpdate(EntityUpdate o1, EntityUpdate o2) {
+		return Objects.equals(o1.getEntityId(), o2.getEntityId())
+				&& Objects.equals(o1.getBaseRevision(), o2.getBaseRevision());
+	}
+
+	private static boolean equalsStatementDocumentUpdate(StatementDocumentUpdate o1, StatementDocumentUpdate o2) {
+		return equalsEntityUpdate(o1, o2)
+				&& Objects.equals(o1.getStatements(), o2.getStatements());
+	}
+
+	private static boolean equalsLabeledStatementDocumentUpdate(
+			LabeledStatementDocumentUpdate o1, LabeledStatementDocumentUpdate o2) {
+		return equalsStatementDocumentUpdate(o1, o2)
+				&& Objects.equals(o1.getLabels(), o2.getLabels());
+	}
+
+	private static boolean equalsTermedStatementDocumentUpdate(
+			TermedStatementDocumentUpdate o1, TermedStatementDocumentUpdate o2) {
+		return equalsLabeledStatementDocumentUpdate(o1, o2)
+				&& Objects.equals(o1.getDescriptions(), o2.getDescriptions())
+				&& Objects.equals(o1.getAliases(), o2.getAliases());
+	}
+
+	/**
+	 * Returns {@code true} if the two {@link MediaInfoUpdate} objects contain
+	 * exactly the same data. It does not matter whether they are different
+	 * implementations of the interface as long as their content is the same.
+	 *
+	 * @param o1
+	 *            the first object to compare
+	 * @param o2
+	 *            the second object to compare
+	 * @return {@code true} if both objects are equal
+	 */
+	public static boolean equalsMediaInfoUpdate(MediaInfoUpdate o1, Object o2) {
+		if (o2 == o1) {
+			return true;
+		}
+		if (!(o2 instanceof MediaInfoUpdate)) {
+			return false;
+		}
+		MediaInfoUpdate other = (MediaInfoUpdate) o2;
+		return equalsLabeledStatementDocumentUpdate(o1, other);
+	}
+
+	/**
+	 * Returns {@code true} if the two {@link ItemUpdate} objects contain exactly
+	 * the same data. It does not matter whether they are different implementations
+	 * of the interface as long as their content is the same.
+	 *
+	 * @param o1
+	 *            the first object to compare
+	 * @param o2
+	 *            the second object to compare
+	 * @return {@code true} if both objects are equal
+	 */
+	public static boolean equalsItemUpdate(ItemUpdate o1, Object o2) {
+		if (o2 == o1) {
+			return true;
+		}
+		if (!(o2 instanceof ItemUpdate)) {
+			return false;
+		}
+		ItemUpdate other = (ItemUpdate) o2;
+		return equalsTermedStatementDocumentUpdate(o1, other)
+				&& Objects.equals(o1.getModifiedSiteLinks(), other.getModifiedSiteLinks())
+				&& Objects.equals(o1.getRemovedSiteLinks(), other.getRemovedSiteLinks());
+	}
+
+	/**
+	 * Returns {@code true} if the two {@link PropertyUpdate} objects contain
+	 * exactly the same data. It does not matter whether they are different
+	 * implementations of the interface as long as their content is the same.
+	 *
+	 * @param o1
+	 *            the first object to compare
+	 * @param o2
+	 *            the second object to compare
+	 * @return {@code true} if both objects are equal
+	 */
+	public static boolean equalsPropertyUpdate(PropertyUpdate o1, Object o2) {
+		if (o2 == o1) {
+			return true;
+		}
+		if (!(o2 instanceof PropertyUpdate)) {
+			return false;
+		}
+		PropertyUpdate other = (PropertyUpdate) o2;
+		return equalsTermedStatementDocumentUpdate(o1, other);
+	}
+
+	/**
+	 * Returns {@code true} if the two {@link SenseUpdate} objects contain exactly
+	 * the same data. It does not matter whether they are different implementations
+	 * of the interface as long as their content is the same.
+	 *
+	 * @param o1
+	 *            the first object to compare
+	 * @param o2
+	 *            the second object to compare
+	 * @return {@code true} if both objects are equal
+	 */
+	public static boolean equalsSenseUpdate(SenseUpdate o1, Object o2) {
+		if (o2 == o1) {
+			return true;
+		}
+		if (!(o2 instanceof SenseUpdate)) {
+			return false;
+		}
+		SenseUpdate other = (SenseUpdate) o2;
+		return equalsStatementDocumentUpdate(o1, other)
+				&& Objects.equals(o1.getGlosses(), other.getGlosses());
+	}
+
+	/**
+	 * Returns {@code true} if the two {@link FormUpdate} objects contain exactly
+	 * the same data. It does not matter whether they are different implementations
+	 * of the interface as long as their content is the same.
+	 *
+	 * @param o1
+	 *            the first object to compare
+	 * @param o2
+	 *            the second object to compare
+	 * @return {@code true} if both objects are equal
+	 */
+	public static boolean equalsFormUpdate(FormUpdate o1, Object o2) {
+		if (o2 == o1) {
+			return true;
+		}
+		if (!(o2 instanceof FormUpdate)) {
+			return false;
+		}
+		FormUpdate other = (FormUpdate) o2;
+		return equalsStatementDocumentUpdate(o1, other)
+				&& Objects.equals(o1.getRepresentations(), other.getRepresentations())
+				&& Objects.equals(o1.getGrammaticalFeatures(), other.getGrammaticalFeatures());
+	}
+
+	/**
+	 * Returns {@code true} if the two {@link LexemeUpdate} objects contain exactly
+	 * the same data. It does not matter whether they are different implementations
+	 * of the interface as long as their content is the same.
+	 *
+	 * @param o1
+	 *            the first object to compare
+	 * @param o2
+	 *            the second object to compare
+	 * @return {@code true} if both objects are equal
+	 */
+	public static boolean equalsLexemeUpdate(LexemeUpdate o1, Object o2) {
+		if (o2 == o1) {
+			return true;
+		}
+		if (!(o2 instanceof LexemeUpdate)) {
+			return false;
+		}
+		LexemeUpdate other = (LexemeUpdate) o2;
+		return equalsStatementDocumentUpdate(o1, other)
+				&& Objects.equals(o1.getLanguage(), other.getLanguage())
+				&& Objects.equals(o1.getLexicalCategory(), other.getLexicalCategory())
+				&& Objects.equals(o1.getLemmas(), other.getLemmas())
+				&& Objects.equals(o1.getAddedSenses(), other.getAddedSenses())
+				&& Objects.equals(o1.getUpdatedSenses(), other.getUpdatedSenses())
+				&& Objects.equals(o1.getRemovedSenses(), other.getRemovedSenses())
+				&& Objects.equals(o1.getAddedForms(), other.getAddedForms())
+				&& Objects.equals(o1.getUpdatedForms(), other.getUpdatedForms())
+				&& Objects.equals(o1.getRemovedForms(), other.getRemovedForms());
+	}
+
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Equality.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Equality.java
@@ -664,6 +664,30 @@ public class Equality {
 	}
 
 	/**
+	 * Returns {@code true} if the two {@link AliasUpdate} objects contain exactly
+	 * the same data. It does not matter whether they are different implementations
+	 * of the interface as long as their content is the same.
+	 *
+	 * @param o1
+	 *            the first object to compare
+	 * @param o2
+	 *            the second object to compare
+	 * @return {@code true} if both objects are equal
+	 */
+	public static boolean equalsAliasUpdate(AliasUpdate o1, Object o2) {
+		if (o2 == o1) {
+			return true;
+		}
+		if (!(o2 instanceof AliasUpdate)) {
+			return false;
+		}
+		AliasUpdate other = (AliasUpdate) o2;
+		return Objects.equals(o1.getRecreated(), other.getRecreated())
+				&& Objects.equals(o1.getAdded(), other.getAdded())
+				&& Objects.equals(o1.getRemoved(), other.getRemoved());
+	}
+
+	/**
 	 * Returns {@code true} if the two {@link StatementUpdate} objects contain
 	 * exactly the same data. It does not matter whether they are different
 	 * implementations of the interface as long as their content is the same.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Equality.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Equality.java
@@ -659,8 +659,8 @@ public class Equality {
 			return false;
 		}
 		TermUpdate other = (TermUpdate) o2;
-		return Objects.equals(o1.getModifiedTerms(), other.getModifiedTerms())
-				&& Objects.equals(o1.getRemovedTerms(), other.getRemovedTerms());
+		return Objects.equals(o1.getModified(), other.getModified())
+				&& Objects.equals(o1.getRemoved(), other.getRemoved());
 	}
 
 	/**
@@ -682,9 +682,9 @@ public class Equality {
 			return false;
 		}
 		StatementUpdate other = (StatementUpdate) o2;
-		return Objects.equals(o1.getAddedStatements(), other.getAddedStatements())
-				&& Objects.equals(o1.getReplacedStatements(), other.getReplacedStatements())
-				&& Objects.equals(o1.getRemovedStatements(), other.getRemovedStatements());
+		return Objects.equals(o1.getAdded(), other.getAdded())
+				&& Objects.equals(o1.getReplaced(), other.getReplaced())
+				&& Objects.equals(o1.getRemoved(), other.getRemoved());
 	}
 
 	private static boolean equalsEntityUpdate(EntityUpdate o1, EntityUpdate o2) {

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/FormUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/FormUpdateBuilder.java
@@ -178,7 +178,7 @@ public class FormUpdateBuilder extends StatementDocumentUpdateBuilder {
 
 	@Override
 	public FormUpdate build() {
-		return factory.getFormUpdate(getEntityId(), getBaseRevision(),
+		return Datamodel.makeFormUpdate(getEntityId(), getBaseRevision(),
 				representations, grammaticalFeatures, statements);
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/FormUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/FormUpdateBuilder.java
@@ -37,7 +37,7 @@ import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
  */
 public class FormUpdateBuilder extends StatementDocumentUpdateBuilder {
 
-	private TermUpdate representations = TermUpdate.NULL;
+	private TermUpdate representations = TermUpdate.EMPTY;
 	private Set<ItemIdValue> grammaticalFeatures;
 
 	private FormUpdateBuilder(FormIdValue formId, long revisionId) {

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/FormUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/FormUpdateBuilder.java
@@ -115,8 +115,8 @@ public class FormUpdateBuilder extends StatementDocumentUpdateBuilder {
 		TermUpdateBuilder combined = getBaseRevision() != null
 				? TermUpdateBuilder.forTerms(getBaseRevision().getRepresentations().values())
 				: TermUpdateBuilder.create();
-		combined.apply(representations);
-		combined.apply(update);
+		combined.append(representations);
+		combined.append(update);
 		representations = combined.build();
 		return this;
 	}
@@ -167,8 +167,8 @@ public class FormUpdateBuilder extends StatementDocumentUpdateBuilder {
 	 *             if {@code update} cannot be applied to base entity revision (if
 	 *             available)
 	 */
-	public FormUpdateBuilder apply(FormUpdate update) {
-		super.apply(update);
+	public FormUpdateBuilder append(FormUpdate update) {
+		super.append(update);
 		updateRepresentations(update.getRepresentations());
 		if (update.getGrammaticalFeatures().isPresent()) {
 			setGrammaticalFeatures(update.getGrammaticalFeatures().get());

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/FormUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/FormUpdateBuilder.java
@@ -40,12 +40,31 @@ public class FormUpdateBuilder extends StatementDocumentUpdateBuilder {
 	private TermUpdate representations = TermUpdate.NULL;
 	private Set<ItemIdValue> grammaticalFeatures;
 
-	private FormUpdateBuilder(FormIdValue formId) {
-		super(formId);
+	private FormUpdateBuilder(FormIdValue formId, long revisionId) {
+		super(formId, revisionId);
 	}
 
 	private FormUpdateBuilder(FormDocument revision) {
 		super(revision);
+	}
+
+	/**
+	 * Creates new builder object for constructing update of form entity with given
+	 * revision ID.
+	 * 
+	 * @param formId
+	 *            ID of the form that is to be updated
+	 * @param revisionId
+	 *            ID of the base form revision to be updated or zero if not
+	 *            available
+	 * @return update builder object
+	 * @throws NullPointerException
+	 *             if {@code formId} is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if {@code formId} is a placeholder ID
+	 */
+	public static FormUpdateBuilder forBaseRevisionId(FormIdValue formId, long revisionId) {
+		return new FormUpdateBuilder(formId, revisionId);
 	}
 
 	/**
@@ -61,7 +80,7 @@ public class FormUpdateBuilder extends StatementDocumentUpdateBuilder {
 	 *             if {@code formId} is a placeholder ID
 	 */
 	public static FormUpdateBuilder forEntityId(FormIdValue formId) {
-		return new FormUpdateBuilder(formId);
+		return new FormUpdateBuilder(formId, 0);
 	}
 
 	/**
@@ -178,7 +197,7 @@ public class FormUpdateBuilder extends StatementDocumentUpdateBuilder {
 
 	@Override
 	public FormUpdate build() {
-		return Datamodel.makeFormUpdate(getEntityId(), getBaseRevision(),
+		return Datamodel.makeFormUpdate(getEntityId(), getBaseRevisionId(),
 				representations, grammaticalFeatures, statements);
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/FormUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/FormUpdateBuilder.java
@@ -58,7 +58,7 @@ public class FormUpdateBuilder extends StatementDocumentUpdateBuilder {
 	 * @throws NullPointerException
 	 *             if {@code formId} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code formId} is not valid
+	 *             if {@code formId} is a placeholder ID
 	 */
 	public static FormUpdateBuilder forEntityId(FormIdValue formId) {
 		return new FormUpdateBuilder(formId);
@@ -77,7 +77,7 @@ public class FormUpdateBuilder extends StatementDocumentUpdateBuilder {
 	 * @throws NullPointerException
 	 *             if {@code revision} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code revision} does not have valid ID
+	 *             if {@code revision} has placeholder ID
 	 */
 	public static FormUpdateBuilder forBaseRevision(FormDocument revision) {
 		return new FormUpdateBuilder(revision);
@@ -134,14 +134,14 @@ public class FormUpdateBuilder extends StatementDocumentUpdateBuilder {
 	 * @throws NullPointerException
 	 *             if {@code features} or any of its items is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if any item ID in {@code features} is invalid or if there are
-	 *             duplicate features
+	 *             if any item ID in {@code features} is a placeholder ID or if
+	 *             there are duplicate features
 	 */
 	public FormUpdateBuilder setGrammaticalFeatures(Collection<ItemIdValue> features) {
 		Objects.requireNonNull(features, "Collection of grammatical features cannot be null.");
 		for (ItemIdValue id : features) {
 			Objects.requireNonNull(id, "Grammatical feature IDs must not be null.");
-			Validate.isTrue(id.isValid(), "Grammatical feature ID must be valid.");
+			Validate.isTrue(!id.isPlaceholder(), "Grammatical feature ID cannot be a placeholder ID.");
 		}
 		Set<ItemIdValue> set = new HashSet<>(features);
 		Validate.isTrue(set.size() == features.size(), "Every grammatical feature must be unique.");

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Hash.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Hash.java
@@ -462,7 +462,7 @@ public class Hash {
 	 * @return object's hash code
 	 */
 	public static int hashCode(TermUpdate o) {
-		return Objects.hash(o.getModifiedTerms(), o.getRemovedTerms());
+		return Objects.hash(o.getModified(), o.getRemoved());
 	}
 
 	/**
@@ -474,7 +474,7 @@ public class Hash {
 	 * @return object's hash code
 	 */
 	public static int hashCode(StatementUpdate o) {
-		return Objects.hash(o.getAddedStatements(), o.getReplacedStatements(), o.getRemovedStatements());
+		return Objects.hash(o.getAdded(), o.getReplaced(), o.getRemoved());
 	}
 
 	private static int hashCodeForEntityUpdate(EntityUpdate o) {

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Hash.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Hash.java
@@ -21,6 +21,7 @@ package org.wikidata.wdtk.datamodel.helpers;
 
 import java.util.Objects;
 
+import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.Claim;
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
@@ -463,6 +464,18 @@ public class Hash {
 	 */
 	public static int hashCode(TermUpdate o) {
 		return Objects.hash(o.getModified(), o.getRemoved());
+	}
+
+	/**
+	 * Calculates hash code for given {@link AliasUpdate} object.
+	 *
+	 * @see Object#hashCode()
+	 * @param o
+	 *            the object to create a hash for
+	 * @return object's hash code
+	 */
+	public static int hashCode(AliasUpdate o) {
+		return Objects.hash(o.getRecreated(), o.getAdded(), o.getRemoved());
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Hash.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Hash.java
@@ -1,5 +1,3 @@
-package org.wikidata.wdtk.datamodel.helpers;
-
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -19,8 +17,46 @@ package org.wikidata.wdtk.datamodel.helpers;
  * limitations under the License.
  * #L%
  */
+package org.wikidata.wdtk.datamodel.helpers;
 
-import org.wikidata.wdtk.datamodel.interfaces.*;
+import java.util.Objects;
+
+import org.wikidata.wdtk.datamodel.interfaces.Claim;
+import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.EntityRedirectDocument;
+import org.wikidata.wdtk.datamodel.interfaces.EntityUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
+import org.wikidata.wdtk.datamodel.interfaces.FormUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.GlobeCoordinatesValue;
+import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
+import org.wikidata.wdtk.datamodel.interfaces.ItemUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.LabeledStatementDocumentUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.LexemeDocument;
+import org.wikidata.wdtk.datamodel.interfaces.LexemeUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.MediaInfoDocument;
+import org.wikidata.wdtk.datamodel.interfaces.MediaInfoUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+import org.wikidata.wdtk.datamodel.interfaces.NoValueSnak;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.QuantityValue;
+import org.wikidata.wdtk.datamodel.interfaces.Reference;
+import org.wikidata.wdtk.datamodel.interfaces.SenseDocument;
+import org.wikidata.wdtk.datamodel.interfaces.SenseUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
+import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
+import org.wikidata.wdtk.datamodel.interfaces.SomeValueSnak;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
+import org.wikidata.wdtk.datamodel.interfaces.StatementDocumentUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
+import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.StringValue;
+import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.TermedDocument;
+import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocumentUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.TimeValue;
+import org.wikidata.wdtk.datamodel.interfaces.ValueSnak;
 
 /**
  * Static class for computing a hashcode of arbitrary data objects using only
@@ -37,7 +73,7 @@ public class Hash {
 	/**
 	 * Prime number used to build hashes.
 	 */
-	final static int prime = 31;
+	private static final int PRIME = 31;
 
 	/**
 	 * Returns a hash code for the given object.
@@ -50,8 +86,8 @@ public class Hash {
 	public static int hashCode(EntityIdValue o) {
 		int result;
 		result = o.getId().hashCode();
-		result = prime * result + o.getSiteIri().hashCode();
-		result = prime * result + o.getEntityType().hashCode();
+		result = PRIME * result + o.getSiteIri().hashCode();
+		result = PRIME * result + o.getEntityType().hashCode();
 		return result;
 	}
 
@@ -78,16 +114,16 @@ public class Hash {
 	public static int hashCode(TimeValue o) {
 		int result;
 		result = Long.hashCode(o.getYear());
-		result = prime * result + o.getMonth();
-		result = prime * result + o.getDay();
-		result = prime * result + o.getHour();
-		result = prime * result + o.getMinute();
-		result = prime * result + o.getSecond();
-		result = prime * result + o.getPrecision();
-		result = prime * result + o.getBeforeTolerance();
-		result = prime * result + o.getAfterTolerance();
-		result = prime * result + o.getTimezoneOffset();
-		result = prime * result + o.getPreferredCalendarModel().hashCode();
+		result = PRIME * result + o.getMonth();
+		result = PRIME * result + o.getDay();
+		result = PRIME * result + o.getHour();
+		result = PRIME * result + o.getMinute();
+		result = PRIME * result + o.getSecond();
+		result = PRIME * result + o.getPrecision();
+		result = PRIME * result + o.getBeforeTolerance();
+		result = PRIME * result + o.getAfterTolerance();
+		result = PRIME * result + o.getTimezoneOffset();
+		result = PRIME * result + o.getPreferredCalendarModel().hashCode();
 		return result;
 	}
 
@@ -104,11 +140,11 @@ public class Hash {
 		result = o.getGlobe().hashCode();
 		long value;
 		value = Double.valueOf(o.getLatitude()).hashCode();
-		result = prime * result + (int) (value ^ (value >>> 32));
+		result = PRIME * result + (int) (value ^ (value >>> 32));
 		value = Double.valueOf(o.getLongitude()).hashCode();
-		result = prime * result + (int) (value ^ (value >>> 32));
+		result = PRIME * result + (int) (value ^ (value >>> 32));
 		value = Double.valueOf(o.getPrecision()).hashCode();
-		result = prime * result + (int) (value ^ (value >>> 32));
+		result = PRIME * result + (int) (value ^ (value >>> 32));
 		return result;
 	}
 
@@ -135,7 +171,7 @@ public class Hash {
 	public static int hashCode(MonolingualTextValue o) {
 		int result;
 		result = o.getLanguageCode().hashCode();
-		result = prime * result + o.getText().hashCode();
+		result = PRIME * result + o.getText().hashCode();
 		return result;
 	}
 
@@ -150,12 +186,12 @@ public class Hash {
 	public static int hashCode(QuantityValue o) {
 		int result;
 		result = o.getNumericValue().hashCode();
-		result = prime * result + o.getUnit().hashCode();
+		result = PRIME * result + o.getUnit().hashCode();
 		if(o.getLowerBound() != null) {
-			result = prime * result + o.getLowerBound().hashCode();
+			result = PRIME * result + o.getLowerBound().hashCode();
 		}
 		if(o.getUpperBound() != null) {
-			result = prime * result + o.getUpperBound().hashCode();
+			result = PRIME * result + o.getUpperBound().hashCode();
 		}
 		return result;
 	}
@@ -171,7 +207,7 @@ public class Hash {
 	public static int hashCode(ValueSnak o) {
 		int result;
 		result = o.getValue().hashCode();
-		result = prime * result + o.getPropertyId().hashCode();
+		result = PRIME * result + o.getPropertyId().hashCode();
 		return result;
 	}
 
@@ -222,8 +258,8 @@ public class Hash {
 	public static int hashCode(Claim o) {
 		int result;
 		result = o.getSubject().hashCode();
-		result = prime * result + o.getMainSnak().hashCode();
-		result = prime * result + o.getQualifiers().hashCode();
+		result = PRIME * result + o.getMainSnak().hashCode();
+		result = PRIME * result + o.getQualifiers().hashCode();
 		return result;
 	}
 
@@ -250,11 +286,11 @@ public class Hash {
 	public static int hashCode(Statement o) {
 		int result;
 		result = o.getSubject().hashCode();
-		result = prime * result + o.getMainSnak().hashCode();
-		result = prime * result + o.getQualifiers().hashCode();
-		result = prime * result + o.getReferences().hashCode();
-		result = prime * result + o.getRank().hashCode();
-		result = prime * result + o.getStatementId().hashCode();
+		result = PRIME * result + o.getMainSnak().hashCode();
+		result = PRIME * result + o.getQualifiers().hashCode();
+		result = PRIME * result + o.getReferences().hashCode();
+		result = PRIME * result + o.getRank().hashCode();
+		result = PRIME * result + o.getStatementId().hashCode();
 		return result;
 	}
 
@@ -281,8 +317,8 @@ public class Hash {
 	public static int hashCode(SiteLink o) {
 		int result;
 		result = o.getBadges().hashCode();
-		result = prime * result + o.getPageTitle().hashCode();
-		result = prime * result + o.getSiteKey().hashCode();
+		result = PRIME * result + o.getPageTitle().hashCode();
+		result = PRIME * result + o.getSiteKey().hashCode();
 		return result;
 	}
 
@@ -297,8 +333,8 @@ public class Hash {
 	public static int hashCode(PropertyDocument o) {
 		int result;
 		result = hashCodeForTermedDocument(o);
-		result = prime * result + o.getStatementGroups().hashCode();
-		result = prime * result + o.getDatatype().hashCode();
+		result = PRIME * result + o.getStatementGroups().hashCode();
+		result = PRIME * result + o.getDatatype().hashCode();
 		return result;
 	}
 
@@ -313,8 +349,8 @@ public class Hash {
 	public static int hashCode(ItemDocument o) {
 		int result;
 		result = hashCodeForTermedDocument(o);
-		result = prime * result + o.getStatementGroups().hashCode();
-		result = prime * result + o.getSiteLinks().hashCode();
+		result = PRIME * result + o.getStatementGroups().hashCode();
+		result = PRIME * result + o.getSiteLinks().hashCode();
 		return result;
 	}
 
@@ -329,10 +365,10 @@ public class Hash {
 	public static int hashCode(LexemeDocument o) {
 		int result;
 		result = o.getLexicalCategory().hashCode();
-		result = prime * result + o.getLanguage().hashCode();
-		result = prime * result + o.getLemmas().hashCode();
-		result = prime * result + Long.hashCode(o.getRevisionId());
-		result = prime * result + o.getStatementGroups().hashCode();
+		result = PRIME * result + o.getLanguage().hashCode();
+		result = PRIME * result + o.getLemmas().hashCode();
+		result = PRIME * result + Long.hashCode(o.getRevisionId());
+		result = PRIME * result + o.getStatementGroups().hashCode();
 		return result;
 	}
 
@@ -347,9 +383,9 @@ public class Hash {
 	public static int hashCode(FormDocument o) {
 		int result;
 		result = o.getGrammaticalFeatures().hashCode();
-		result = prime * result + o.getRepresentations().hashCode();
-		result = prime * result + Long.hashCode(o.getRevisionId());
-		result = prime * result + o.getStatementGroups().hashCode();
+		result = PRIME * result + o.getRepresentations().hashCode();
+		result = PRIME * result + Long.hashCode(o.getRevisionId());
+		result = PRIME * result + o.getStatementGroups().hashCode();
 		return result;
 	}
 
@@ -364,8 +400,8 @@ public class Hash {
 	public static int hashCode(SenseDocument o) {
 		int result;
 		result = o.getGlosses().hashCode();
-		result = prime * result + Long.hashCode(o.getRevisionId());
-		result = prime * result + o.getStatementGroups().hashCode();
+		result = PRIME * result + Long.hashCode(o.getRevisionId());
+		result = PRIME * result + o.getStatementGroups().hashCode();
 		return result;
 	}
 
@@ -380,7 +416,7 @@ public class Hash {
 	public static int hashCode(MediaInfoDocument o) {
 		int result;
 		result = o.getLabels().hashCode();
-		result = prime * result + o.getStatementGroups().hashCode();
+		result = PRIME * result + o.getStatementGroups().hashCode();
 		return result;
 	}
 
@@ -395,9 +431,9 @@ public class Hash {
 	private static int hashCodeForTermedDocument(TermedDocument o) {
 		int result;
 		result = o.getAliases().hashCode();
-		result = prime * result + o.getDescriptions().hashCode();
-		result = prime * result + o.getLabels().hashCode();
-		result = prime * result + Long.hashCode(o.getRevisionId());
+		result = PRIME * result + o.getDescriptions().hashCode();
+		result = PRIME * result + o.getLabels().hashCode();
+		result = PRIME * result + Long.hashCode(o.getRevisionId());
 		return result;
 	}
 
@@ -412,8 +448,132 @@ public class Hash {
 	public static int hashCode(EntityRedirectDocument o) {
 		int result;
 		result = o.getEntityId().hashCode();
-		result = prime * result + o.getTargetId().hashCode();
-		result = prime * result + Long.hashCode(o.getRevisionId());
+		result = PRIME * result + o.getTargetId().hashCode();
+		result = PRIME * result + Long.hashCode(o.getRevisionId());
 		return result;
 	}
+
+	/**
+	 * Calculates hash code for given {@link TermUpdate} object.
+	 *
+	 * @see Object#hashCode()
+	 * @param o
+	 *            the object to create a hash for
+	 * @return object's hash code
+	 */
+	public static int hashCode(TermUpdate o) {
+		return Objects.hash(o.getModifiedTerms(), o.getRemovedTerms());
+	}
+
+	/**
+	 * Calculates hash code for given {@link StatementUpdate} object.
+	 *
+	 * @see Object#hashCode()
+	 * @param o
+	 *            the object to create a hash for
+	 * @return object's hash code
+	 */
+	public static int hashCode(StatementUpdate o) {
+		return Objects.hash(o.getAddedStatements(), o.getReplacedStatements(), o.getRemovedStatements());
+	}
+
+	private static int hashCodeForEntityUpdate(EntityUpdate o) {
+		return Objects.hash(o.getEntityId(), o.getBaseRevision());
+	}
+
+	private static int hashCodeForStatementDocumentUpdate(StatementDocumentUpdate o) {
+		return hashCodeForEntityUpdate(o) * PRIME + Objects.hash(o.getStatements());
+	}
+
+	private static int hashCodeForLabeledStatementDocumentUpdate(LabeledStatementDocumentUpdate o) {
+		return hashCodeForStatementDocumentUpdate(o) * PRIME + Objects.hash(o.getLabels());
+	}
+
+	private static int hashCodeForTermedStatementDocumentUpdate(TermedStatementDocumentUpdate o) {
+		return hashCodeForLabeledStatementDocumentUpdate(o) * PRIME + Objects.hash(o.getDescriptions(), o.getAliases());
+	}
+
+	/**
+	 * Calculates hash code for given {@link MediaInfoUpdate} object.
+	 *
+	 * @see Object#hashCode()
+	 * @param o
+	 *            the object to create a hash for
+	 * @return object's hash code
+	 */
+	public static int hashCode(MediaInfoUpdate o) {
+		return hashCodeForLabeledStatementDocumentUpdate(o);
+	}
+
+	/**
+	 * Calculates hash code for given {@link ItemUpdate} object.
+	 *
+	 * @see Object#hashCode()
+	 * @param o
+	 *            the object to create a hash for
+	 * @return object's hash code
+	 */
+	public static int hashCode(ItemUpdate o) {
+		return hashCodeForTermedStatementDocumentUpdate(o) * PRIME
+				+ Objects.hash(o.getModifiedSiteLinks(), o.getRemovedSiteLinks());
+	}
+
+	/**
+	 * Calculates hash code for given {@link PropertyUpdate} object.
+	 *
+	 * @see Object#hashCode()
+	 * @param o
+	 *            the object to create a hash for
+	 * @return object's hash code
+	 */
+	public static int hashCode(PropertyUpdate o) {
+		return hashCodeForTermedStatementDocumentUpdate(o);
+	}
+
+	/**
+	 * Calculates hash code for given {@link SenseUpdate} object.
+	 *
+	 * @see Object#hashCode()
+	 * @param o
+	 *            the object to create a hash for
+	 * @return object's hash code
+	 */
+	public static int hashCode(SenseUpdate o) {
+		return hashCodeForStatementDocumentUpdate(o) * PRIME + Objects.hash(o.getGlosses());
+	}
+
+	/**
+	 * Calculates hash code for given {@link FormUpdate} object.
+	 *
+	 * @see Object#hashCode()
+	 * @param o
+	 *            the object to create a hash for
+	 * @return object's hash code
+	 */
+	public static int hashCode(FormUpdate o) {
+		return hashCodeForStatementDocumentUpdate(o) * PRIME
+				+ Objects.hash(o.getRepresentations(), o.getGrammaticalFeatures());
+	}
+
+	/**
+	 * Calculates hash code for given {@link LexemeUpdate} object.
+	 *
+	 * @see Object#hashCode()
+	 * @param o
+	 *            the object to create a hash for
+	 * @return object's hash code
+	 */
+	public static int hashCode(LexemeUpdate o) {
+		return hashCodeForStatementDocumentUpdate(o) * PRIME + Objects.hash(
+				o.getLanguage(),
+				o.getLexicalCategory(),
+				o.getLemmas(),
+				o.getAddedSenses(),
+				o.getUpdatedSenses(),
+				o.getRemovedSenses(),
+				o.getAddedForms(),
+				o.getUpdatedForms(),
+				o.getRemovedForms());
+	}
+
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Hash.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Hash.java
@@ -478,7 +478,7 @@ public class Hash {
 	}
 
 	private static int hashCodeForEntityUpdate(EntityUpdate o) {
-		return Objects.hash(o.getEntityId(), o.getBaseRevision());
+		return Objects.hash(o.getEntityId(), o.getBaseRevisionId());
 	}
 
 	private static int hashCodeForStatementDocumentUpdate(StatementDocumentUpdate o) {

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilder.java
@@ -204,7 +204,7 @@ public class ItemUpdateBuilder extends TermedStatementDocumentUpdateBuilder {
 
 	@Override
 	public ItemUpdate build() {
-		return factory.getItemUpdate(getEntityId(), getBaseRevision(), labels, descriptions, aliases, statements,
+		return Datamodel.makeItemUpdate(getEntityId(), getBaseRevision(), labels, descriptions, aliases, statements,
 				modifiedSiteLinks.values(), removedSiteLinks);
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilder.java
@@ -21,16 +21,15 @@ package org.wikidata.wdtk.datamodel.helpers;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
 import org.apache.commons.lang3.Validate;
+import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ItemUpdate;
-import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
@@ -134,14 +133,8 @@ public class ItemUpdateBuilder extends TermedDocumentUpdateBuilder {
 	}
 
 	@Override
-	public ItemUpdateBuilder putAliases(String language, List<MonolingualTextValue> aliases) {
-		super.putAliases(language, aliases);
-		return this;
-	}
-
-	@Override
-	public ItemUpdateBuilder putAliasesAsStrings(String language, List<String> aliases) {
-		super.putAliasesAsStrings(language, aliases);
+	public ItemUpdateBuilder updateAliases(String language, AliasUpdate update) {
+		super.updateAliases(language, update);
 		return this;
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilder.java
@@ -43,12 +43,31 @@ public class ItemUpdateBuilder extends TermedDocumentUpdateBuilder {
 	private final Map<String, SiteLink> modifiedSiteLinks = new HashMap<>();
 	private final Set<String> removedSiteLinks = new HashSet<>();
 
-	private ItemUpdateBuilder(ItemIdValue itemId) {
-		super(itemId);
+	private ItemUpdateBuilder(ItemIdValue itemId, long revisionId) {
+		super(itemId, revisionId);
 	}
 
 	private ItemUpdateBuilder(ItemDocument revision) {
 		super(revision);
+	}
+
+	/**
+	 * Creates new builder object for constructing update of item entity with given
+	 * revision ID.
+	 * 
+	 * @param itemId
+	 *            ID of the item entity that is to be updated
+	 * @param revisionId
+	 *            ID of the base item revision to be updated or zero if not
+	 *            available
+	 * @return update builder object
+	 * @throws NullPointerException
+	 *             if {@code itemId} is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if {@code itemId} is a placeholder ID
+	 */
+	public static ItemUpdateBuilder forBaseRevisionId(ItemIdValue itemId, long revisionId) {
+		return new ItemUpdateBuilder(itemId, revisionId);
 	}
 
 	/**
@@ -64,7 +83,7 @@ public class ItemUpdateBuilder extends TermedDocumentUpdateBuilder {
 	 *             if {@code itemId} is a placeholder ID
 	 */
 	public static ItemUpdateBuilder forEntityId(ItemIdValue itemId) {
-		return new ItemUpdateBuilder(itemId);
+		return new ItemUpdateBuilder(itemId, 0);
 	}
 
 	/**
@@ -211,7 +230,7 @@ public class ItemUpdateBuilder extends TermedDocumentUpdateBuilder {
 
 	@Override
 	public ItemUpdate build() {
-		return Datamodel.makeItemUpdate(getEntityId(), getBaseRevision(), labels, descriptions, aliases, statements,
+		return Datamodel.makeItemUpdate(getEntityId(), getBaseRevisionId(), labels, descriptions, aliases, statements,
 				modifiedSiteLinks.values(), removedSiteLinks);
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilder.java
@@ -37,7 +37,7 @@ import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 /**
  * Builder for incremental construction of {@link ItemUpdate} objects.
  */
-public class ItemUpdateBuilder extends TermedStatementDocumentUpdateBuilder {
+public class ItemUpdateBuilder extends TermedDocumentUpdateBuilder {
 
 	private final Map<String, SiteLink> modifiedSiteLinks = new HashMap<>();
 	private final Set<String> removedSiteLinks = new HashSet<>();

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilder.java
@@ -148,9 +148,15 @@ public class ItemUpdateBuilder extends TermedStatementDocumentUpdateBuilder {
 	 * @return {@code this} (fluent method)
 	 * @throws NullPointerException
 	 *             if {@code site} is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if there is no such site link in base entity revision (if
+	 *             available)
 	 */
 	public ItemUpdateBuilder removeSiteLink(String site) {
 		Objects.requireNonNull(site, "Site key cannot be null.");
+		if (getBaseRevision() != null && !getBaseRevision().getSiteLinks().containsKey(site)) {
+			throw new IllegalArgumentException("Removed site link is not in the current revision.");
+		}
 		removedSiteLinks.add(site);
 		modifiedSiteLinks.remove(site);
 		return this;

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilder.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang3.Validate;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ItemUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
@@ -114,8 +115,14 @@ public class ItemUpdateBuilder extends TermedDocumentUpdateBuilder {
 	}
 
 	@Override
-	public ItemUpdateBuilder setAliases(String language, List<String> aliases) {
-		super.setAliases(language, aliases);
+	public ItemUpdateBuilder putAliases(String language, List<MonolingualTextValue> aliases) {
+		super.putAliases(language, aliases);
+		return this;
+	}
+
+	@Override
+	public ItemUpdateBuilder putAliasesAsStrings(String language, List<String> aliases) {
+		super.putAliasesAsStrings(language, aliases);
 		return this;
 	}
 
@@ -135,7 +142,7 @@ public class ItemUpdateBuilder extends TermedDocumentUpdateBuilder {
 	 * @throws NullPointerException
 	 *             if {@code link} is {@code null}
 	 */
-	public ItemUpdateBuilder setSiteLink(SiteLink link) {
+	public ItemUpdateBuilder putSiteLink(SiteLink link) {
 		Objects.requireNonNull(link, "Site link cannot be null.");
 		if (getBaseRevision() != null) {
 			SiteLink original = getBaseRevision().getSiteLinks().get(link.getSiteKey());
@@ -153,7 +160,7 @@ public class ItemUpdateBuilder extends TermedDocumentUpdateBuilder {
 	/**
 	 * Removes site link. Site links with other site keys are not touched. Calling
 	 * this method overrides any previous changes made with the same site key by
-	 * this method or {@link #setSiteLink(SiteLink)}.
+	 * this method or {@link #putSiteLink(SiteLink)}.
 	 * <p>
 	 * If base entity revision was provided, attempts to remove missing site links
 	 * will be silently ignored, resulting in empty update.
@@ -191,10 +198,10 @@ public class ItemUpdateBuilder extends TermedDocumentUpdateBuilder {
 	 *             if {@code update} cannot be applied to base entity revision (if
 	 *             available)
 	 */
-	public ItemUpdateBuilder apply(ItemUpdate update) {
-		super.apply(update);
+	public ItemUpdateBuilder append(ItemUpdate update) {
+		super.append(update);
 		for (SiteLink link : update.getModifiedSiteLinks().values()) {
-			setSiteLink(link);
+			putSiteLink(link);
 		}
 		for (String site : update.getRemovedSiteLinks()) {
 			removeSiteLink(site);

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilder.java
@@ -60,7 +60,7 @@ public class ItemUpdateBuilder extends TermedStatementDocumentUpdateBuilder {
 	 * @throws NullPointerException
 	 *             if {@code itemId} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code itemId} is not valid
+	 *             if {@code itemId} is a placeholder ID
 	 */
 	public static ItemUpdateBuilder forEntityId(ItemIdValue itemId) {
 		return new ItemUpdateBuilder(itemId);
@@ -79,7 +79,7 @@ public class ItemUpdateBuilder extends TermedStatementDocumentUpdateBuilder {
 	 * @throws NullPointerException
 	 *             if {@code revision} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code revision} does not have valid ID
+	 *             if {@code revision} has placeholder ID
 	 */
 	public static ItemUpdateBuilder forBaseRevision(ItemDocument revision) {
 		return new ItemUpdateBuilder(revision);

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LabeledDocumentUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LabeledDocumentUpdateBuilder.java
@@ -40,7 +40,7 @@ import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocument;
  */
 public abstract class LabeledDocumentUpdateBuilder extends StatementDocumentUpdateBuilder {
 
-	TermUpdate labels = TermUpdate.NULL;
+	TermUpdate labels = TermUpdate.EMPTY;
 
 	/**
 	 * Initializes new builder object for constructing update of entity with given

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LabeledDocumentUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LabeledDocumentUpdateBuilder.java
@@ -48,13 +48,16 @@ public abstract class LabeledDocumentUpdateBuilder extends StatementDocumentUpda
 	 * 
 	 * @param entityId
 	 *            ID of the entity that is to be updated
+	 * @param revisionId
+	 *            ID of the base entity revision to be updated or zero if not
+	 *            available
 	 * @throws NullPointerException
 	 *             if {@code entityId} is {@code null}
 	 * @throws IllegalArgumentException
 	 *             if {@code entityId} is a placeholder ID
 	 */
-	protected LabeledDocumentUpdateBuilder(EntityIdValue entityId) {
-		super(entityId);
+	protected LabeledDocumentUpdateBuilder(EntityIdValue entityId, long revisionId) {
+		super(entityId, revisionId);
 	}
 
 	/**
@@ -73,6 +76,33 @@ public abstract class LabeledDocumentUpdateBuilder extends StatementDocumentUpda
 	}
 
 	/**
+	 * Creates new builder object for constructing update of entity with given
+	 * revision ID.
+	 * <p>
+	 * Supported entity IDs include {@link ItemIdValue}, {@link PropertyIdValue},
+	 * and {@link MediaInfoIdValue}.
+	 * 
+	 * @param entityId
+	 *            ID of the entity that is to be updated
+	 * @param revisionId
+	 *            ID of the base entity revision to be updated or zero if not
+	 *            available
+	 * @return builder object matching entity type
+	 * @throws NullPointerException
+	 *             if {@code entityId} is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if {@code entityId} is of unrecognized type or it is a
+	 *             placeholder ID
+	 */
+	public static LabeledDocumentUpdateBuilder forBaseRevisionId(EntityIdValue entityId, long revisionId) {
+		Objects.requireNonNull(entityId, "Entity ID cannot be null.");
+		if (entityId instanceof MediaInfoIdValue) {
+			return MediaInfoUpdateBuilder.forBaseRevisionId((MediaInfoIdValue) entityId, revisionId);
+		}
+		return TermedDocumentUpdateBuilder.forBaseRevisionId(entityId, revisionId);
+	}
+
+	/**
 	 * Creates new builder object for constructing update of entity with given ID.
 	 * <p>
 	 * Supported entity IDs include {@link ItemIdValue}, {@link PropertyIdValue},
@@ -88,11 +118,7 @@ public abstract class LabeledDocumentUpdateBuilder extends StatementDocumentUpda
 	 *             placeholder ID
 	 */
 	public static LabeledDocumentUpdateBuilder forEntityId(EntityIdValue entityId) {
-		Objects.requireNonNull(entityId, "Entity ID cannot be null.");
-		if (entityId instanceof MediaInfoIdValue) {
-			return MediaInfoUpdateBuilder.forEntityId((MediaInfoIdValue) entityId);
-		}
-		return TermedDocumentUpdateBuilder.forEntityId(entityId);
+		return forBaseRevisionId(entityId, 0);
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LabeledDocumentUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LabeledDocumentUpdateBuilder.java
@@ -38,7 +38,7 @@ import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocument;
  * Builder for incremental construction of
  * {@link LabeledStatementDocumentUpdate} objects.
  */
-public abstract class LabeledStatementDocumentUpdateBuilder extends StatementDocumentUpdateBuilder {
+public abstract class LabeledDocumentUpdateBuilder extends StatementDocumentUpdateBuilder {
 
 	TermUpdate labels = TermUpdate.NULL;
 
@@ -53,7 +53,7 @@ public abstract class LabeledStatementDocumentUpdateBuilder extends StatementDoc
 	 * @throws IllegalArgumentException
 	 *             if {@code entityId} is a placeholder ID
 	 */
-	protected LabeledStatementDocumentUpdateBuilder(EntityIdValue entityId) {
+	protected LabeledDocumentUpdateBuilder(EntityIdValue entityId) {
 		super(entityId);
 	}
 
@@ -68,7 +68,7 @@ public abstract class LabeledStatementDocumentUpdateBuilder extends StatementDoc
 	 * @throws IllegalArgumentException
 	 *             if {@code revision} has placeholder ID
 	 */
-	protected LabeledStatementDocumentUpdateBuilder(LabeledStatementDocument revision) {
+	protected LabeledDocumentUpdateBuilder(LabeledStatementDocument revision) {
 		super(revision);
 	}
 
@@ -87,12 +87,12 @@ public abstract class LabeledStatementDocumentUpdateBuilder extends StatementDoc
 	 *             if {@code entityId} is of unrecognized type or it is a
 	 *             placeholder ID
 	 */
-	public static LabeledStatementDocumentUpdateBuilder forEntityId(EntityIdValue entityId) {
+	public static LabeledDocumentUpdateBuilder forEntityId(EntityIdValue entityId) {
 		Objects.requireNonNull(entityId, "Entity ID cannot be null.");
 		if (entityId instanceof MediaInfoIdValue) {
 			return MediaInfoUpdateBuilder.forEntityId((MediaInfoIdValue) entityId);
 		}
-		return TermedStatementDocumentUpdateBuilder.forEntityId(entityId);
+		return TermedDocumentUpdateBuilder.forEntityId(entityId);
 	}
 
 	/**
@@ -114,13 +114,13 @@ public abstract class LabeledStatementDocumentUpdateBuilder extends StatementDoc
 	 *             if {@code revision} is of unrecognized type or its ID is a
 	 *             placeholder ID
 	 */
-	public static LabeledStatementDocumentUpdateBuilder forBaseRevision(LabeledStatementDocument revision) {
+	public static LabeledDocumentUpdateBuilder forBaseRevision(LabeledStatementDocument revision) {
 		Objects.requireNonNull(revision, "Base entity revision cannot be null.");
 		if (revision instanceof MediaInfoDocument) {
 			return MediaInfoUpdateBuilder.forBaseRevision((MediaInfoDocument) revision);
 		}
 		if (revision instanceof TermedStatementDocument) {
-			return TermedStatementDocumentUpdateBuilder.forBaseRevision((TermedStatementDocument) revision);
+			return TermedDocumentUpdateBuilder.forBaseRevision((TermedStatementDocument) revision);
 		}
 		throw new IllegalArgumentException("Unrecognized entity document type.");
 	}
@@ -131,7 +131,7 @@ public abstract class LabeledStatementDocumentUpdateBuilder extends StatementDoc
 	}
 
 	@Override
-	public LabeledStatementDocumentUpdateBuilder updateStatements(StatementUpdate update) {
+	public LabeledDocumentUpdateBuilder updateStatements(StatementUpdate update) {
 		super.updateStatements(update);
 		return this;
 	}
@@ -147,7 +147,7 @@ public abstract class LabeledStatementDocumentUpdateBuilder extends StatementDoc
 	 * @throws NullPointerException
 	 *             if {@code update} is {@code null}
 	 */
-	public LabeledStatementDocumentUpdateBuilder updateLabels(TermUpdate update) {
+	public LabeledDocumentUpdateBuilder updateLabels(TermUpdate update) {
 		Objects.requireNonNull(update, "Update cannot be null.");
 		TermUpdateBuilder combined = getBaseRevision() != null
 				? TermUpdateBuilder.forTerms(getBaseRevision().getLabels().values())

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LabeledDocumentUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LabeledDocumentUpdateBuilder.java
@@ -152,14 +152,14 @@ public abstract class LabeledDocumentUpdateBuilder extends StatementDocumentUpda
 		TermUpdateBuilder combined = getBaseRevision() != null
 				? TermUpdateBuilder.forTerms(getBaseRevision().getLabels().values())
 				: TermUpdateBuilder.create();
-		combined.apply(labels);
-		combined.apply(update);
+		combined.append(labels);
+		combined.append(update);
 		labels = combined.build();
 		return this;
 	}
 
-	void apply(LabeledStatementDocumentUpdate update) {
-		super.apply(update);
+	void append(LabeledStatementDocumentUpdate update) {
+		super.append(update);
 		updateLabels(update.getLabels());
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LabeledStatementDocumentUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LabeledStatementDocumentUpdateBuilder.java
@@ -144,7 +144,7 @@ public abstract class LabeledStatementDocumentUpdateBuilder extends StatementDoc
 	 * @throws NullPointerException
 	 *             if {@code update} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if removed label is not present in current entity revision (if
+	 *             if removed label is not present in base entity revision (if
 	 *             available)
 	 */
 	public LabeledStatementDocumentUpdateBuilder updateLabels(TermUpdate update) {

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LabeledStatementDocumentUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LabeledStatementDocumentUpdateBuilder.java
@@ -51,7 +51,7 @@ public abstract class LabeledStatementDocumentUpdateBuilder extends StatementDoc
 	 * @throws NullPointerException
 	 *             if {@code entityId} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code entityId} is not a valid ID
+	 *             if {@code entityId} is a placeholder ID
 	 */
 	protected LabeledStatementDocumentUpdateBuilder(EntityIdValue entityId) {
 		super(entityId);
@@ -66,7 +66,7 @@ public abstract class LabeledStatementDocumentUpdateBuilder extends StatementDoc
 	 * @throws NullPointerException
 	 *             if {@code revision} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code revision} does not have valid ID
+	 *             if {@code revision} has placeholder ID
 	 */
 	protected LabeledStatementDocumentUpdateBuilder(LabeledStatementDocument revision) {
 		super(revision);
@@ -84,7 +84,8 @@ public abstract class LabeledStatementDocumentUpdateBuilder extends StatementDoc
 	 * @throws NullPointerException
 	 *             if {@code entityId} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code entityId} is of unrecognized type or it is not valid
+	 *             if {@code entityId} is of unrecognized type or it is a
+	 *             placeholder ID
 	 */
 	public static LabeledStatementDocumentUpdateBuilder forEntityId(EntityIdValue entityId) {
 		Objects.requireNonNull(entityId, "Entity ID cannot be null.");
@@ -110,8 +111,8 @@ public abstract class LabeledStatementDocumentUpdateBuilder extends StatementDoc
 	 * @throws NullPointerException
 	 *             if {@code revision} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code revision} is of unrecognized type or it does not have
-	 *             valid ID
+	 *             if {@code revision} is of unrecognized type or its ID is a
+	 *             placeholder ID
 	 */
 	public static LabeledStatementDocumentUpdateBuilder forBaseRevision(LabeledStatementDocument revision) {
 		Objects.requireNonNull(revision, "Entity document cannot be null.");

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LabeledStatementDocumentUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LabeledStatementDocumentUpdateBuilder.java
@@ -115,7 +115,7 @@ public abstract class LabeledStatementDocumentUpdateBuilder extends StatementDoc
 	 *             placeholder ID
 	 */
 	public static LabeledStatementDocumentUpdateBuilder forBaseRevision(LabeledStatementDocument revision) {
-		Objects.requireNonNull(revision, "Entity document cannot be null.");
+		Objects.requireNonNull(revision, "Base entity revision cannot be null.");
 		if (revision instanceof MediaInfoDocument) {
 			return MediaInfoUpdateBuilder.forBaseRevision((MediaInfoDocument) revision);
 		}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilder.java
@@ -220,6 +220,9 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 		if (!sense.getEntityId().isPlaceholder()) {
 			sense = sense.withEntityId(SenseIdValue.NULL);
 		}
+		if (sense.getRevisionId() != 0) {
+			sense = sense.withRevisionId(0);
+		}
 		addedSenses.add(sense);
 		return this;
 	}
@@ -252,9 +255,9 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 					.filter(s -> s.getEntityId().equals(id))
 					.findFirst().orElse(null);
 			Validate.isTrue(original != null, "Cannot update sense that is not in the base revision.");
-			builder = SenseUpdateBuilder.forBaseRevision(original);
+			builder = SenseUpdateBuilder.forBaseRevision(original.withRevisionId(getBaseRevisionId()));
 		} else {
-			builder = SenseUpdateBuilder.forEntityId(id);
+			builder = SenseUpdateBuilder.forBaseRevisionId(id, getBaseRevisionId());
 		}
 		SenseUpdate prior = updatedSenses.get(id);
 		if (prior != null) {
@@ -309,8 +312,12 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 	 */
 	public LexemeUpdateBuilder addForm(FormDocument form) {
 		Objects.requireNonNull(form, "Form cannot be null.");
-		if (!form.getEntityId().isPlaceholder())
+		if (!form.getEntityId().isPlaceholder()) {
 			form = form.withEntityId(FormIdValue.NULL);
+		}
+		if (form.getRevisionId() != 0) {
+			form = form.withRevisionId(0);
+		}
 		addedForms.add(form);
 		return this;
 	}
@@ -343,9 +350,9 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 					.filter(s -> s.getEntityId().equals(id))
 					.findFirst().orElse(null);
 			Validate.isTrue(original != null, "Cannot update form that is not in the base revision.");
-			builder = FormUpdateBuilder.forBaseRevision(original);
+			builder = FormUpdateBuilder.forBaseRevision(original.withRevisionId(getBaseRevisionId()));
 		} else {
-			builder = FormUpdateBuilder.forEntityId(id);
+			builder = FormUpdateBuilder.forBaseRevisionId(id, getBaseRevisionId());
 		}
 		FormUpdate prior = updatedForms.get(id);
 		if (prior != null) {

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilder.java
@@ -48,7 +48,7 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 
 	private ItemIdValue language;
 	private ItemIdValue lexicalCategory;
-	private TermUpdate lemmas = TermUpdate.NULL;
+	private TermUpdate lemmas = TermUpdate.EMPTY;
 	private final List<SenseDocument> addedSenses = new ArrayList<>();
 	private final Map<SenseIdValue, SenseUpdate> updatedSenses = new HashMap<>();
 	private final Set<SenseIdValue> removedSenses = new HashSet<>();

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilder.java
@@ -179,8 +179,8 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 		TermUpdateBuilder combined = getBaseRevision() != null
 				? TermUpdateBuilder.forTerms(getBaseRevision().getLemmas().values())
 				: TermUpdateBuilder.create();
-		combined.apply(lemmas);
-		combined.apply(update);
+		combined.append(lemmas);
+		combined.append(update);
 		lemmas = combined.build();
 		return this;
 	}
@@ -239,9 +239,9 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 		}
 		SenseUpdate prior = updatedSenses.get(id);
 		if (prior != null) {
-			builder.apply(prior);
+			builder.append(prior);
 		}
-		builder.apply(update);
+		builder.append(update);
 		SenseUpdate combined = builder.build();
 		if (!combined.isEmpty()) {
 			updatedSenses.put(id, combined);
@@ -330,9 +330,9 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 		}
 		FormUpdate prior = updatedForms.get(id);
 		if (prior != null) {
-			builder.apply(prior);
+			builder.append(prior);
 		}
-		builder.apply(update);
+		builder.append(update);
 		FormUpdate combined = builder.build();
 		if (!combined.isEmpty()) {
 			updatedForms.put(id, combined);
@@ -382,8 +382,8 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 	 *             if {@code update} cannot be applied to base entity revision (if
 	 *             available)
 	 */
-	public LexemeUpdateBuilder apply(LexemeUpdate update) {
-		super.apply(update);
+	public LexemeUpdateBuilder append(LexemeUpdate update) {
+		super.append(update);
 		if (update.getLanguage().isPresent()) {
 			setLanguage(update.getLanguage().get());
 		}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilder.java
@@ -74,7 +74,7 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 	 * @throws NullPointerException
 	 *             if {@code lexemeId} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code lexemeId} is not valid
+	 *             if {@code lexemeId} is a placeholder ID
 	 */
 	public static LexemeUpdateBuilder forEntityId(LexemeIdValue lexemeId) {
 		return new LexemeUpdateBuilder(lexemeId);
@@ -93,7 +93,7 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 	 * @throws NullPointerException
 	 *             if {@code revision} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code revision} does not have valid ID
+	 *             if {@code revision} has placeholder ID
 	 */
 	public static LexemeUpdateBuilder forBaseRevision(LexemeDocument revision) {
 		return new LexemeUpdateBuilder(revision);
@@ -130,7 +130,7 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 	 */
 	public LexemeUpdateBuilder setLanguage(ItemIdValue language) {
 		Objects.requireNonNull(language, "Language cannot be null.");
-		Validate.isTrue(language.isValid(), "Language ID is not valid.");
+		Validate.isTrue(!language.isPlaceholder(), "Language ID cannot be a placeholder ID.");
 		if (getBaseRevision() != null && getBaseRevision().getLanguage().equals(language)) {
 			this.language = null;
 			return this;
@@ -154,7 +154,7 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 	 */
 	public LexemeUpdateBuilder setLexicalCategory(ItemIdValue category) {
 		Objects.requireNonNull(category, "Lexical category cannot be null.");
-		Validate.isTrue(category.isValid(), "Lexical category ID is not valid.");
+		Validate.isTrue(!category.isPlaceholder(), "Lexical category ID cannot be a placeholder ID.");
 		if (getBaseRevision() != null && getBaseRevision().getLexicalCategory().equals(category)) {
 			lexicalCategory = null;
 			return this;
@@ -198,7 +198,7 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 	 */
 	public LexemeUpdateBuilder addSense(SenseDocument sense) {
 		Objects.requireNonNull(sense, "Sense cannot be null.");
-		if (sense.getEntityId().isValid()) {
+		if (!sense.getEntityId().isPlaceholder()) {
 			sense = sense.withEntityId(SenseIdValue.NULL);
 		}
 		addedSenses.add(sense);
@@ -267,7 +267,7 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 	 */
 	public LexemeUpdateBuilder removeSense(SenseIdValue senseId) {
 		Objects.requireNonNull(senseId, "Sense ID cannot be null.");
-		Validate.isTrue(senseId.isValid(), "ID of removed sense must be valid.");
+		Validate.isTrue(!senseId.isPlaceholder(), "ID of removed sense cannot be a placeholder ID.");
 		if (getBaseRevision() != null) {
 			Validate.isTrue(getBaseRevision().getSenses().stream().anyMatch(s -> s.getEntityId().equals(senseId)),
 					"Cannot remove sense that is not in the base revision.");
@@ -290,7 +290,7 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 	 */
 	public LexemeUpdateBuilder addForm(FormDocument form) {
 		Objects.requireNonNull(form, "Form cannot be null.");
-		if (form.getEntityId().isValid())
+		if (!form.getEntityId().isPlaceholder())
 			form = form.withEntityId(FormIdValue.NULL);
 		addedForms.add(form);
 		return this;
@@ -358,7 +358,7 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 	 */
 	public LexemeUpdateBuilder removeForm(FormIdValue formId) {
 		Objects.requireNonNull(formId, "Form ID cannot be null.");
-		Validate.isTrue(formId.isValid(), "ID of removed form must be valid.");
+		Validate.isTrue(!formId.isPlaceholder(), "ID of removed form cannot be a placeholder ID.");
 		if (getBaseRevision() != null) {
 			Validate.isTrue(getBaseRevision().getForms().stream().anyMatch(s -> s.getEntityId().equals(formId)),
 					"Cannot remove form that is not in the base revision.");

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilder.java
@@ -227,22 +227,27 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 		Objects.requireNonNull(update, "Sense update cannot be null.");
 		SenseIdValue id = update.getEntityId();
 		Validate.validState(!removedSenses.contains(id), "Cannot update removed sense.");
-		SenseUpdateBuilder combined;
+		SenseUpdateBuilder builder;
 		if (getBaseRevision() != null) {
 			SenseDocument original = getBaseRevision().getSenses().stream()
 					.filter(s -> s.getEntityId().equals(id))
 					.findFirst().orElse(null);
 			Validate.isTrue(original != null, "Cannot update sense that is not in the base revision.");
-			combined = SenseUpdateBuilder.forBaseRevision(original);
+			builder = SenseUpdateBuilder.forBaseRevision(original);
 		} else {
-			combined = SenseUpdateBuilder.forEntityId(id);
+			builder = SenseUpdateBuilder.forEntityId(id);
 		}
 		SenseUpdate prior = updatedSenses.get(id);
 		if (prior != null) {
-			combined.apply(prior);
+			builder.apply(prior);
 		}
-		combined.apply(update);
-		updatedSenses.put(id, combined.build());
+		builder.apply(update);
+		SenseUpdate combined = builder.build();
+		if (!combined.isEmpty()) {
+			updatedSenses.put(id, combined);
+		} else {
+			updatedSenses.remove(id);
+		}
 		return this;
 	}
 
@@ -313,22 +318,27 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 		Objects.requireNonNull(update, "Form update cannot be null.");
 		FormIdValue id = update.getEntityId();
 		Validate.validState(!removedForms.contains(id), "Cannot update removed form.");
-		FormUpdateBuilder combined;
+		FormUpdateBuilder builder;
 		if (getBaseRevision() != null) {
 			FormDocument original = getBaseRevision().getForms().stream()
 					.filter(s -> s.getEntityId().equals(id))
 					.findFirst().orElse(null);
 			Validate.isTrue(original != null, "Cannot update form that is not in the base revision.");
-			combined = FormUpdateBuilder.forBaseRevision(original);
+			builder = FormUpdateBuilder.forBaseRevision(original);
 		} else {
-			combined = FormUpdateBuilder.forEntityId(id);
+			builder = FormUpdateBuilder.forEntityId(id);
 		}
 		FormUpdate prior = updatedForms.get(id);
 		if (prior != null) {
-			combined.apply(prior);
+			builder.apply(prior);
 		}
-		combined.apply(update);
-		updatedForms.put(id, combined.build());
+		builder.apply(update);
+		FormUpdate combined = builder.build();
+		if (!combined.isEmpty()) {
+			updatedForms.put(id, combined);
+		} else {
+			updatedForms.remove(id);
+		}
 		return this;
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilder.java
@@ -56,12 +56,31 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 	private final Map<FormIdValue, FormUpdate> updatedForms = new HashMap<>();
 	private final Set<FormIdValue> removedForms = new HashSet<>();
 
-	private LexemeUpdateBuilder(LexemeIdValue lexemeId) {
-		super(lexemeId);
+	private LexemeUpdateBuilder(LexemeIdValue lexemeId, long revisionId) {
+		super(lexemeId, revisionId);
 	}
 
 	private LexemeUpdateBuilder(LexemeDocument revision) {
 		super(revision);
+	}
+
+	/**
+	 * Creates new builder object for constructing update of lexeme entity with
+	 * given revision ID.
+	 * 
+	 * @param lexemeId
+	 *            ID of the lexeme that is to be updated
+	 * @param revisionId
+	 *            ID of the base lexeme revision to be updated or zero if not
+	 *            available
+	 * @return update builder object
+	 * @throws NullPointerException
+	 *             if {@code lexemeId} is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if {@code lexemeId} is a placeholder ID
+	 */
+	public static LexemeUpdateBuilder forBaseRevisionId(LexemeIdValue lexemeId, long revisionId) {
+		return new LexemeUpdateBuilder(lexemeId, revisionId);
 	}
 
 	/**
@@ -77,7 +96,7 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 	 *             if {@code lexemeId} is a placeholder ID
 	 */
 	public static LexemeUpdateBuilder forEntityId(LexemeIdValue lexemeId) {
-		return new LexemeUpdateBuilder(lexemeId);
+		return new LexemeUpdateBuilder(lexemeId, 0);
 	}
 
 	/**
@@ -414,7 +433,7 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 
 	@Override
 	public LexemeUpdate build() {
-		return Datamodel.makeLexemeUpdate(getEntityId(), getBaseRevision(),
+		return Datamodel.makeLexemeUpdate(getEntityId(), getBaseRevisionId(),
 				language, lexicalCategory, lemmas, statements,
 				addedSenses, updatedSenses.values(), removedSenses,
 				addedForms, updatedForms.values(), removedForms);

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilder.java
@@ -404,7 +404,7 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 
 	@Override
 	public LexemeUpdate build() {
-		return factory.getLexemeUpdate(getEntityId(), getBaseRevision(),
+		return Datamodel.makeLexemeUpdate(getEntityId(), getBaseRevision(),
 				language, lexicalCategory, lemmas, statements,
 				addedSenses, updatedSenses.values(), removedSenses,
 				addedForms, updatedForms.values(), removedForms);

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/MediaInfoUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/MediaInfoUpdateBuilder.java
@@ -116,7 +116,7 @@ public class MediaInfoUpdateBuilder extends LabeledStatementDocumentUpdateBuilde
 
 	@Override
 	public MediaInfoUpdate build() {
-		return factory.getMediaInfoUpdate(getEntityId(), getBaseRevision(), labels, statements);
+		return Datamodel.makeMediaInfoUpdate(getEntityId(), getBaseRevision(), labels, statements);
 	}
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/MediaInfoUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/MediaInfoUpdateBuilder.java
@@ -30,12 +30,31 @@ import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
  */
 public class MediaInfoUpdateBuilder extends LabeledDocumentUpdateBuilder {
 
-	private MediaInfoUpdateBuilder(MediaInfoIdValue mediaInfoId) {
-		super(mediaInfoId);
+	private MediaInfoUpdateBuilder(MediaInfoIdValue mediaInfoId, long revisionId) {
+		super(mediaInfoId, revisionId);
 	}
 
 	private MediaInfoUpdateBuilder(MediaInfoDocument revision) {
 		super(revision);
+	}
+
+	/**
+	 * Creates new builder object for constructing update of media entity with given
+	 * revision ID.
+	 * 
+	 * @param mediaInfoId
+	 *            ID of the media entity that is to be updated
+	 * @param revisionId
+	 *            ID of the base media entity revision to be updated or zero if not
+	 *            available
+	 * @return update builder object
+	 * @throws NullPointerException
+	 *             if {@code mediaInfoId} is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if {@code mediaInfoId} is a placeholder ID
+	 */
+	public static MediaInfoUpdateBuilder forBaseRevisionId(MediaInfoIdValue mediaInfoId, long revisionId) {
+		return new MediaInfoUpdateBuilder(mediaInfoId, revisionId);
 	}
 
 	/**
@@ -51,7 +70,7 @@ public class MediaInfoUpdateBuilder extends LabeledDocumentUpdateBuilder {
 	 *             if {@code mediaInfoId} is a placeholder ID
 	 */
 	public static MediaInfoUpdateBuilder forEntityId(MediaInfoIdValue mediaInfoId) {
-		return new MediaInfoUpdateBuilder(mediaInfoId);
+		return new MediaInfoUpdateBuilder(mediaInfoId, 0);
 	}
 
 	/**
@@ -116,7 +135,7 @@ public class MediaInfoUpdateBuilder extends LabeledDocumentUpdateBuilder {
 
 	@Override
 	public MediaInfoUpdate build() {
-		return Datamodel.makeMediaInfoUpdate(getEntityId(), getBaseRevision(), labels, statements);
+		return Datamodel.makeMediaInfoUpdate(getEntityId(), getBaseRevisionId(), labels, statements);
 	}
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/MediaInfoUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/MediaInfoUpdateBuilder.java
@@ -22,8 +22,8 @@ package org.wikidata.wdtk.datamodel.helpers;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoDocument;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoUpdate;
-import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 
 /**
  * Builder for incremental construction of {@link MediaInfoUpdate} objects.
@@ -92,6 +92,25 @@ public class MediaInfoUpdateBuilder extends LabeledStatementDocumentUpdateBuilde
 	@Override
 	public MediaInfoUpdateBuilder updateLabels(TermUpdate update) {
 		super.updateLabels(update);
+		return this;
+	}
+
+	/**
+	 * Replays all changes in provided update into this builder object. Changes from
+	 * the update are added on top of changes already present in this builder
+	 * object.
+	 * 
+	 * @param update
+	 *            media update to replay
+	 * @return {@code this} (fluent method)
+	 * @throws NullPointerException
+	 *             if {@code update} is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if {@code update} cannot be applied to base entity revision (if
+	 *             available)
+	 */
+	public MediaInfoUpdateBuilder apply(MediaInfoUpdate update) {
+		super.apply(update);
 		return this;
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/MediaInfoUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/MediaInfoUpdateBuilder.java
@@ -28,7 +28,7 @@ import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 /**
  * Builder for incremental construction of {@link MediaInfoUpdate} objects.
  */
-public class MediaInfoUpdateBuilder extends LabeledStatementDocumentUpdateBuilder {
+public class MediaInfoUpdateBuilder extends LabeledDocumentUpdateBuilder {
 
 	private MediaInfoUpdateBuilder(MediaInfoIdValue mediaInfoId) {
 		super(mediaInfoId);

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/MediaInfoUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/MediaInfoUpdateBuilder.java
@@ -48,7 +48,7 @@ public class MediaInfoUpdateBuilder extends LabeledStatementDocumentUpdateBuilde
 	 * @throws NullPointerException
 	 *             if {@code mediaInfoId} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code mediaInfoId} is not valid
+	 *             if {@code mediaInfoId} is a placeholder ID
 	 */
 	public static MediaInfoUpdateBuilder forEntityId(MediaInfoIdValue mediaInfoId) {
 		return new MediaInfoUpdateBuilder(mediaInfoId);
@@ -67,7 +67,7 @@ public class MediaInfoUpdateBuilder extends LabeledStatementDocumentUpdateBuilde
 	 * @throws NullPointerException
 	 *             if {@code revision} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code revision} does not have valid ID
+	 *             if {@code revision} has placeholder ID
 	 */
 	public static MediaInfoUpdateBuilder forBaseRevision(MediaInfoDocument revision) {
 		return new MediaInfoUpdateBuilder(revision);

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/MediaInfoUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/MediaInfoUpdateBuilder.java
@@ -110,7 +110,7 @@ public class MediaInfoUpdateBuilder extends LabeledDocumentUpdateBuilder {
 	 *             available)
 	 */
 	public MediaInfoUpdateBuilder apply(MediaInfoUpdate update) {
-		super.apply(update);
+		super.append(update);
 		return this;
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilder.java
@@ -19,9 +19,7 @@
  */
 package org.wikidata.wdtk.datamodel.helpers;
 
-import java.util.List;
-
-import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyUpdate;
@@ -124,14 +122,8 @@ public class PropertyUpdateBuilder extends TermedDocumentUpdateBuilder {
 	}
 
 	@Override
-	public PropertyUpdateBuilder putAliases(String language, List<MonolingualTextValue> aliases) {
-		super.putAliases(language, aliases);
-		return this;
-	}
-
-	@Override
-	public PropertyUpdateBuilder putAliasesAsStrings(String language, List<String> aliases) {
-		super.putAliasesAsStrings(language, aliases);
+	public PropertyUpdateBuilder updateAliases(String language, AliasUpdate update) {
+		super.updateAliases(language, update);
 		return this;
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilder.java
@@ -50,7 +50,7 @@ public class PropertyUpdateBuilder extends TermedStatementDocumentUpdateBuilder 
 	 * @throws NullPointerException
 	 *             if {@code propertyId} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code propertyId} is not valid
+	 *             if {@code propertyId} is a placeholder ID
 	 */
 	public static PropertyUpdateBuilder forEntityId(PropertyIdValue propertyId) {
 		return new PropertyUpdateBuilder(propertyId);
@@ -69,7 +69,7 @@ public class PropertyUpdateBuilder extends TermedStatementDocumentUpdateBuilder 
 	 * @throws NullPointerException
 	 *             if {@code revision} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code revision} does not have valid ID
+	 *             if {@code revision} has placeholder ID
 	 */
 	public static PropertyUpdateBuilder forBaseRevision(PropertyDocument revision) {
 		return new PropertyUpdateBuilder(revision);

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilder.java
@@ -19,14 +19,13 @@
  */
 package org.wikidata.wdtk.datamodel.helpers;
 
-import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
-
 import java.util.List;
 
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 
 /**
  * Builder for incremental construction of {@link PropertyUpdate} objects.
@@ -107,6 +106,25 @@ public class PropertyUpdateBuilder extends TermedStatementDocumentUpdateBuilder 
 	@Override
 	public PropertyUpdateBuilder setAliases(String language, List<String> aliases) {
 		super.setAliases(language, aliases);
+		return this;
+	}
+
+	/**
+	 * Replays all changes in provided update into this builder object. Changes from
+	 * the update are added on top of changes already present in this builder
+	 * object.
+	 * 
+	 * @param update
+	 *            property update to replay
+	 * @return {@code this} (fluent method)
+	 * @throws NullPointerException
+	 *             if {@code update} is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if {@code update} cannot be applied to base entity revision (if
+	 *             available)
+	 */
+	public PropertyUpdateBuilder apply(PropertyUpdate update) {
+		super.apply(update);
 		return this;
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilder.java
@@ -130,7 +130,7 @@ public class PropertyUpdateBuilder extends TermedStatementDocumentUpdateBuilder 
 
 	@Override
 	public PropertyUpdate build() {
-		return factory.getPropertyUpdate(getEntityId(), getBaseRevision(), labels, descriptions, aliases, statements);
+		return Datamodel.makePropertyUpdate(getEntityId(), getBaseRevision(), labels, descriptions, aliases, statements);
 	}
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilder.java
@@ -33,12 +33,31 @@ import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
  */
 public class PropertyUpdateBuilder extends TermedDocumentUpdateBuilder {
 
-	private PropertyUpdateBuilder(PropertyIdValue propertyId) {
-		super(propertyId);
+	private PropertyUpdateBuilder(PropertyIdValue propertyId, long revisionId) {
+		super(propertyId, revisionId);
 	}
 
 	private PropertyUpdateBuilder(PropertyDocument revision) {
 		super(revision);
+	}
+
+	/**
+	 * Creates new builder object for constructing update of property entity with
+	 * given revision ID.
+	 * 
+	 * @param propertyId
+	 *            ID of the property entity that is to be updated
+	 * @param revisionId
+	 *            ID of the base property revision to be updated or zero if not
+	 *            available
+	 * @return update builder object
+	 * @throws NullPointerException
+	 *             if {@code propertyId} is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if {@code propertyId} is a placeholder ID
+	 */
+	public static PropertyUpdateBuilder forBaseRevisionId(PropertyIdValue propertyId, long revisionId) {
+		return new PropertyUpdateBuilder(propertyId, revisionId);
 	}
 
 	/**
@@ -54,7 +73,7 @@ public class PropertyUpdateBuilder extends TermedDocumentUpdateBuilder {
 	 *             if {@code propertyId} is a placeholder ID
 	 */
 	public static PropertyUpdateBuilder forEntityId(PropertyIdValue propertyId) {
-		return new PropertyUpdateBuilder(propertyId);
+		return new PropertyUpdateBuilder(propertyId, 0);
 	}
 
 	/**
@@ -137,7 +156,7 @@ public class PropertyUpdateBuilder extends TermedDocumentUpdateBuilder {
 
 	@Override
 	public PropertyUpdate build() {
-		return Datamodel.makePropertyUpdate(getEntityId(), getBaseRevision(),
+		return Datamodel.makePropertyUpdate(getEntityId(), getBaseRevisionId(),
 				labels, descriptions, aliases, statements);
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilder.java
@@ -21,6 +21,7 @@ package org.wikidata.wdtk.datamodel.helpers;
 
 import java.util.List;
 
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyUpdate;
@@ -104,8 +105,14 @@ public class PropertyUpdateBuilder extends TermedDocumentUpdateBuilder {
 	}
 
 	@Override
-	public PropertyUpdateBuilder setAliases(String language, List<String> aliases) {
-		super.setAliases(language, aliases);
+	public PropertyUpdateBuilder putAliases(String language, List<MonolingualTextValue> aliases) {
+		super.putAliases(language, aliases);
+		return this;
+	}
+
+	@Override
+	public PropertyUpdateBuilder putAliasesAsStrings(String language, List<String> aliases) {
+		super.putAliasesAsStrings(language, aliases);
 		return this;
 	}
 
@@ -123,14 +130,15 @@ public class PropertyUpdateBuilder extends TermedDocumentUpdateBuilder {
 	 *             if {@code update} cannot be applied to base entity revision (if
 	 *             available)
 	 */
-	public PropertyUpdateBuilder apply(PropertyUpdate update) {
-		super.apply(update);
+	public PropertyUpdateBuilder append(PropertyUpdate update) {
+		super.append(update);
 		return this;
 	}
 
 	@Override
 	public PropertyUpdate build() {
-		return Datamodel.makePropertyUpdate(getEntityId(), getBaseRevision(), labels, descriptions, aliases, statements);
+		return Datamodel.makePropertyUpdate(getEntityId(), getBaseRevision(),
+				labels, descriptions, aliases, statements);
 	}
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilder.java
@@ -30,7 +30,7 @@ import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 /**
  * Builder for incremental construction of {@link PropertyUpdate} objects.
  */
-public class PropertyUpdateBuilder extends TermedStatementDocumentUpdateBuilder {
+public class PropertyUpdateBuilder extends TermedDocumentUpdateBuilder {
 
 	private PropertyUpdateBuilder(PropertyIdValue propertyId) {
 		super(propertyId);

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/SenseUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/SenseUpdateBuilder.java
@@ -34,12 +34,31 @@ public class SenseUpdateBuilder extends StatementDocumentUpdateBuilder {
 
 	private TermUpdate glosses = TermUpdate.NULL;
 
-	private SenseUpdateBuilder(SenseIdValue senseId) {
-		super(senseId);
+	private SenseUpdateBuilder(SenseIdValue senseId, long revisionId) {
+		super(senseId, revisionId);
 	}
 
 	private SenseUpdateBuilder(SenseDocument revision) {
 		super(revision);
+	}
+
+	/**
+	 * Creates new builder object for constructing update of sense entity with given
+	 * revision ID.
+	 * 
+	 * @param senseId
+	 *            ID of the sense that is to be updated
+	 * @param revisionId
+	 *            ID of the base sense revision to be updated or zero if not
+	 *            available
+	 * @return update builder object
+	 * @throws NullPointerException
+	 *             if {@code senseId} is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if {@code senseId} is a placeholder ID
+	 */
+	public static SenseUpdateBuilder forBaseRevisionId(SenseIdValue senseId, long revisionId) {
+		return new SenseUpdateBuilder(senseId, revisionId);
 	}
 
 	/**
@@ -55,7 +74,7 @@ public class SenseUpdateBuilder extends StatementDocumentUpdateBuilder {
 	 *             if {@code senseId} is a placeholder ID
 	 */
 	public static SenseUpdateBuilder forEntityId(SenseIdValue senseId) {
-		return new SenseUpdateBuilder(senseId);
+		return new SenseUpdateBuilder(senseId, 0);
 	}
 
 	/**
@@ -137,7 +156,7 @@ public class SenseUpdateBuilder extends StatementDocumentUpdateBuilder {
 
 	@Override
 	public SenseUpdate build() {
-		return Datamodel.makeSenseUpdate(getEntityId(), getBaseRevision(), glosses, statements);
+		return Datamodel.makeSenseUpdate(getEntityId(), getBaseRevisionId(), glosses, statements);
 	}
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/SenseUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/SenseUpdateBuilder.java
@@ -52,7 +52,7 @@ public class SenseUpdateBuilder extends StatementDocumentUpdateBuilder {
 	 * @throws NullPointerException
 	 *             if {@code senseId} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code senseId} is not valid
+	 *             if {@code senseId} is a placeholder ID
 	 */
 	public static SenseUpdateBuilder forEntityId(SenseIdValue senseId) {
 		return new SenseUpdateBuilder(senseId);
@@ -71,7 +71,7 @@ public class SenseUpdateBuilder extends StatementDocumentUpdateBuilder {
 	 * @throws NullPointerException
 	 *             if {@code revision} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code revision} does not have valid ID
+	 *             if {@code revision} has placeholder ID
 	 */
 	public static SenseUpdateBuilder forBaseRevision(SenseDocument revision) {
 		return new SenseUpdateBuilder(revision);

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/SenseUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/SenseUpdateBuilder.java
@@ -137,7 +137,7 @@ public class SenseUpdateBuilder extends StatementDocumentUpdateBuilder {
 
 	@Override
 	public SenseUpdate build() {
-		return factory.getSenseUpdate(getEntityId(), getBaseRevision(), glosses, statements);
+		return Datamodel.makeSenseUpdate(getEntityId(), getBaseRevision(), glosses, statements);
 	}
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/SenseUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/SenseUpdateBuilder.java
@@ -32,7 +32,7 @@ import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
  */
 public class SenseUpdateBuilder extends StatementDocumentUpdateBuilder {
 
-	private TermUpdate glosses = TermUpdate.NULL;
+	private TermUpdate glosses = TermUpdate.EMPTY;
 
 	private SenseUpdateBuilder(SenseIdValue senseId, long revisionId) {
 		super(senseId, revisionId);

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/SenseUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/SenseUpdateBuilder.java
@@ -109,8 +109,8 @@ public class SenseUpdateBuilder extends StatementDocumentUpdateBuilder {
 		TermUpdateBuilder combined = getBaseRevision() != null
 				? TermUpdateBuilder.forTerms(getBaseRevision().getGlosses().values())
 				: TermUpdateBuilder.create();
-		combined.apply(glosses);
-		combined.apply(update);
+		combined.append(glosses);
+		combined.append(update);
 		glosses = combined.build();
 		return this;
 	}
@@ -129,8 +129,8 @@ public class SenseUpdateBuilder extends StatementDocumentUpdateBuilder {
 	 *             if {@code update} cannot be applied to base entity revision (if
 	 *             available)
 	 */
-	public SenseUpdateBuilder apply(SenseUpdate update) {
-		super.apply(update);
+	public SenseUpdateBuilder append(SenseUpdate update) {
+		super.append(update);
 		updateGlosses(update.getGlosses());
 		return this;
 	}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilder.java
@@ -130,7 +130,7 @@ public abstract class StatementDocumentUpdateBuilder extends EntityUpdateBuilder
 	 *             placeholder ID
 	 */
 	public static StatementDocumentUpdateBuilder forBaseRevision(StatementDocument revision) {
-		Objects.requireNonNull(revision, "Entity document cannot be null.");
+		Objects.requireNonNull(revision, "Base entity revision cannot be null.");
 		if (revision instanceof SenseDocument) {
 			return SenseUpdateBuilder.forBaseRevision((SenseDocument) revision);
 		}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilder.java
@@ -55,13 +55,16 @@ public abstract class StatementDocumentUpdateBuilder extends EntityUpdateBuilder
 	 * 
 	 * @param entityId
 	 *            ID of the entity that is to be updated
+	 * @param revisionId
+	 *            ID of the base entity revision to be updated or zero if not
+	 *            available
 	 * @throws NullPointerException
 	 *             if {@code entityId} is {@code null}
 	 * @throws IllegalArgumentException
 	 *             if {@code entityId} is a placeholder ID
 	 */
-	protected StatementDocumentUpdateBuilder(EntityIdValue entityId) {
-		super(entityId);
+	protected StatementDocumentUpdateBuilder(EntityIdValue entityId, long revisionId) {
+		super(entityId, revisionId);
 	}
 
 	/**
@@ -77,6 +80,40 @@ public abstract class StatementDocumentUpdateBuilder extends EntityUpdateBuilder
 	 */
 	protected StatementDocumentUpdateBuilder(StatementDocument revision) {
 		super(revision);
+	}
+
+	/**
+	 * Creates new builder object for constructing update of entity with given
+	 * revision ID.
+	 * <p>
+	 * Supported entity IDs include {@link ItemIdValue}, {@link PropertyIdValue},
+	 * {@link LexemeIdValue}, {@link FormIdValue}, {@link SenseIdValue}, and
+	 * {@link MediaInfoIdValue}.
+	 * 
+	 * @param entityId
+	 *            ID of the entity that is to be updated
+	 * @param revisionId
+	 *            ID of the base entity revision to be updated or zero if not
+	 *            available
+	 * @return builder object matching entity type
+	 * @throws NullPointerException
+	 *             if {@code entityId} is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if {@code entityId} is of unrecognized type or it is a
+	 *             placeholder ID
+	 */
+	public static StatementDocumentUpdateBuilder forBaseRevisionId(EntityIdValue entityId, long revisionId) {
+		Objects.requireNonNull(entityId, "Entity ID cannot be null.");
+		if (entityId instanceof SenseIdValue) {
+			return SenseUpdateBuilder.forBaseRevisionId((SenseIdValue) entityId, revisionId);
+		}
+		if (entityId instanceof FormIdValue) {
+			return FormUpdateBuilder.forBaseRevisionId((FormIdValue) entityId, revisionId);
+		}
+		if (entityId instanceof LexemeIdValue) {
+			return LexemeUpdateBuilder.forBaseRevisionId((LexemeIdValue) entityId, revisionId);
+		}
+		return LabeledDocumentUpdateBuilder.forBaseRevisionId(entityId, revisionId);
 	}
 
 	/**
@@ -96,17 +133,7 @@ public abstract class StatementDocumentUpdateBuilder extends EntityUpdateBuilder
 	 *             placeholder ID
 	 */
 	public static StatementDocumentUpdateBuilder forEntityId(EntityIdValue entityId) {
-		Objects.requireNonNull(entityId, "Entity ID cannot be null.");
-		if (entityId instanceof SenseIdValue) {
-			return SenseUpdateBuilder.forEntityId((SenseIdValue) entityId);
-		}
-		if (entityId instanceof FormIdValue) {
-			return FormUpdateBuilder.forEntityId((FormIdValue) entityId);
-		}
-		if (entityId instanceof LexemeIdValue) {
-			return LexemeUpdateBuilder.forEntityId((LexemeIdValue) entityId);
-		}
-		return LabeledDocumentUpdateBuilder.forEntityId(entityId);
+		return forBaseRevisionId(entityId, 0);
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilder.java
@@ -170,8 +170,8 @@ public abstract class StatementDocumentUpdateBuilder extends EntityUpdateBuilder
 	public StatementDocumentUpdateBuilder updateStatements(StatementUpdate update) {
 		Objects.requireNonNull(update, "Update cannot be null.");
 		StatementUpdateBuilder combined = getBaseRevision() != null
-				? StatementUpdateBuilder.forStatementGroups(getBaseRevision().getStatementGroups())
-				: StatementUpdateBuilder.create();
+				? StatementUpdateBuilder.forStatementGroups(getEntityId(), getBaseRevision().getStatementGroups())
+				: StatementUpdateBuilder.create(getEntityId());
 		combined.append(statements);
 		combined.append(update);
 		statements = combined.build();

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilder.java
@@ -172,13 +172,13 @@ public abstract class StatementDocumentUpdateBuilder extends EntityUpdateBuilder
 		StatementUpdateBuilder combined = getBaseRevision() != null
 				? StatementUpdateBuilder.forStatementGroups(getBaseRevision().getStatementGroups())
 				: StatementUpdateBuilder.create();
-		combined.apply(statements);
-		combined.apply(update);
+		combined.append(statements);
+		combined.append(update);
 		statements = combined.build();
 		return this;
 	}
 
-	void apply(StatementDocumentUpdate update) {
+	void append(StatementDocumentUpdate update) {
 		Objects.requireNonNull(update, "Update cannot be null.");
 		updateStatements(update.getStatements());
 	}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilder.java
@@ -47,7 +47,7 @@ import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
  */
 public abstract class StatementDocumentUpdateBuilder extends EntityUpdateBuilder {
 
-	StatementUpdate statements = StatementUpdate.NULL;
+	StatementUpdate statements = StatementUpdate.EMPTY;
 
 	/**
 	 * Initializes new builder object for constructing update of entity with given

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilder.java
@@ -58,7 +58,7 @@ public abstract class StatementDocumentUpdateBuilder extends EntityUpdateBuilder
 	 * @throws NullPointerException
 	 *             if {@code entityId} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code entityId} is not a valid ID
+	 *             if {@code entityId} is a placeholder ID
 	 */
 	protected StatementDocumentUpdateBuilder(EntityIdValue entityId) {
 		super(entityId);
@@ -73,7 +73,7 @@ public abstract class StatementDocumentUpdateBuilder extends EntityUpdateBuilder
 	 * @throws NullPointerException
 	 *             if {@code revision} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code revision} does not have valid ID
+	 *             if {@code revision} has placeholder ID
 	 */
 	protected StatementDocumentUpdateBuilder(StatementDocument revision) {
 		super(revision);
@@ -92,7 +92,8 @@ public abstract class StatementDocumentUpdateBuilder extends EntityUpdateBuilder
 	 * @throws NullPointerException
 	 *             if {@code entityId} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code entityId} is of unrecognized type or it is not valid
+	 *             if {@code entityId} is of unrecognized type or it is a
+	 *             placeholder ID
 	 */
 	public static StatementDocumentUpdateBuilder forEntityId(EntityIdValue entityId) {
 		Objects.requireNonNull(entityId, "Entity ID cannot be null.");
@@ -125,8 +126,8 @@ public abstract class StatementDocumentUpdateBuilder extends EntityUpdateBuilder
 	 * @throws NullPointerException
 	 *             if {@code revision} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code revision} is of unrecognized type or it does not have
-	 *             valid ID
+	 *             if {@code revision} is of unrecognized type or its ID is a
+	 *             placeholder ID
 	 */
 	public static StatementDocumentUpdateBuilder forBaseRevision(StatementDocument revision) {
 		Objects.requireNonNull(revision, "Entity document cannot be null.");

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilder.java
@@ -106,7 +106,7 @@ public abstract class StatementDocumentUpdateBuilder extends EntityUpdateBuilder
 		if (entityId instanceof LexemeIdValue) {
 			return LexemeUpdateBuilder.forEntityId((LexemeIdValue) entityId);
 		}
-		return LabeledStatementDocumentUpdateBuilder.forEntityId(entityId);
+		return LabeledDocumentUpdateBuilder.forEntityId(entityId);
 	}
 
 	/**
@@ -141,7 +141,7 @@ public abstract class StatementDocumentUpdateBuilder extends EntityUpdateBuilder
 			return LexemeUpdateBuilder.forBaseRevision((LexemeDocument) revision);
 		}
 		if (revision instanceof LabeledStatementDocument) {
-			return LabeledStatementDocumentUpdateBuilder
+			return LabeledDocumentUpdateBuilder
 					.forBaseRevision((LabeledStatementDocument) revision);
 		}
 		throw new IllegalArgumentException("Unrecognized entity document type.");

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilder.java
@@ -47,6 +47,12 @@ public class StatementUpdateBuilder {
 	private final Set<String> removed = new HashSet<>();
 
 	/**
+	 * Creates new empty builder.
+	 */
+	public StatementUpdateBuilder() {
+	}
+
+	/**
 	 * Adds statement to the entity. If {@code statement} has an ID (perhaps because
 	 * it is a modified copy of another statement), its ID is stripped to ensure the
 	 * statement is added and no other statement is modified.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilder.java
@@ -19,7 +19,11 @@
  */
 package org.wikidata.wdtk.datamodel.helpers;
 
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -31,6 +35,7 @@ import org.apache.commons.lang3.Validate;
 import org.wikidata.wdtk.datamodel.implementation.DataObjectFactoryImpl;
 import org.wikidata.wdtk.datamodel.interfaces.DataObjectFactory;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
+import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
 
 /**
@@ -42,14 +47,73 @@ public class StatementUpdateBuilder {
 
 	private static DataObjectFactory factory = new DataObjectFactoryImpl();
 
+	private final Map<String, Statement> base;
 	private final List<Statement> added = new ArrayList<>();
 	private final Map<String, Statement> replaced = new HashMap<>();
 	private final Set<String> removed = new HashSet<>();
 
+	private StatementUpdateBuilder(Collection<Statement> base) {
+		if (base != null) {
+			for (Statement statement : base) {
+				Validate.notNull(statement, "Base document statement cannot be null.");
+				Validate.notBlank(statement.getStatementId(), "Base document statement must have valid ID.");
+			}
+			this.base = base.stream().collect(toMap(s -> s.getStatementId(), s -> s));
+		} else {
+			this.base = null;
+		}
+	}
+
 	/**
-	 * Creates new empty builder.
+	 * Creates new builder object for constructing statement update.
+	 * 
+	 * @return update builder object
 	 */
-	public StatementUpdateBuilder() {
+	public static StatementUpdateBuilder create() {
+		return new StatementUpdateBuilder(null);
+	}
+
+	/**
+	 * Creates new builder object for constructing update of given base revision
+	 * statements. Provided statements will be used to check correctness of changes.
+	 * <p>
+	 * Since all changes will be checked after the {@link StatementUpdate} is passed
+	 * to {@link EntityDocumentBuilder} anyway, it is usually unnecessary to use
+	 * this method. It is simpler to initialize the builder with {@link #create()}.
+	 * 
+	 * @param statements
+	 *            statements from base revision of the document
+	 * @return update builder object
+	 * @throws NullPointerException
+	 *             if {@code statements} or any of its items is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if any statement is missing statement ID
+	 */
+	public static StatementUpdateBuilder forStatements(Collection<Statement> statements) {
+		Objects.requireNonNull(statements, "Base document statement collection cannot be null.");
+		return new StatementUpdateBuilder(statements);
+	}
+
+	/**
+	 * Creates new builder object for constructing update of given base revision
+	 * statement groups. Provided statements will be used to check correctness of
+	 * changes.
+	 * <p>
+	 * Since all changes will be checked after the {@link StatementUpdate} is passed
+	 * to {@link EntityDocumentBuilder} anyway, it is usually unnecessary to use
+	 * this method. It is simpler to initialize the builder with {@link #create()}.
+	 * 
+	 * @param groups
+	 *            statement groups from base revision of the document
+	 * @return update builder object
+	 * @throws NullPointerException
+	 *             if {@code groups} or any of its items is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if any statement is missing statement ID
+	 */
+	public static StatementUpdateBuilder forStatementGroups(Collection<StatementGroup> groups) {
+		Objects.requireNonNull(groups, "Base document statement group collection cannot be null.");
+		return new StatementUpdateBuilder(groups.stream().flatMap(g -> g.getStatements().stream()).collect(toList()));
 	}
 
 	/**
@@ -77,6 +141,10 @@ public class StatementUpdateBuilder {
 	 * have statement ID identifying statement to replace. Calling this method
 	 * overrides any previous changes made to the same statement ID by this method
 	 * or {@link #removeStatement(String)}.
+	 * <p>
+	 * If base revision statements were provided, existence of the statement is
+	 * checked. Any attempt to replace some statement with identical statement is
+	 * silently ignored, resulting in empty update.
 	 * 
 	 * @param statement
 	 *            replacement for existing statement
@@ -84,11 +152,21 @@ public class StatementUpdateBuilder {
 	 * @throws NullPointerException
 	 *             if {@code statement} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code statement} does not have statement ID
+	 *             if {@code statement} does not have statement ID or it is not
+	 *             among base revision statements (if available)
 	 */
 	public StatementUpdateBuilder replaceStatement(Statement statement) {
 		Objects.requireNonNull(statement, "Statement cannot be null.");
 		Validate.notEmpty(statement.getStatementId(), "Statement must have an ID.");
+		if (base != null) {
+			Statement original = base.get(statement.getStatementId());
+			Validate.isTrue(original != null, "Replaced statement is not in base revision.");
+			if (statement.equals(original)) {
+				replaced.remove(statement.getStatementId());
+				removed.remove(statement.getStatementId());
+				return this;
+			}
+		}
 		replaced.put(statement.getStatementId(), statement);
 		removed.remove(statement.getStatementId());
 		return this;
@@ -99,17 +177,56 @@ public class StatementUpdateBuilder {
 	 * previous changes made to the same statement ID by
 	 * {@link #replaceStatement(Statement)}. Removing the same statement ID twice is
 	 * silently tolerated.
+	 * <p>
+	 * If base revision statements were provided, this method checks that statement
+	 * with this ID exists in the base revision.
 	 * 
 	 * @param statementId
 	 *            ID of the removed statement
 	 * @return {@code this} (fluent method)
+	 * @throws NullPointerException
+	 *             if {@code statementId} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code statementId} is empty
+	 *             if {@code statementId} is empty or it is not among base revision
+	 *             statements (if available)
 	 */
 	public StatementUpdateBuilder removeStatement(String statementId) {
-		Validate.notEmpty(statementId, "Statement ID must not be empty.");
+		Validate.notBlank(statementId, "Statement ID must not be empty.");
+		if (base != null) {
+			Statement original = base.get(statementId);
+			Validate.isTrue(original != null, "Removed statement is not in base revision.");
+		}
 		removed.add(statementId);
 		replaced.remove(statementId);
+		return this;
+	}
+
+	/**
+	 * Replays all changes in provided update into this builder object. Changes are
+	 * performed as if by calling {@link #addStatement(Statement)},
+	 * {@link #replaceStatement(Statement)}, and {@link #removeStatement(String)}
+	 * methods.
+	 * 
+	 * @param update
+	 *            statement update to replay
+	 * @return {@code this} (fluent method)
+	 * @throws NullPointerException
+	 *             if {@code update} is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if updated or removed statement is not among base revision
+	 *             statements (if available)
+	 */
+	public StatementUpdateBuilder apply(StatementUpdate update) {
+		Objects.requireNonNull(update, "Statement update cannot be null.");
+		for (Statement statement : update.getAddedStatements()) {
+			addStatement(statement);
+		}
+		for (Statement statement : update.getReplacedStatements().values()) {
+			replaceStatement(statement);
+		}
+		for (String statementId : update.getRemovedStatements()) {
+			removeStatement(statementId);
+		}
 		return this;
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilder.java
@@ -32,8 +32,6 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.apache.commons.lang3.Validate;
-import org.wikidata.wdtk.datamodel.implementation.DataObjectFactoryImpl;
-import org.wikidata.wdtk.datamodel.interfaces.DataObjectFactory;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
@@ -44,8 +42,6 @@ import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
  * @see StatementDocumentUpdateBuilder
  */
 public class StatementUpdateBuilder {
-
-	private static DataObjectFactory factory = new DataObjectFactoryImpl();
 
 	private final Map<String, Statement> base;
 	private final List<Statement> added = new ArrayList<>();
@@ -237,7 +233,7 @@ public class StatementUpdateBuilder {
 	 * @return constructed object
 	 */
 	public StatementUpdate build() {
-		return factory.getStatementUpdate(added, replaced.values(), removed);
+		return Datamodel.makeStatementUpdate(added, replaced.values(), removed);
 	}
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilder.java
@@ -141,7 +141,7 @@ public class StatementUpdateBuilder {
 	 * @throws IllegalArgumentException
 	 *             if statement's subject is inconsistent with other statements
 	 */
-	public StatementUpdateBuilder addStatement(Statement statement) {
+	public StatementUpdateBuilder add(Statement statement) {
 		Objects.requireNonNull(statement, "Statement cannot be null.");
 		if (subject != null) {
 			Validate.isTrue(subject.equals(statement.getSubject()), "Inconsistent statement subject.");
@@ -160,7 +160,7 @@ public class StatementUpdateBuilder {
 	 * Replaces existing statement in the entity. Provided {@code statement} must
 	 * have statement ID identifying statement to replace. Calling this method
 	 * overrides any previous changes made to the same statement ID by this method
-	 * or {@link #removeStatement(String)}.
+	 * or {@link #remove(String)}.
 	 * <p>
 	 * If base revision statements were provided, existence of the statement is
 	 * checked. Any attempt to replace some statement with identical statement is
@@ -176,7 +176,7 @@ public class StatementUpdateBuilder {
 	 *             among base revision statements (if available) or its subject is
 	 *             inconsistent with other statements
 	 */
-	public StatementUpdateBuilder replaceStatement(Statement statement) {
+	public StatementUpdateBuilder replace(Statement statement) {
 		Objects.requireNonNull(statement, "Statement cannot be null.");
 		Validate.notEmpty(statement.getStatementId(), "Statement must have an ID.");
 		if (subject != null) {
@@ -202,8 +202,8 @@ public class StatementUpdateBuilder {
 	/**
 	 * Removes existing statement from the entity. Calling this method overrides any
 	 * previous changes made to the same statement ID by
-	 * {@link #replaceStatement(Statement)}. Removing the same statement ID twice is
-	 * silently tolerated.
+	 * {@link #replace(Statement)}. Removing the same statement ID twice is silently
+	 * tolerated.
 	 * <p>
 	 * If base revision statements were provided, this method checks that statement
 	 * with this ID exists in the base revision.
@@ -217,7 +217,7 @@ public class StatementUpdateBuilder {
 	 *             if {@code statementId} is empty or it is not among base revision
 	 *             statements (if available)
 	 */
-	public StatementUpdateBuilder removeStatement(String statementId) {
+	public StatementUpdateBuilder remove(String statementId) {
 		Validate.notBlank(statementId, "Statement ID must not be empty.");
 		if (base != null) {
 			Statement original = base.get(statementId);
@@ -230,9 +230,8 @@ public class StatementUpdateBuilder {
 
 	/**
 	 * Replays all changes in provided update into this builder object. Changes are
-	 * performed as if by calling {@link #addStatement(Statement)},
-	 * {@link #replaceStatement(Statement)}, and {@link #removeStatement(String)}
-	 * methods.
+	 * performed as if by calling {@link #add(Statement)},
+	 * {@link #replace(Statement)}, and {@link #remove(String)} methods.
 	 * 
 	 * @param update
 	 *            statement update to replay
@@ -243,16 +242,16 @@ public class StatementUpdateBuilder {
 	 *             if updated or removed statement is not among base revision
 	 *             statements (if available)
 	 */
-	public StatementUpdateBuilder apply(StatementUpdate update) {
+	public StatementUpdateBuilder append(StatementUpdate update) {
 		Objects.requireNonNull(update, "Statement update cannot be null.");
-		for (Statement statement : update.getAddedStatements()) {
-			addStatement(statement);
+		for (Statement statement : update.getAdded()) {
+			add(statement);
 		}
-		for (Statement statement : update.getReplacedStatements().values()) {
-			replaceStatement(statement);
+		for (Statement statement : update.getReplaced().values()) {
+			replace(statement);
 		}
-		for (String statementId : update.getRemovedStatements()) {
-			removeStatement(statementId);
+		for (String statementId : update.getRemoved()) {
+			remove(statementId);
 		}
 		return this;
 	}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilder.java
@@ -60,7 +60,7 @@ public class StatementUpdateBuilder {
 				Validate.notBlank(statement.getStatementId(), "Base document statement must have valid ID.");
 			}
 			Validate.isTrue(
-					base.stream().map(s -> s.getSubject()).distinct().count() == 1,
+					base.stream().map(s -> s.getSubject()).distinct().count() <= 1,
 					"Base document statements must all refer to the same subject.");
 			Validate.isTrue(
 					base.stream().map(s -> s.getStatementId()).distinct().count() == base.size(),

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilder.java
@@ -52,8 +52,8 @@ public class StatementUpdateBuilder {
 
 	private StatementUpdateBuilder(Collection<Statement> base) {
 		if (base != null) {
-			Validate.noNullElements(base, "Base document statements cannot be null.");
 			for (Statement statement : base) {
+				Objects.requireNonNull(statement, "Base document statements cannot be null.");
 				Validate.isTrue(
 						!statement.getSubject().isPlaceholder(),
 						"Statement subject cannot have placeholder ID.");
@@ -95,9 +95,9 @@ public class StatementUpdateBuilder {
 	 *            statements from base revision of the document
 	 * @return update builder object
 	 * @throws NullPointerException
-	 *             if {@code statements} is {@code null}
+	 *             if {@code statements} or any of its items is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if any statement is {@code null} or it is missing statement ID
+	 *             if any statement is missing statement ID
 	 */
 	public static StatementUpdateBuilder forStatements(Collection<Statement> statements) {
 		Objects.requireNonNull(statements, "Base document statement collection cannot be null.");

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermUpdateBuilder.java
@@ -44,7 +44,9 @@ public class TermUpdateBuilder {
 
 	private TermUpdateBuilder(Collection<MonolingualTextValue> base) {
 		if (base != null) {
-			Validate.noNullElements(base, "Base document terms cannot be null.");
+			for (MonolingualTextValue value : base) {
+				Objects.requireNonNull(value, "Base document terms cannot be null.");
+			}
 			Validate.isTrue(
 					base.stream().map(v -> v.getLanguageCode()).distinct().count() == base.size(),
 					"Base document terms must have unique language codes.");
@@ -74,9 +76,9 @@ public class TermUpdateBuilder {
 	 *            terms from base revision of the document
 	 * @return update builder object
 	 * @throws NullPointerException
-	 *             if {@code terms} is {@code null}
+	 *             if {@code terms} or any of its items is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if any items in {@code terms} are {@code null} or duplicate
+	 *             if there are duplicate items in {@code terms}
 	 */
 	public static TermUpdateBuilder forTerms(Collection<MonolingualTextValue> terms) {
 		Objects.requireNonNull(terms, "Base document term collection cannot be null.");

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermUpdateBuilder.java
@@ -30,7 +30,6 @@ import java.util.Set;
 
 import org.apache.commons.lang3.Validate;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
-import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 
 /**
@@ -69,7 +68,7 @@ public class TermUpdateBuilder {
 	 * terms. Provided terms will be used to check correctness of changes.
 	 * <p>
 	 * Since all changes will be checked after the {@link TermUpdate} is passed to
-	 * {@link EntityDocumentBuilder} anyway, it is usually unnecessary to use this
+	 * {@link EntityUpdateBuilder} anyway, it is usually unnecessary to use this
 	 * method. It is simpler to initialize the builder with {@link #create()}.
 	 * 
 	 * @param terms
@@ -86,15 +85,10 @@ public class TermUpdateBuilder {
 	}
 
 	/**
-	 * Adds or changes term. If there is no term for the language code, new term is
-	 * added. If a term with this langua *
-	 * <p>
-	 * Since all changes will be checked after the {@link StatementUpdate} is passed
-	 * to {@link EntityDocumentBuilder} anyway, it is usually unnecessary to use
-	 * this method. It is simpler to initialize the builder with {@link #create()}.
-	 * ge code already exists, it is replaced. Terms with other language codes are
-	 * not touched. Calling this method overrides any previous changes made with the
-	 * same language code by this method or {@link #remove(String)}.
+	 * Adds or changes term. If a term with this language code already exists, it is
+	 * replaced. Terms with other language codes are not touched. Calling this
+	 * method overrides any previous changes made with the same language code by
+	 * this method or {@link #remove(String)}.
 	 * <p>
 	 * If base revision terms were provided, attempt to overwrite some term with the
 	 * same value will be silently ignored, resulting in empty update.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermUpdateBuilder.java
@@ -41,6 +41,12 @@ public class TermUpdateBuilder {
 	private final Set<String> removed = new HashSet<>();
 
 	/**
+	 * Creates new empty builder.
+	 */
+	public TermUpdateBuilder() {
+	}
+
+	/**
 	 * Adds or changes term. If there is no term for the language code, new term is
 	 * added. If a term with this language code already exists, it is replaced.
 	 * Terms with other language codes are not touched. Calling this method

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermUpdateBuilder.java
@@ -29,8 +29,6 @@ import java.util.Objects;
 import java.util.Set;
 
 import org.apache.commons.lang3.Validate;
-import org.wikidata.wdtk.datamodel.implementation.DataObjectFactoryImpl;
-import org.wikidata.wdtk.datamodel.interfaces.DataObjectFactory;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
@@ -39,8 +37,6 @@ import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
  * Builder for incremental construction of {@link TermUpdate} objects.
  */
 public class TermUpdateBuilder {
-
-	private static DataObjectFactory factory = new DataObjectFactoryImpl();
 
 	private final Map<String, MonolingualTextValue> base;
 	private final Map<String, MonolingualTextValue> modified = new HashMap<>();
@@ -171,7 +167,7 @@ public class TermUpdateBuilder {
 	 * @return constructed object
 	 */
 	public TermUpdate build() {
-		return factory.getTermUpdate(modified.values(), removed);
+		return Datamodel.makeTermUpdate(modified.values(), removed);
 	}
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermUpdateBuilder.java
@@ -45,6 +45,9 @@ public class TermUpdateBuilder {
 	private TermUpdateBuilder(Collection<MonolingualTextValue> base) {
 		if (base != null) {
 			Validate.noNullElements(base, "Base document terms cannot be null.");
+			Validate.isTrue(
+					base.stream().map(v -> v.getLanguageCode()).distinct().count() == base.size(),
+					"Base document terms must have unique language codes.");
 			this.base = base.stream().collect(toMap(v -> v.getLanguageCode(), v -> v));
 		} else
 			this.base = null;
@@ -71,7 +74,9 @@ public class TermUpdateBuilder {
 	 *            terms from base revision of the document
 	 * @return update builder object
 	 * @throws NullPointerException
-	 *             if {@code terms} or any of its items is {@code null}
+	 *             if {@code terms} is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if any items in {@code terms} are {@code null} or duplicate
 	 */
 	public static TermUpdateBuilder forTerms(Collection<MonolingualTextValue> terms) {
 		Objects.requireNonNull(terms, "Base document term collection cannot be null.");

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermUpdateBuilder.java
@@ -94,7 +94,7 @@ public class TermUpdateBuilder {
 	 * this method. It is simpler to initialize the builder with {@link #create()}.
 	 * ge code already exists, it is replaced. Terms with other language codes are
 	 * not touched. Calling this method overrides any previous changes made with the
-	 * same language code by this method or {@link #removeTerm(String)}.
+	 * same language code by this method or {@link #remove(String)}.
 	 * <p>
 	 * If base revision terms were provided, attempt to overwrite some term with the
 	 * same value will be silently ignored, resulting in empty update.
@@ -105,7 +105,7 @@ public class TermUpdateBuilder {
 	 * @throws NullPointerException
 	 *             if {@code term} is {@code null}
 	 */
-	public TermUpdateBuilder setTerm(MonolingualTextValue term) {
+	public TermUpdateBuilder put(MonolingualTextValue term) {
 		Objects.requireNonNull(term, "Term cannot be null.");
 		if (base != null) {
 			if (term.equals(base.get(term.getLanguageCode()))) {
@@ -122,7 +122,7 @@ public class TermUpdateBuilder {
 	/**
 	 * Removes term. Terms with other language codes are not touched. Calling this
 	 * method overrides any previous changes made with the same language code by
-	 * this method or {@link #setTerm(MonolingualTextValue)}.
+	 * this method or {@link #put(MonolingualTextValue)}.
 	 * <p>
 	 * If base revision terms were provided, attempts to remove missing terms will
 	 * be silently ignored, resulting in empty update.
@@ -135,7 +135,7 @@ public class TermUpdateBuilder {
 	 * @throws IllegalArgumentException
 	 *             if {@code languageCode} is blank
 	 */
-	public TermUpdateBuilder removeTerm(String languageCode) {
+	public TermUpdateBuilder remove(String languageCode) {
 		Validate.notBlank(languageCode, "Language code must be provided.");
 		if (base != null && !base.containsKey(languageCode)) {
 			modified.remove(languageCode);
@@ -148,8 +148,8 @@ public class TermUpdateBuilder {
 
 	/**
 	 * Replays all changes in provided update into this builder object. Changes are
-	 * performed as if by calling {@link #setTerm(MonolingualTextValue)} and
-	 * {@link #removeTerm(String)} methods.
+	 * performed as if by calling {@link #put(MonolingualTextValue)} and
+	 * {@link #remove(String)} methods.
 	 * 
 	 * @param update
 	 *            term update to replay
@@ -157,13 +157,13 @@ public class TermUpdateBuilder {
 	 * @throws NullPointerException
 	 *             if {@code update} is {@code null}
 	 */
-	public TermUpdateBuilder apply(TermUpdate update) {
+	public TermUpdateBuilder append(TermUpdate update) {
 		Objects.requireNonNull(update, "Term update cannot be null.");
-		for (MonolingualTextValue term : update.getModifiedTerms().values()) {
-			setTerm(term);
+		for (MonolingualTextValue term : update.getModified().values()) {
+			put(term);
 		}
-		for (String language : update.getRemovedTerms()) {
-			removeTerm(language);
+		for (String language : update.getRemoved()) {
+			remove(language);
 		}
 		return this;
 	}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermedDocumentUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermedDocumentUpdateBuilder.java
@@ -187,12 +187,15 @@ public abstract class TermedDocumentUpdateBuilder extends LabeledDocumentUpdateB
 	 *             if {@code language}, {@code aliases}, or any of the aliases are
 	 *             {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code aliases} contains duplicates
+	 *             if {@code language} is blank or {@code aliases} contains
+	 *             duplicates
 	 */
 	public TermedDocumentUpdateBuilder setAliases(String language, List<String> aliases) {
-		Objects.requireNonNull(language, "Language code cannot be null.");
+		Validate.notBlank(language, "Specify language code.");
 		Objects.requireNonNull(aliases, "Alias list cannot be null.");
-		Validate.noNullElements(aliases, "Aliases cannot be null.");
+		for (String alias : aliases) {
+			Objects.requireNonNull(alias, "Aliases cannot be null.");
+		}
 		Validate.isTrue(new HashSet<>(aliases).size() == aliases.size(), "Aliases must be unique.");
 		List<MonolingualTextValue> values = aliases.stream()
 				.map(a -> Datamodel.makeMonolingualTextValue(a, language))

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermedDocumentUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermedDocumentUpdateBuilder.java
@@ -43,7 +43,7 @@ import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocumentUpdate;
  * Builder for incremental construction of {@link TermedStatementDocumentUpdate}
  * objects.
  */
-public abstract class TermedStatementDocumentUpdateBuilder extends LabeledStatementDocumentUpdateBuilder {
+public abstract class TermedDocumentUpdateBuilder extends LabeledDocumentUpdateBuilder {
 
 	TermUpdate descriptions = TermUpdate.NULL;
 	final Map<String, List<MonolingualTextValue>> aliases = new HashMap<>();
@@ -59,7 +59,7 @@ public abstract class TermedStatementDocumentUpdateBuilder extends LabeledStatem
 	 * @throws IllegalArgumentException
 	 *             if {@code entityId} is a placeholder ID
 	 */
-	protected TermedStatementDocumentUpdateBuilder(EntityIdValue entityId) {
+	protected TermedDocumentUpdateBuilder(EntityIdValue entityId) {
 		super(entityId);
 	}
 
@@ -74,7 +74,7 @@ public abstract class TermedStatementDocumentUpdateBuilder extends LabeledStatem
 	 * @throws IllegalArgumentException
 	 *             if {@code revision} has placeholder ID
 	 */
-	protected TermedStatementDocumentUpdateBuilder(TermedStatementDocument revision) {
+	protected TermedDocumentUpdateBuilder(TermedStatementDocument revision) {
 		super(revision);
 	}
 
@@ -92,7 +92,7 @@ public abstract class TermedStatementDocumentUpdateBuilder extends LabeledStatem
 	 *             if {@code entityId} is of unrecognized type or it is a
 	 *             placeholder ID
 	 */
-	public static TermedStatementDocumentUpdateBuilder forEntityId(EntityIdValue entityId) {
+	public static TermedDocumentUpdateBuilder forEntityId(EntityIdValue entityId) {
 		Objects.requireNonNull(entityId, "Entity ID cannot be null.");
 		if (entityId instanceof ItemIdValue) {
 			return ItemUpdateBuilder.forEntityId((ItemIdValue) entityId);
@@ -122,7 +122,7 @@ public abstract class TermedStatementDocumentUpdateBuilder extends LabeledStatem
 	 *             if {@code revision} is of unrecognized type or its ID is a
 	 *             placeholder ID
 	 */
-	public static TermedStatementDocumentUpdateBuilder forBaseRevision(TermedStatementDocument revision) {
+	public static TermedDocumentUpdateBuilder forBaseRevision(TermedStatementDocument revision) {
 		Objects.requireNonNull(revision, "Base entity revision cannot be null.");
 		if (revision instanceof ItemDocument) {
 			return ItemUpdateBuilder.forBaseRevision((ItemDocument) revision);
@@ -139,13 +139,13 @@ public abstract class TermedStatementDocumentUpdateBuilder extends LabeledStatem
 	}
 
 	@Override
-	public TermedStatementDocumentUpdateBuilder updateStatements(StatementUpdate update) {
+	public TermedDocumentUpdateBuilder updateStatements(StatementUpdate update) {
 		super.updateStatements(update);
 		return this;
 	}
 
 	@Override
-	public TermedStatementDocumentUpdateBuilder updateLabels(TermUpdate update) {
+	public TermedDocumentUpdateBuilder updateLabels(TermUpdate update) {
 		super.updateLabels(update);
 		return this;
 	}
@@ -161,7 +161,7 @@ public abstract class TermedStatementDocumentUpdateBuilder extends LabeledStatem
 	 * @throws NullPointerException
 	 *             if {@code update} is {@code null}
 	 */
-	public TermedStatementDocumentUpdateBuilder updateDescriptions(TermUpdate update) {
+	public TermedDocumentUpdateBuilder updateDescriptions(TermUpdate update) {
 		Objects.requireNonNull(update, "Update cannot be null.");
 		TermUpdateBuilder combined = getBaseRevision() != null
 				? TermUpdateBuilder.forTerms(getBaseRevision().getDescriptions().values())
@@ -189,7 +189,7 @@ public abstract class TermedStatementDocumentUpdateBuilder extends LabeledStatem
 	 * @throws IllegalArgumentException
 	 *             if {@code aliases} contains duplicates
 	 */
-	public TermedStatementDocumentUpdateBuilder setAliases(String language, List<String> aliases) {
+	public TermedDocumentUpdateBuilder setAliases(String language, List<String> aliases) {
 		Objects.requireNonNull(language, "Language code cannot be null.");
 		Objects.requireNonNull(aliases, "Alias list cannot be null.");
 		Validate.noNullElements(aliases, "Aliases cannot be null.");

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermedDocumentUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermedDocumentUpdateBuilder.java
@@ -42,7 +42,7 @@ import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocumentUpdate;
  */
 public abstract class TermedDocumentUpdateBuilder extends LabeledDocumentUpdateBuilder {
 
-	TermUpdate descriptions = TermUpdate.NULL;
+	TermUpdate descriptions = TermUpdate.EMPTY;
 	final Map<String, AliasUpdate> aliases = new HashMap<>();
 
 	/**
@@ -225,7 +225,7 @@ public abstract class TermedDocumentUpdateBuilder extends LabeledDocumentUpdateB
 		} else {
 			builder = AliasUpdateBuilder.create();
 		}
-		builder.append(aliases.getOrDefault(language, AliasUpdate.NULL));
+		builder.append(aliases.getOrDefault(language, AliasUpdate.EMPTY));
 		builder.append(update);
 		AliasUpdate combined = builder.build();
 		if (!combined.isEmpty()) {

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermedDocumentUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermedDocumentUpdateBuilder.java
@@ -54,13 +54,16 @@ public abstract class TermedDocumentUpdateBuilder extends LabeledDocumentUpdateB
 	 * 
 	 * @param entityId
 	 *            ID of the entity that is to be updated
+	 * @param revisionId
+	 *            ID of the base entity revision to be updated or zero if not
+	 *            available
 	 * @throws NullPointerException
 	 *             if {@code entityId} is {@code null}
 	 * @throws IllegalArgumentException
 	 *             if {@code entityId} is a placeholder ID
 	 */
-	protected TermedDocumentUpdateBuilder(EntityIdValue entityId) {
-		super(entityId);
+	protected TermedDocumentUpdateBuilder(EntityIdValue entityId, long revisionId) {
+		super(entityId, revisionId);
 	}
 
 	/**
@@ -79,6 +82,35 @@ public abstract class TermedDocumentUpdateBuilder extends LabeledDocumentUpdateB
 	}
 
 	/**
+	 * Creates new builder object for constructing update of entity with given
+	 * revision ID.
+	 * <p>
+	 * Supported entity IDs include {@link ItemIdValue} and {@link PropertyIdValue}.
+	 * 
+	 * @param entityId
+	 *            ID of the entity that is to be updated
+	 * @param revisionId
+	 *            ID of the base entity revision to be updated or zero if not
+	 *            available
+	 * @return builder object matching entity type
+	 * @throws NullPointerException
+	 *             if {@code entityId} is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if {@code entityId} is of unrecognized type or it is a
+	 *             placeholder ID
+	 */
+	public static TermedDocumentUpdateBuilder forBaseRevisionId(EntityIdValue entityId, long revisionId) {
+		Objects.requireNonNull(entityId, "Entity ID cannot be null.");
+		if (entityId instanceof ItemIdValue) {
+			return ItemUpdateBuilder.forBaseRevisionId((ItemIdValue) entityId, revisionId);
+		}
+		if (entityId instanceof PropertyIdValue) {
+			return PropertyUpdateBuilder.forBaseRevisionId((PropertyIdValue) entityId, revisionId);
+		}
+		throw new IllegalArgumentException("Unrecognized entity ID type.");
+	}
+
+	/**
 	 * Creates new builder object for constructing update of entity with given ID.
 	 * <p>
 	 * Supported entity IDs include {@link ItemIdValue} and {@link PropertyIdValue}.
@@ -93,14 +125,7 @@ public abstract class TermedDocumentUpdateBuilder extends LabeledDocumentUpdateB
 	 *             placeholder ID
 	 */
 	public static TermedDocumentUpdateBuilder forEntityId(EntityIdValue entityId) {
-		Objects.requireNonNull(entityId, "Entity ID cannot be null.");
-		if (entityId instanceof ItemIdValue) {
-			return ItemUpdateBuilder.forEntityId((ItemIdValue) entityId);
-		}
-		if (entityId instanceof PropertyIdValue) {
-			return PropertyUpdateBuilder.forEntityId((PropertyIdValue) entityId);
-		}
-		throw new IllegalArgumentException("Unrecognized entity ID type.");
+		return forBaseRevisionId(entityId, 0);
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermedStatementDocumentUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermedStatementDocumentUpdateBuilder.java
@@ -57,7 +57,7 @@ public abstract class TermedStatementDocumentUpdateBuilder extends LabeledStatem
 	 * @throws NullPointerException
 	 *             if {@code entityId} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code entityId} is not a valid ID
+	 *             if {@code entityId} is a placeholder ID
 	 */
 	protected TermedStatementDocumentUpdateBuilder(EntityIdValue entityId) {
 		super(entityId);
@@ -72,7 +72,7 @@ public abstract class TermedStatementDocumentUpdateBuilder extends LabeledStatem
 	 * @throws NullPointerException
 	 *             if {@code revision} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code revision} does not have valid ID
+	 *             if {@code revision} has placeholder ID
 	 */
 	protected TermedStatementDocumentUpdateBuilder(TermedStatementDocument revision) {
 		super(revision);
@@ -89,7 +89,8 @@ public abstract class TermedStatementDocumentUpdateBuilder extends LabeledStatem
 	 * @throws NullPointerException
 	 *             if {@code entityId} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code entityId} is of unrecognized type or it is not valid
+	 *             if {@code entityId} is of unrecognized type or it is a
+	 *             placeholder ID
 	 */
 	public static TermedStatementDocumentUpdateBuilder forEntityId(EntityIdValue entityId) {
 		Objects.requireNonNull(entityId, "Entity ID cannot be null.");
@@ -118,8 +119,8 @@ public abstract class TermedStatementDocumentUpdateBuilder extends LabeledStatem
 	 * @throws NullPointerException
 	 *             if {@code revision} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code revision} is of unrecognized type or it does not have
-	 *             valid ID
+	 *             if {@code revision} is of unrecognized type or its ID is a
+	 *             placeholder ID
 	 */
 	public static TermedStatementDocumentUpdateBuilder forBaseRevision(TermedStatementDocument revision) {
 		Objects.requireNonNull(revision, "Entity document cannot be null.");

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermedStatementDocumentUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermedStatementDocumentUpdateBuilder.java
@@ -157,8 +157,8 @@ public abstract class TermedStatementDocumentUpdateBuilder extends LabeledStatem
 	 * @throws NullPointerException
 	 *             if {@code update} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if removed description is not present in current entity revision
-	 *             (if available)
+	 *             if removed description is not present in base entity revision (if
+	 *             available)
 	 */
 	public TermedStatementDocumentUpdateBuilder updateDescriptions(TermUpdate update) {
 		Objects.requireNonNull(update, "Update cannot be null.");

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermedStatementDocumentUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/TermedStatementDocumentUpdateBuilder.java
@@ -123,7 +123,7 @@ public abstract class TermedStatementDocumentUpdateBuilder extends LabeledStatem
 	 *             placeholder ID
 	 */
 	public static TermedStatementDocumentUpdateBuilder forBaseRevision(TermedStatementDocument revision) {
-		Objects.requireNonNull(revision, "Entity document cannot be null.");
+		Objects.requireNonNull(revision, "Base entity revision cannot be null.");
 		if (revision instanceof ItemDocument) {
 			return ItemUpdateBuilder.forBaseRevision((ItemDocument) revision);
 		}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/AliasUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/AliasUpdateImpl.java
@@ -1,0 +1,186 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.implementation;
+
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toSet;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+import org.apache.commons.lang3.Validate;
+import org.wikidata.wdtk.datamodel.helpers.Equality;
+import org.wikidata.wdtk.datamodel.helpers.Hash;
+import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Jackson implementation of {@link AliasUpdate}.
+ */
+public class AliasUpdateImpl implements AliasUpdate {
+
+	@JsonIgnore
+	private final String languageCode;
+	@JsonIgnore
+	private final List<MonolingualTextValue> recreated;
+	private final List<MonolingualTextValue> added;
+	private final Set<MonolingualTextValue> removed;
+
+	/**
+	 * Initializes new alias update. This update applies to aliases in one language
+	 * only. Callers should specify either {@code recreated} parameter or
+	 * {@code added} and {@code removed} parameters, because combination of the two
+	 * update approaches is not possible. To remove all aliases, pass empty list in
+	 * {@code recreated} parameter.
+	 * 
+	 * @param recreated
+	 *            new list of aliases that completely replaces the old ones or
+	 *            {@code null} to not recreate aliases
+	 * @param added
+	 *            aliases added in this update or empty collection for no additions
+	 * @param removed
+	 *            aliases removed in this update or empty collection for no removals
+	 * @throws NullPointerException
+	 *             if {@code added}, {@code removed}, or any alias is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if given invalid combination of parameters
+	 */
+	public AliasUpdateImpl(List<MonolingualTextValue> recreated, List<MonolingualTextValue> added,
+			Collection<MonolingualTextValue> removed) {
+		Objects.requireNonNull(added, "List of added aliases cannot be null.");
+		Objects.requireNonNull(removed, "List of removed aliases cannot be null.");
+		Validate.isTrue(recreated == null || added.isEmpty() && removed.isEmpty(),
+				"Cannot combine additions/removals with recreating the alias list.");
+		List<MonolingualTextValue> all = new ArrayList<>();
+		if (recreated != null) {
+			all.addAll(recreated);
+		}
+		all.addAll(added);
+		all.addAll(removed);
+		for (MonolingualTextValue alias : all) {
+			Validate.notNull(alias, "Alias object cannot be null.");
+		}
+		Validate.isTrue(all.stream().map(v -> v.getLanguageCode()).distinct().count() <= 1,
+				"Inconsistent language codes.");
+		if (recreated != null) {
+			Validate.isTrue(recreated.stream().distinct().count() == recreated.size(),
+					"Every alias in the new list of aliases must be unique.");
+		}
+		Validate.isTrue(added.stream().distinct().count() == added.size(),
+				"Every new alias must be unique.");
+		Validate.isTrue(removed.stream().distinct().count() == removed.size(),
+				"Every removed alias must be unique.");
+		Validate.isTrue(all.stream().distinct().count() == all.size(),
+				"Cannot add and remove the same alias.");
+		languageCode = all.stream().map(v -> v.getLanguageCode()).findFirst().orElse(null);
+		this.recreated = recreated != null
+				? Collections.unmodifiableList(recreated.stream().map(TermImpl::new).collect(toList()))
+				: null;
+		this.added = Collections.unmodifiableList(added.stream().map(AddedAlias::new).collect(toList()));
+		this.removed = Collections.unmodifiableSet(removed.stream().map(RemovedAlias::new).collect(toSet()));
+	}
+
+	@JsonIgnore
+	@Override
+	public boolean isEmpty() {
+		return recreated == null && added.isEmpty() && removed.isEmpty();
+	}
+
+	@JsonIgnore
+	@Override
+	public Optional<String> getLanguageCode() {
+		return Optional.ofNullable(languageCode);
+	}
+
+	@JsonIgnore
+	@Override
+	public Optional<List<MonolingualTextValue>> getRecreated() {
+		return Optional.ofNullable(recreated);
+	}
+
+	@JsonIgnore
+	@Override
+	public List<MonolingualTextValue> getAdded() {
+		return added;
+	}
+
+	@JsonIgnore
+	@Override
+	public Set<MonolingualTextValue> getRemoved() {
+		return removed;
+	}
+
+	static class AddedAlias extends TermImpl {
+
+		AddedAlias(MonolingualTextValue alias) {
+			super(alias);
+		}
+
+		@JsonProperty("add")
+		String getAddCommand() {
+			return "";
+		}
+
+	}
+
+	static class RemovedAlias extends TermImpl {
+
+		RemovedAlias(MonolingualTextValue alias) {
+			super(alias);
+		}
+
+		@JsonProperty("remove")
+		String getRemoveCommand() {
+			return "";
+		}
+
+	}
+
+	@JsonValue
+	List<Object> toJson() {
+		List<Object> items = new ArrayList<>();
+		if (recreated != null) {
+			items.addAll(recreated);
+		}
+		items.addAll(removed);
+		items.addAll(added);
+		return items;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return Equality.equalsAliasUpdate(this, obj);
+	}
+
+	@Override
+	public int hashCode() {
+		return Hash.hashCode(this);
+	}
+
+}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/AliasUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/AliasUpdateImpl.java
@@ -170,6 +170,9 @@ public class AliasUpdateImpl implements AliasUpdate {
 		}
 		items.addAll(removed);
 		items.addAll(added);
+		if (items.isEmpty() && recreated == null) {
+			return null;
+		}
 		return items;
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImpl.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -44,7 +45,6 @@ import org.wikidata.wdtk.datamodel.interfaces.MediaInfoDocument;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
-import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.NoValueSnak;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
@@ -63,6 +63,7 @@ import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
 import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.StringValue;
+import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.TimeValue;
 import org.wikidata.wdtk.datamodel.interfaces.Value;
 import org.wikidata.wdtk.datamodel.interfaces.ValueSnak;
@@ -327,6 +328,14 @@ public class DataObjectFactoryImpl implements DataObjectFactory {
 	}
 
 	@Override
+	public AliasUpdate getAliasUpdate(
+			List<MonolingualTextValue> recreated,
+			List<MonolingualTextValue> added,
+			Collection<MonolingualTextValue> removed) {
+		return new AliasUpdateImpl(recreated, added, removed);
+	}
+
+	@Override
 	public StatementUpdate getStatementUpdate(
 			Collection<Statement> added,
 			Collection<Statement> replaced,
@@ -388,7 +397,7 @@ public class DataObjectFactoryImpl implements DataObjectFactory {
 			long revisionId,
 			TermUpdate labels,
 			TermUpdate descriptions,
-			Map<String, List<MonolingualTextValue>> aliases,
+			Map<String, AliasUpdate> aliases,
 			StatementUpdate statements,
 			Collection<SiteLink> modifiedSiteLinks,
 			Collection<String> removedSiteLinks) {
@@ -402,7 +411,7 @@ public class DataObjectFactoryImpl implements DataObjectFactory {
 			long revisionId,
 			TermUpdate labels,
 			TermUpdate descriptions,
-			Map<String, List<MonolingualTextValue>> aliases,
+			Map<String, AliasUpdate> aliases,
 			StatementUpdate statements) {
 		return new PropertyUpdateImpl(entityId, revisionId, labels, descriptions, aliases, statements);
 	}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImpl.java
@@ -326,26 +326,26 @@ public class DataObjectFactoryImpl implements DataObjectFactory {
 	@Override
 	public SenseUpdate getSenseUpdate(
 			SenseIdValue entityId,
-			SenseDocument document,
+			long revisionId,
 			TermUpdate glosses,
 			StatementUpdate statements) {
-		return new SenseUpdateImpl(entityId, document, glosses, statements);
+		return new SenseUpdateImpl(entityId, revisionId, glosses, statements);
 	}
 
 	@Override
 	public FormUpdate getFormUpdate(
 			FormIdValue entityId,
-			FormDocument document,
+			long revisionId,
 			TermUpdate representations,
 			Collection<ItemIdValue> grammaticalFeatures,
 			StatementUpdate statements) {
-		return new FormUpdateImpl(entityId, document, representations, grammaticalFeatures, statements);
+		return new FormUpdateImpl(entityId, revisionId, representations, grammaticalFeatures, statements);
 	}
 
 	@Override
 	public LexemeUpdate getLexemeUpdate(
 			LexemeIdValue entityId,
-			LexemeDocument document,
+			long revisionId,
 			ItemIdValue language,
 			ItemIdValue lexicalCategory,
 			TermUpdate lemmas,
@@ -356,7 +356,7 @@ public class DataObjectFactoryImpl implements DataObjectFactory {
 			Collection<FormDocument> addedForms,
 			Collection<FormUpdate> updatedForms,
 			Collection<FormIdValue> removedForms) {
-		return new LexemeUpdateImpl(entityId, document,
+		return new LexemeUpdateImpl(entityId, revisionId,
 				language, lexicalCategory, lemmas, statements,
 				addedSenses, updatedSenses, removedSenses,
 				addedForms, updatedForms, removedForms);
@@ -365,35 +365,35 @@ public class DataObjectFactoryImpl implements DataObjectFactory {
 	@Override
 	public MediaInfoUpdate getMediaInfoUpdate(
 			MediaInfoIdValue entityId,
-			MediaInfoDocument document,
+			long revisionId,
 			TermUpdate labels,
 			StatementUpdate statements) {
-		return new MediaInfoUpdateImpl(entityId, document, labels, statements);
+		return new MediaInfoUpdateImpl(entityId, revisionId, labels, statements);
 	}
 
 	@Override
 	public ItemUpdate getItemUpdate(
 			ItemIdValue entityId,
-			ItemDocument document,
+			long revisionId,
 			TermUpdate labels,
 			TermUpdate descriptions,
 			Map<String, List<MonolingualTextValue>> aliases,
 			StatementUpdate statements,
 			Collection<SiteLink> modifiedSiteLinks,
 			Collection<String> removedSiteLinks) {
-		return new ItemUpdateImpl(entityId, document, labels, descriptions, aliases, statements,
+		return new ItemUpdateImpl(entityId, revisionId, labels, descriptions, aliases, statements,
 				modifiedSiteLinks, removedSiteLinks);
 	}
 
 	@Override
 	public PropertyUpdate getPropertyUpdate(
 			PropertyIdValue entityId,
-			PropertyDocument document,
+			long revisionId,
 			TermUpdate labels,
 			TermUpdate descriptions,
 			Map<String, List<MonolingualTextValue>> aliases,
 			StatementUpdate statements) {
-		return new PropertyUpdateImpl(entityId, document, labels, descriptions, aliases, statements);
+		return new PropertyUpdateImpl(entityId, revisionId, labels, descriptions, aliases, statements);
 	}
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/EntityIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/EntityIdValueImpl.java
@@ -219,12 +219,6 @@ public abstract class EntityIdValueImpl extends ValueImpl implements
 		}
 	}
 
-	@JsonIgnore
-	@Override
-	public boolean isValid() {
-		return EntityIdValue.super.isValid();
-	}
-
 	protected void assertHasJsonEntityType(String expectedType) {
 		if(!expectedType.equals(value.entityType)) {
 			throw new IllegalArgumentException(

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/EntityUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/EntityUpdateImpl.java
@@ -50,12 +50,12 @@ public abstract class EntityUpdateImpl implements EntityUpdate {
 	 * @throws NullPointerException
 	 *             if {@code entityId} is {@code null}
 	 * @throws IllegalArgumentException
-	 *             if {@code entityId} is not a valid ID or it does not match base
+	 *             if {@code entityId} is a placeholder ID or it does not match base
 	 *             revision document ID (if provided)
 	 */
 	protected EntityUpdateImpl(EntityIdValue entityId, EntityDocument revision) {
 		Objects.requireNonNull(entityId, "Entity ID cannot be null.");
-		Validate.isTrue(entityId.isValid(), "Entity ID must be valid.");
+		Validate.isTrue(!entityId.isPlaceholder(), "Cannot create update for placeholder entity ID.");
 		if (revision != null) {
 			Validate.isTrue(entityId.equals(revision.getEntityId()),
 					"Entity ID must be the same as ID of the base revision document.");

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/EntityUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/EntityUpdateImpl.java
@@ -26,7 +26,6 @@ import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.EntityUpdate;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Jackson implementation of {@link EntityUpdate}.
@@ -62,11 +61,6 @@ public abstract class EntityUpdateImpl implements EntityUpdate {
 	@Override
 	public EntityIdValue getEntityId() {
 		return entityId;
-	}
-
-	@JsonProperty
-	String getId() {
-		return entityId.getId();
 	}
 
 	@JsonIgnore

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/EntityUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/EntityUpdateImpl.java
@@ -22,7 +22,6 @@ package org.wikidata.wdtk.datamodel.implementation;
 import java.util.Objects;
 
 import org.apache.commons.lang3.Validate;
-import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.EntityUpdate;
 
@@ -37,31 +36,26 @@ public abstract class EntityUpdateImpl implements EntityUpdate {
 	@JsonIgnore
 	private final EntityIdValue entityId;
 	@JsonIgnore
-	private final EntityDocument baseRevision;
+	private final long revisionId;
 
 	/**
 	 * Initializes new entity update.
 	 * 
 	 * @param entityId
 	 *            ID of the entity that is to be updated
-	 * @param revision
-	 *            base entity revision to be updated or {@code null} if not
-	 *            available
+	 * @param revisionId
+	 *            base entity revision to be updated or zero if not available
 	 * @throws NullPointerException
 	 *             if {@code entityId} is {@code null}
 	 * @throws IllegalArgumentException
 	 *             if {@code entityId} is a placeholder ID or it does not match base
 	 *             revision document ID (if provided)
 	 */
-	protected EntityUpdateImpl(EntityIdValue entityId, EntityDocument revision) {
+	protected EntityUpdateImpl(EntityIdValue entityId, long revisionId) {
 		Objects.requireNonNull(entityId, "Entity ID cannot be null.");
 		Validate.isTrue(!entityId.isPlaceholder(), "Cannot create update for placeholder entity ID.");
-		if (revision != null) {
-			Validate.isTrue(entityId.equals(revision.getEntityId()),
-					"Entity ID must be the same as ID of the base revision document.");
-		}
 		this.entityId = entityId;
-		baseRevision = revision;
+		this.revisionId = revisionId;
 	}
 
 	@JsonIgnore
@@ -77,8 +71,8 @@ public abstract class EntityUpdateImpl implements EntityUpdate {
 
 	@JsonIgnore
 	@Override
-	public EntityDocument getBaseRevision() {
-		return baseRevision;
+	public long getBaseRevisionId() {
+		return revisionId;
 	}
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/FormDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/FormDocumentImpl.java
@@ -143,11 +143,7 @@ public class FormDocumentImpl extends StatementDocumentImpl implements FormDocum
 	@JsonIgnore
 	@Override
 	public FormIdValue getEntityId() {
-		if (!EntityIdValue.SITE_LOCAL.equals(siteIri)) {
-			return new FormIdValueImpl(entityId, siteIri);
-		} else {
-			return FormIdValue.NULL;
-		}
+		return new FormIdValueImpl(entityId, siteIri);
 	}
 
 	@JsonIgnore

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/FormIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/FormIdValueImpl.java
@@ -44,7 +44,10 @@ import java.util.regex.Pattern;
 @JsonDeserialize()
 public class FormIdValueImpl extends ValueImpl implements FormIdValue {
 
-	private static final Pattern PATTERN = Pattern.compile("^L[1-9]\\d*-F[1-9]\\d*$");
+	/*
+	 * Allow L0-F0 from FormIdValue.NULL.
+	 */
+	private static final Pattern PATTERN = Pattern.compile("L[1-9]\\d*-F[1-9]\\d*|L0-F0");
 
 	private final String id;
 	private final String siteIri;
@@ -105,8 +108,8 @@ public class FormIdValueImpl extends ValueImpl implements FormIdValue {
 
 	@JsonIgnore
 	@Override
-	public boolean isValid() {
-		return FormIdValue.super.isValid();
+	public boolean isPlaceholder() {
+		return id.equals("L0-F0");
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/FormUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/FormUpdateImpl.java
@@ -29,6 +29,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import org.apache.commons.lang3.Validate;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
@@ -78,6 +79,15 @@ public class FormUpdateImpl extends StatementDocumentUpdateImpl implements FormU
 			StatementUpdate statements) {
 		super(entityId, revisionId, statements);
 		Objects.requireNonNull(representations, "Representation update cannot be null.");
+		if (grammaticalFeatures != null) {
+			for (ItemIdValue feature : grammaticalFeatures) {
+				Objects.requireNonNull(feature, "Grammatical feature cannot be null.");
+				Validate.isTrue(!feature.isPlaceholder(), "Grammatical feature cannot be a placeholder ID.");
+			}
+			Validate.isTrue(
+					grammaticalFeatures.stream().distinct().count() == grammaticalFeatures.size(),
+					"Grammatical features must be unique.");
+		}
 		this.representations = representations;
 		this.grammaticalFeatures = grammaticalFeatures != null
 				? Collections.unmodifiableSet(new HashSet<>(grammaticalFeatures))

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/FormUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/FormUpdateImpl.java
@@ -29,6 +29,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import org.wikidata.wdtk.datamodel.helpers.Equality;
+import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
 import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.FormUpdate;
@@ -125,6 +127,16 @@ public class FormUpdateImpl extends StatementDocumentUpdateImpl implements FormU
 		if (grammaticalFeatures == null)
 			return null;
 		return grammaticalFeatures.stream().map(f -> f.getId()).collect(toList());
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return Equality.equalsFormUpdate(this, obj);
+	}
+
+	@Override
+	public int hashCode() {
+		return Hash.hashCode(this);
 	}
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/FormUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/FormUpdateImpl.java
@@ -31,7 +31,6 @@ import java.util.Set;
 
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
-import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
 import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.FormUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
@@ -58,8 +57,8 @@ public class FormUpdateImpl extends StatementDocumentUpdateImpl implements FormU
 	 * 
 	 * @param entityId
 	 *            ID of the form that is to be updated
-	 * @param revision
-	 *            base form revision to be updated or {@code null} if not available
+	 * @param revisionId
+	 *            base form revision to be updated or zero if not available
 	 * @param representations
 	 *            changes in form representations, possibly empty
 	 * @param grammaticalFeatures
@@ -73,11 +72,11 @@ public class FormUpdateImpl extends StatementDocumentUpdateImpl implements FormU
 	 */
 	public FormUpdateImpl(
 			FormIdValue entityId,
-			FormDocument revision,
+			long revisionId,
 			TermUpdate representations,
 			Collection<ItemIdValue> grammaticalFeatures,
 			StatementUpdate statements) {
-		super(entityId, revision, statements);
+		super(entityId, revisionId, statements);
 		Objects.requireNonNull(representations, "Representation update cannot be null.");
 		this.representations = representations;
 		this.grammaticalFeatures = grammaticalFeatures != null
@@ -89,12 +88,6 @@ public class FormUpdateImpl extends StatementDocumentUpdateImpl implements FormU
 	@Override
 	public FormIdValue getEntityId() {
 		return (FormIdValue) super.getEntityId();
-	}
-
-	@JsonIgnore
-	@Override
-	public FormDocument getBaseRevision() {
-		return (FormDocument) super.getBaseRevision();
 	}
 
 	@JsonIgnore

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImpl.java
@@ -29,7 +29,6 @@ import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
-import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
@@ -142,11 +141,7 @@ public class ItemDocumentImpl extends TermedStatementDocumentImpl
 	@JsonIgnore
 	@Override
 	public ItemIdValue getEntityId() {
-		if (!EntityIdValue.SITE_LOCAL.equals(siteIri)) {
-			return new ItemIdValueImpl(entityId, siteIri);
-		} else {
-			return ItemIdValue.NULL;
-		}
+		return new ItemIdValueImpl(entityId, siteIri);
 	}
 
 	@JsonProperty("sitelinks")

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemIdValueImpl.java
@@ -95,6 +95,12 @@ public class ItemIdValueImpl extends EntityIdValueImpl implements
 		return EntityIdValue.ET_ITEM;
 	}
 
+	@JsonIgnore
+	@Override
+	public boolean isPlaceholder() {
+		return getId().equals("Q0");
+	}
+
 	@Override
 	public <T> T accept(ValueVisitor<T> valueVisitor) {
 		return valueVisitor.visit(this);
@@ -114,4 +120,5 @@ public class ItemIdValueImpl extends EntityIdValueImpl implements
 	public String toString() {
 		return ToString.toString(this);
 	}
+
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemUpdateImpl.java
@@ -25,15 +25,14 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
+import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ItemUpdate;
-import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
@@ -82,7 +81,7 @@ public class ItemUpdateImpl extends TermedStatementDocumentUpdateImpl implements
 			long revisionId,
 			TermUpdate labels,
 			TermUpdate descriptions,
-			Map<String, List<MonolingualTextValue>> aliases,
+			Map<String, AliasUpdate> aliases,
 			StatementUpdate statements,
 			Collection<SiteLink> modifiedSiteLinks,
 			Collection<String> removedSiteLinks) {

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemUpdateImpl.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.wikidata.wdtk.datamodel.helpers.Equality;
+import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ItemUpdate;
@@ -152,6 +154,16 @@ public class ItemUpdateImpl extends TermedStatementDocumentUpdateImpl implements
 			map.put(site, new RemovedSiteLink(site));
 		}
 		return map;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return Equality.equalsItemUpdate(this, obj);
+	}
+
+	@Override
+	public int hashCode() {
+		return Hash.hashCode(this);
 	}
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemUpdateImpl.java
@@ -31,7 +31,6 @@ import java.util.Set;
 
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
-import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ItemUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
@@ -41,8 +40,8 @@ import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Jackson implementation of {@link ItemUpdate}.
@@ -59,8 +58,8 @@ public class ItemUpdateImpl extends TermedStatementDocumentUpdateImpl implements
 	 * 
 	 * @param entityId
 	 *            ID of the item that is to be updated
-	 * @param revision
-	 *            base item revision to be updated or {@code null} if not available
+	 * @param revisionId
+	 *            base item revision to be updated or zero if not available
 	 * @param labels
 	 *            changes in entity labels or {@code null} for no change
 	 * @param descriptions
@@ -80,14 +79,14 @@ public class ItemUpdateImpl extends TermedStatementDocumentUpdateImpl implements
 	 */
 	public ItemUpdateImpl(
 			ItemIdValue entityId,
-			ItemDocument revision,
+			long revisionId,
 			TermUpdate labels,
 			TermUpdate descriptions,
 			Map<String, List<MonolingualTextValue>> aliases,
 			StatementUpdate statements,
 			Collection<SiteLink> modifiedSiteLinks,
 			Collection<String> removedSiteLinks) {
-		super(entityId, revision, labels, descriptions, aliases, statements);
+		super(entityId, revisionId, labels, descriptions, aliases, statements);
 		this.modifiedSiteLinks = Collections.unmodifiableMap(modifiedSiteLinks.stream()
 				.collect(toMap(sl -> sl.getSiteKey(), sl -> sl)));
 		this.removedSiteLinks = Collections.unmodifiableSet(new HashSet<>(removedSiteLinks));
@@ -97,12 +96,6 @@ public class ItemUpdateImpl extends TermedStatementDocumentUpdateImpl implements
 	@Override
 	public ItemIdValue getEntityId() {
 		return (ItemIdValue) super.getEntityId();
-	}
-
-	@JsonIgnore
-	@Override
-	public ItemDocument getBaseRevision() {
-		return (ItemDocument) super.getBaseRevision();
 	}
 
 	@JsonIgnore

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemUpdateImpl.java
@@ -45,7 +45,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * Jackson implementation of {@link ItemUpdate}.
  */
-public class ItemUpdateImpl extends TermedStatementDocumentUpdateImpl implements ItemUpdate {
+public class ItemUpdateImpl extends TermedDocumentUpdateImpl implements ItemUpdate {
 
 	@JsonIgnore
 	private final Map<String, SiteLink> modifiedSiteLinks;

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/LabeledDocumentUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/LabeledDocumentUpdateImpl.java
@@ -34,7 +34,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * Jackson implementation of {@link LabeledStatementDocumentUpdate}.
  */
-public abstract class LabeledStatementDocumentUpdateImpl extends StatementDocumentUpdateImpl
+public abstract class LabeledDocumentUpdateImpl extends StatementDocumentUpdateImpl
 		implements LabeledStatementDocumentUpdate {
 
 	@JsonIgnore
@@ -56,7 +56,7 @@ public abstract class LabeledStatementDocumentUpdateImpl extends StatementDocume
 	 * @throws IllegalArgumentException
 	 *             if any parameters or their combination is invalid
 	 */
-	protected LabeledStatementDocumentUpdateImpl(
+	protected LabeledDocumentUpdateImpl(
 			EntityIdValue entityId,
 			long revisionId,
 			TermUpdate labels,

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/LabeledStatementDocumentUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/LabeledStatementDocumentUpdateImpl.java
@@ -22,15 +22,14 @@ package org.wikidata.wdtk.datamodel.implementation;
 import java.util.Objects;
 
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.LabeledStatementDocument;
 import org.wikidata.wdtk.datamodel.interfaces.LabeledStatementDocumentUpdate;
-import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Jackson implementation of {@link LabeledStatementDocumentUpdate}.
@@ -46,9 +45,8 @@ public abstract class LabeledStatementDocumentUpdateImpl extends StatementDocume
 	 * 
 	 * @param entityId
 	 *            ID of the entity that is to be updated
-	 * @param revision
-	 *            base entity revision to be updated or {@code null} if not
-	 *            available
+	 * @param revisionId
+	 *            base entity revision to be updated or zero if not available
 	 * @param labels
 	 *            changes in entity labels, possibly empty
 	 * @param statements
@@ -60,18 +58,12 @@ public abstract class LabeledStatementDocumentUpdateImpl extends StatementDocume
 	 */
 	protected LabeledStatementDocumentUpdateImpl(
 			EntityIdValue entityId,
-			LabeledStatementDocument revision,
+			long revisionId,
 			TermUpdate labels,
 			StatementUpdate statements) {
-		super(entityId, revision, statements);
+		super(entityId, revisionId, statements);
 		Objects.requireNonNull(labels, "Label update cannot be null.");
 		this.labels = labels;
-	}
-
-	@JsonIgnore
-	@Override
-	public LabeledStatementDocument getBaseRevision() {
-		return (LabeledStatementDocument) super.getBaseRevision();
 	}
 
 	@JsonIgnore

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/LexemeDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/LexemeDocumentImpl.java
@@ -195,11 +195,7 @@ public class LexemeDocumentImpl extends StatementDocumentImpl implements LexemeD
 	@JsonIgnore
 	@Override
 	public LexemeIdValue getEntityId() {
-		if (!EntityIdValue.SITE_LOCAL.equals(siteIri)) {
-			return new LexemeIdValueImpl(entityId, siteIri);
-		} else {
-			return LexemeIdValue.NULL;
-		}
+		return new LexemeIdValueImpl(entityId, siteIri);
 	}
 
 	@JsonIgnore

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/LexemeIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/LexemeIdValueImpl.java
@@ -78,7 +78,7 @@ public class LexemeIdValueImpl extends EntityIdValueImpl implements LexemeIdValu
 	@JsonIgnore
 	@Override
 	public boolean isPlaceholder() {
-		return getId().equals("P0");
+		return getId().equals("L0");
 	}
 
 	@Override

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/LexemeIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/LexemeIdValueImpl.java
@@ -75,6 +75,12 @@ public class LexemeIdValueImpl extends EntityIdValueImpl implements LexemeIdValu
 		return EntityIdValue.ET_LEXEME;
 	}
 
+	@JsonIgnore
+	@Override
+	public boolean isPlaceholder() {
+		return getId().equals("P0");
+	}
+
 	@Override
 	public <T> T accept(ValueVisitor<T> valueVisitor) {
 		return valueVisitor.visit(this);
@@ -94,4 +100,5 @@ public class LexemeIdValueImpl extends EntityIdValueImpl implements LexemeIdValu
 	public String toString() {
 		return ToString.toString(this);
 	}
+
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/LexemeUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/LexemeUpdateImpl.java
@@ -138,6 +138,8 @@ public class LexemeUpdateImpl extends StatementDocumentUpdateImpl implements Lex
 		Objects.requireNonNull(updatedSenses, "List of sense updates cannot be null.");
 		for (SenseUpdate update : updatedSenses) {
 			Objects.requireNonNull(update, "Sense update cannot be null.");
+			Validate.isTrue(update.getBaseRevisionId() == revisionId,
+					"Nested sense update must have the same revision ID as lexeme update.");
 		}
 		Validate.isTrue(
 				updatedSenses.stream().map(s -> s.getEntityId()).distinct().count() == updatedSenses.size(),
@@ -166,6 +168,8 @@ public class LexemeUpdateImpl extends StatementDocumentUpdateImpl implements Lex
 		Objects.requireNonNull(updatedForms, "List of form updates cannot be null.");
 		for (FormUpdate update : updatedForms) {
 			Objects.requireNonNull(update, "Form update cannot be null.");
+			Validate.isTrue(update.getBaseRevisionId() == revisionId,
+					"Nested form update must have the same revision ID as lexeme update.");
 		}
 		Validate.isTrue(
 				updatedForms.stream().map(s -> s.getEntityId()).distinct().count() == updatedForms.size(),

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/LexemeUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/LexemeUpdateImpl.java
@@ -37,14 +37,13 @@ import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
 import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.FormUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.LexemeDocument;
 import org.wikidata.wdtk.datamodel.interfaces.LexemeIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.LexemeUpdate;
-import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.SenseDocument;
 import org.wikidata.wdtk.datamodel.interfaces.SenseIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.SenseUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -80,9 +79,8 @@ public class LexemeUpdateImpl extends StatementDocumentUpdateImpl implements Lex
 	 * 
 	 * @param entityId
 	 *            ID of the lexeme that is to be updated
-	 * @param revision
-	 *            base lexeme revision to be updated or {@code null} if not
-	 *            available
+	 * @param revisionId
+	 *            base lexeme revision to be updated or zero if not available
 	 * @param language
 	 *            new lexeme language or {@code null} for no change
 	 * @param lexicalCategory
@@ -110,7 +108,7 @@ public class LexemeUpdateImpl extends StatementDocumentUpdateImpl implements Lex
 	 */
 	public LexemeUpdateImpl(
 			LexemeIdValue entityId,
-			LexemeDocument revision,
+			long revisionId,
 			ItemIdValue language,
 			ItemIdValue lexicalCategory,
 			TermUpdate lemmas,
@@ -121,7 +119,7 @@ public class LexemeUpdateImpl extends StatementDocumentUpdateImpl implements Lex
 			Collection<FormDocument> addedForms,
 			Collection<FormUpdate> updatedForms,
 			Collection<FormIdValue> removedForms) {
-		super(entityId, revision, statements);
+		super(entityId, revisionId, statements);
 		Objects.requireNonNull(lemmas, "Lemma update cannot be null.");
 		this.language = language;
 		this.lexicalCategory = lexicalCategory;
@@ -140,12 +138,6 @@ public class LexemeUpdateImpl extends StatementDocumentUpdateImpl implements Lex
 	@Override
 	public LexemeIdValue getEntityId() {
 		return (LexemeIdValue) super.getEntityId();
-	}
-
-	@JsonIgnore
-	@Override
-	public LexemeDocument getBaseRevision() {
-		return (LexemeDocument) super.getBaseRevision();
 	}
 
 	@JsonIgnore

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/LexemeUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/LexemeUpdateImpl.java
@@ -31,6 +31,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import org.wikidata.wdtk.datamodel.helpers.Equality;
+import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
 import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.FormUpdate;
@@ -322,6 +324,16 @@ public class LexemeUpdateImpl extends StatementDocumentUpdateImpl implements Lex
 			list.add(new RemovedForm(id));
 		}
 		return list;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return Equality.equalsLexemeUpdate(this, obj);
+	}
+
+	@Override
+	public int hashCode() {
+		return Hash.hashCode(this);
 	}
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoDocumentImpl.java
@@ -96,11 +96,7 @@ public class MediaInfoDocumentImpl extends LabeledStatementDocumentImpl implemen
 	@JsonIgnore
 	@Override
 	public MediaInfoIdValue getEntityId() {
-		if (!EntityIdValue.SITE_LOCAL.equals(siteIri)) {
-			return new MediaInfoIdValueImpl(entityId, siteIri);
-		} else {
-			return MediaInfoIdValue.NULL;
-		}
+		return new MediaInfoIdValueImpl(entityId, siteIri);
 	}
 
 	@Override

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoIdValueImpl.java
@@ -75,6 +75,12 @@ public class MediaInfoIdValueImpl extends EntityIdValueImpl implements MediaInfo
 		return EntityIdValue.ET_MEDIA_INFO;
 	}
 
+	@JsonIgnore
+	@Override
+	public boolean isPlaceholder() {
+		return getId().equals("M0");
+	}
+
 	@Override
 	public <T> T accept(ValueVisitor<T> valueVisitor) {
 		return valueVisitor.visit(this);

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoUpdateImpl.java
@@ -21,11 +21,10 @@ package org.wikidata.wdtk.datamodel.implementation;
 
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
-import org.wikidata.wdtk.datamodel.interfaces.MediaInfoDocument;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoUpdate;
-import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -39,8 +38,8 @@ public class MediaInfoUpdateImpl extends LabeledStatementDocumentUpdateImpl impl
 	 * 
 	 * @param entityId
 	 *            ID of the media that is to be updated
-	 * @param revision
-	 *            base media revision to be updated or {@code null} if not available
+	 * @param revisionId
+	 *            base media revision to be updated or zero if not available
 	 * @param labels
 	 *            changes in entity labels or {@code null} for no change
 	 * @param statements
@@ -52,22 +51,16 @@ public class MediaInfoUpdateImpl extends LabeledStatementDocumentUpdateImpl impl
 	 */
 	public MediaInfoUpdateImpl(
 			MediaInfoIdValue entityId,
-			MediaInfoDocument revision,
+			long revisionId,
 			TermUpdate labels,
 			StatementUpdate statements) {
-		super(entityId, revision, labels, statements);
+		super(entityId, revisionId, labels, statements);
 	}
 
 	@JsonIgnore
 	@Override
 	public MediaInfoIdValue getEntityId() {
 		return (MediaInfoIdValue) super.getEntityId();
-	}
-
-	@JsonIgnore
-	@Override
-	public MediaInfoDocument getBaseRevision() {
-		return (MediaInfoDocument) super.getBaseRevision();
 	}
 
 	@Override

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoUpdateImpl.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 /**
  * Jackson implementation of {@link MediaInfoUpdate}.
  */
-public class MediaInfoUpdateImpl extends LabeledStatementDocumentUpdateImpl implements MediaInfoUpdate {
+public class MediaInfoUpdateImpl extends LabeledDocumentUpdateImpl implements MediaInfoUpdate {
 
 	/**
 	 * Initializes new media update.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoUpdateImpl.java
@@ -19,6 +19,8 @@
  */
 package org.wikidata.wdtk.datamodel.implementation;
 
+import org.wikidata.wdtk.datamodel.helpers.Equality;
+import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoDocument;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoUpdate;
@@ -66,6 +68,16 @@ public class MediaInfoUpdateImpl extends LabeledStatementDocumentUpdateImpl impl
 	@Override
 	public MediaInfoDocument getBaseRevision() {
 		return (MediaInfoDocument) super.getBaseRevision();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return Equality.equalsMediaInfoUpdate(this, obj);
+	}
+
+	@Override
+	public int hashCode() {
+		return Hash.hashCode(this);
 	}
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImpl.java
@@ -28,7 +28,6 @@ import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
-import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
@@ -143,11 +142,7 @@ public class PropertyDocumentImpl extends TermedStatementDocumentImpl
 	@JsonIgnore
 	@Override
 	public PropertyIdValue getEntityId() {
-		if (!EntityIdValue.SITE_LOCAL.equals(siteIri)) {
-			return new PropertyIdValueImpl(entityId, siteIri);
-		} else {
-			return PropertyIdValue.NULL;
-		}
+		return new PropertyIdValueImpl(entityId, siteIri);
 	}
 
 	@JsonIgnore

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyIdValueImpl.java
@@ -77,6 +77,12 @@ public class PropertyIdValueImpl extends EntityIdValueImpl implements
 		return EntityIdValue.ET_PROPERTY;
 	}
 
+	@JsonIgnore
+	@Override
+	public boolean isPlaceholder() {
+		return getId().equals("P0");
+	}
+
 	@Override
 	public <T> T accept(ValueVisitor<T> valueVisitor) {
 		return valueVisitor.visit(this);
@@ -96,4 +102,5 @@ public class PropertyIdValueImpl extends EntityIdValueImpl implements
 	public String toString() {
 		return ToString.toString(this);
 	}
+
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyUpdateImpl.java
@@ -34,7 +34,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 /**
  * Jackson implementation of {@link PropertyUpdate}.
  */
-public class PropertyUpdateImpl extends TermedStatementDocumentUpdateImpl implements PropertyUpdate {
+public class PropertyUpdateImpl extends TermedDocumentUpdateImpl implements PropertyUpdate {
 
 	/**
 	 * Initializes new property update.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyUpdateImpl.java
@@ -24,6 +24,8 @@ import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 import java.util.List;
 import java.util.Map;
 
+import org.wikidata.wdtk.datamodel.helpers.Equality;
+import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
@@ -78,6 +80,16 @@ public class PropertyUpdateImpl extends TermedStatementDocumentUpdateImpl implem
 	@Override
 	public PropertyDocument getBaseRevision() {
 		return (PropertyDocument) super.getBaseRevision();
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return Equality.equalsPropertyUpdate(this, obj);
+	}
+
+	@Override
+	public int hashCode() {
+		return Hash.hashCode(this);
 	}
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyUpdateImpl.java
@@ -19,12 +19,11 @@
  */
 package org.wikidata.wdtk.datamodel.implementation;
 
-import java.util.List;
 import java.util.Map;
 
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
-import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
@@ -63,7 +62,7 @@ public class PropertyUpdateImpl extends TermedStatementDocumentUpdateImpl implem
 			long revisionId,
 			TermUpdate labels,
 			TermUpdate descriptions,
-			Map<String, List<MonolingualTextValue>> aliases,
+			Map<String, AliasUpdate> aliases,
 			StatementUpdate statements) {
 		super(entityId, revisionId, labels, descriptions, aliases, statements);
 	}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyUpdateImpl.java
@@ -19,18 +19,16 @@
  */
 package org.wikidata.wdtk.datamodel.implementation;
 
-import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
-
 import java.util.List;
 import java.util.Map;
 
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -44,8 +42,8 @@ public class PropertyUpdateImpl extends TermedStatementDocumentUpdateImpl implem
 	 * 
 	 * @param entityId
 	 *            ID of the property entity that is to be updated
-	 * @param revision
-	 *            base property entity revision to be updated or {@code null} if not
+	 * @param revisionId
+	 *            base property entity revision to be updated or zero if not
 	 *            available
 	 * @param labels
 	 *            changes in entity labels or {@code null} for no change
@@ -62,24 +60,18 @@ public class PropertyUpdateImpl extends TermedStatementDocumentUpdateImpl implem
 	 */
 	public PropertyUpdateImpl(
 			PropertyIdValue entityId,
-			PropertyDocument revision,
+			long revisionId,
 			TermUpdate labels,
 			TermUpdate descriptions,
 			Map<String, List<MonolingualTextValue>> aliases,
 			StatementUpdate statements) {
-		super(entityId, revision, labels, descriptions, aliases, statements);
+		super(entityId, revisionId, labels, descriptions, aliases, statements);
 	}
 
 	@JsonIgnore
 	@Override
 	public PropertyIdValue getEntityId() {
 		return (PropertyIdValue) super.getEntityId();
-	}
-
-	@JsonIgnore
-	@Override
-	public PropertyDocument getBaseRevision() {
-		return (PropertyDocument) super.getBaseRevision();
 	}
 
 	@Override

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SenseDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SenseDocumentImpl.java
@@ -125,11 +125,7 @@ public class SenseDocumentImpl extends StatementDocumentImpl implements SenseDoc
 	@JsonIgnore
 	@Override
 	public SenseIdValue getEntityId() {
-		if (!EntityIdValue.SITE_LOCAL.equals(siteIri)) {
-			return new SenseIdValueImpl(entityId, siteIri);
-		} else {
-			return SenseIdValue.NULL;
-		}
+		return new SenseIdValueImpl(entityId, siteIri);
 	}
 
 	@JsonProperty("type")

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SenseIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SenseIdValueImpl.java
@@ -44,7 +44,10 @@ import java.util.regex.Pattern;
 @JsonDeserialize()
 public class SenseIdValueImpl extends ValueImpl implements SenseIdValue {
 
-	private static final Pattern PATTERN = Pattern.compile("^L[1-9]\\d*-S[1-9]\\d*$");
+	/*
+	 * Allow L0-S0 from SenseIdValue.NULL.
+	 */
+	private static final Pattern PATTERN = Pattern.compile("L[1-9]\\d*-S[1-9]\\d*|L0-S0");
 
 	private final String id;
 	private final String siteIri;
@@ -105,8 +108,8 @@ public class SenseIdValueImpl extends ValueImpl implements SenseIdValue {
 
 	@JsonIgnore
 	@Override
-	public boolean isValid() {
-		return SenseIdValue.super.isValid();
+	public boolean isPlaceholder() {
+		return id.equals("L0-S0");
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SenseUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SenseUpdateImpl.java
@@ -22,6 +22,8 @@ package org.wikidata.wdtk.datamodel.implementation;
 import java.util.Objects;
 
 import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
+import org.wikidata.wdtk.datamodel.helpers.Equality;
+import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.interfaces.SenseDocument;
 import org.wikidata.wdtk.datamodel.interfaces.SenseIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.SenseUpdate;
@@ -94,6 +96,16 @@ public class SenseUpdateImpl extends StatementDocumentUpdateImpl implements Sens
 	@JsonInclude(Include.NON_EMPTY)
 	TermUpdate getJsonGlosses() {
 		return glosses.isEmpty() ? null : glosses;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return Equality.equalsSenseUpdate(this, obj);
+	}
+
+	@Override
+	public int hashCode() {
+		return Hash.hashCode(this);
 	}
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SenseUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SenseUpdateImpl.java
@@ -21,18 +21,17 @@ package org.wikidata.wdtk.datamodel.implementation;
 
 import java.util.Objects;
 
-import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
-import org.wikidata.wdtk.datamodel.interfaces.SenseDocument;
 import org.wikidata.wdtk.datamodel.interfaces.SenseIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.SenseUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Jackson implementation of {@link SenseUpdate}.
@@ -47,8 +46,8 @@ public class SenseUpdateImpl extends StatementDocumentUpdateImpl implements Sens
 	 * 
 	 * @param entityId
 	 *            ID of the sense that is to be updated
-	 * @param revision
-	 *            base sense revision to be updated or {@code null} if not available
+	 * @param revisionId
+	 *            base sense revision to be updated or zero if not available
 	 * @param glosses
 	 *            changes in sense glosses, possibly empty
 	 * @param statements
@@ -60,10 +59,10 @@ public class SenseUpdateImpl extends StatementDocumentUpdateImpl implements Sens
 	 */
 	public SenseUpdateImpl(
 			SenseIdValue entityId,
-			SenseDocument revision,
+			long revisionId,
 			TermUpdate glosses,
 			StatementUpdate statements) {
-		super(entityId, revision, statements);
+		super(entityId, revisionId, statements);
 		Objects.requireNonNull(glosses, "Gloss update cannot be null.");
 		this.glosses = glosses;
 	}
@@ -72,12 +71,6 @@ public class SenseUpdateImpl extends StatementDocumentUpdateImpl implements Sens
 	@Override
 	public SenseIdValue getEntityId() {
 		return (SenseIdValue) super.getEntityId();
-	}
-
-	@JsonIgnore
-	@Override
-	public SenseDocument getBaseRevision() {
-		return (SenseDocument) super.getBaseRevision();
 	}
 
 	@JsonIgnore

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StatementDocumentUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StatementDocumentUpdateImpl.java
@@ -22,7 +22,6 @@ package org.wikidata.wdtk.datamodel.implementation;
 import java.util.Objects;
 
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.StatementDocument;
 import org.wikidata.wdtk.datamodel.interfaces.StatementDocumentUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
 
@@ -46,9 +45,8 @@ public abstract class StatementDocumentUpdateImpl extends EntityUpdateImpl imple
 	 * 
 	 * @param entityId
 	 *            ID of the entity that is to be updated
-	 * @param revision
-	 *            base entity revision to be updated or {@code null} if not
-	 *            available
+	 * @param revisionId
+	 *            base entity revision to be updated or zero if not available
 	 * @param statements
 	 *            changes in entity statements, possibly empty
 	 * @throws NullPointerException
@@ -58,17 +56,11 @@ public abstract class StatementDocumentUpdateImpl extends EntityUpdateImpl imple
 	 */
 	protected StatementDocumentUpdateImpl(
 			EntityIdValue entityId,
-			StatementDocument revision,
+			long revisionId,
 			StatementUpdate statements) {
-		super(entityId, revision);
+		super(entityId, revisionId);
 		Objects.requireNonNull(statements, "Statement update cannot be null.");
 		this.statements = statements;
-	}
-
-	@JsonIgnore
-	@Override
-	public StatementDocument getBaseRevision() {
-		return (StatementDocument) super.getBaseRevision();
 	}
 
 	@JsonIgnore

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StatementDocumentUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StatementDocumentUpdateImpl.java
@@ -20,7 +20,9 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
 import java.util.Objects;
+import java.util.stream.Stream;
 
+import org.apache.commons.lang3.Validate;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.StatementDocumentUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
@@ -60,6 +62,10 @@ public abstract class StatementDocumentUpdateImpl extends EntityUpdateImpl imple
 			StatementUpdate statements) {
 		super(entityId, revisionId);
 		Objects.requireNonNull(statements, "Statement update cannot be null.");
+		EntityIdValue subject = Stream.concat(statements.getAdded().stream(), statements.getReplaced().values().stream())
+				.map(s -> s.getSubject())
+				.findFirst().orElse(null);
+		Validate.isTrue(subject == null || subject.equals(entityId), "Statements describe different subject.");
 		this.statements = statements;
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StatementUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StatementUpdateImpl.java
@@ -27,10 +27,14 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Stream;
 
+import org.apache.commons.lang3.Validate;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
+import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
 
@@ -62,13 +66,39 @@ public class StatementUpdateImpl implements StatementUpdate {
 	 * @param removed
 	 *            IDs of removed statements
 	 * @throws NullPointerException
-	 *             if any parameter is {@code null}
+	 *             if any parameter or any item is {@code null}
 	 * @throws IllegalArgumentException
 	 *             if any parameters or their combination is invalid
 	 */
 	public StatementUpdateImpl(Collection<Statement> added,
 			Collection<Statement> replaced,
 			Collection<String> removed) {
+		Objects.requireNonNull(added, "Added statement collection cannot be null.");
+		Objects.requireNonNull(replaced, "Replaced statement collection cannot be null.");
+		Objects.requireNonNull(removed, "Removed statement collection cannot be null.");
+		for (Statement statement : added) {
+			Objects.requireNonNull(statement, "Added statement cannot be null.");
+			Validate.isTrue(statement.getStatementId().isEmpty(), "Added statement cannot have an ID.");
+		}
+		for (Statement statement : replaced) {
+			Objects.requireNonNull(statement, "Replaced statement cannot be null.");
+			Validate.notBlank(statement.getStatementId(), "Replaced statement must have an ID.");
+		}
+		for (String id : removed) {
+			Validate.notBlank(id, "Removed statement ID cannot be null or blank.");
+		}
+		long distinctIds = Stream
+				.concat(replaced.stream().map(s -> s.getStatementId()), removed.stream())
+				.distinct()
+				.count();
+		Validate.isTrue(replaced.size() + removed.size() == distinctIds, "Statement IDs must be unique.");
+		Validate.isTrue(
+				Stream.concat(added.stream(), replaced.stream()).map(s -> s.getSubject()).distinct().count() <= 1,
+				"All statements must have the same subject.");
+		EntityIdValue subject = Stream.concat(added.stream(), replaced.stream())
+				.map(s -> s.getSubject())
+				.findFirst().orElse(null);
+		Validate.isTrue(subject == null || !subject.isPlaceholder(), "Cannot update entity with placeholder ID.");
 		this.added = Collections.unmodifiableList(new ArrayList<>(added));
 		this.replaced = Collections.unmodifiableMap(replaced.stream().collect(toMap(s -> s.getStatementId(), s -> s)));
 		this.removed = Collections.unmodifiableSet(new HashSet<>(removed));

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StatementUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StatementUpdateImpl.java
@@ -82,19 +82,19 @@ public class StatementUpdateImpl implements StatementUpdate {
 
 	@JsonIgnore
 	@Override
-	public List<Statement> getAddedStatements() {
+	public List<Statement> getAdded() {
 		return added;
 	}
 
 	@JsonIgnore
 	@Override
-	public Map<String, Statement> getReplacedStatements() {
+	public Map<String, Statement> getReplaced() {
 		return replaced;
 	}
 
 	@JsonIgnore
 	@Override
-	public Set<String> getRemovedStatements() {
+	public Set<String> getRemoved() {
 		return removed;
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StatementUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StatementUpdateImpl.java
@@ -29,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.wikidata.wdtk.datamodel.helpers.Equality;
+import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
 
@@ -124,6 +126,16 @@ public class StatementUpdateImpl implements StatementUpdate {
 			list.add(new RemovedStatement(id));
 		}
 		return list;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return Equality.equalsStatementUpdate(this, obj);
+	}
+
+	@Override
+	public int hashCode() {
+		return Hash.hashCode(this);
 	}
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermImpl.java
@@ -71,6 +71,17 @@ public class TermImpl implements MonolingualTextValue {
 		this.text = text;
 	}
 
+	/**
+	 * Copy constructor. This constructor is useful for converting from
+	 * {@link MonolingualTextValueImpl}.
+	 * 
+	 * @param other
+	 *            monolingual text value to copy
+	 */
+	public TermImpl(MonolingualTextValue other) {
+		this(other.getLanguageCode(), other.getText());
+	}
+
 	@Override
 	public <T> T accept(ValueVisitor<T> valueVisitor) {
 		return valueVisitor.visit(this);

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermUpdateImpl.java
@@ -28,6 +28,8 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.wikidata.wdtk.datamodel.helpers.Equality;
+import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 
@@ -112,6 +114,16 @@ public class TermUpdateImpl implements TermUpdate {
 			map.put(language, new RemovedMonolingualTextValue(language));
 		}
 		return map;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		return Equality.equalsTermUpdate(this, obj);
+	}
+
+	@Override
+	public int hashCode() {
+		return Hash.hashCode(this);
 	}
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermUpdateImpl.java
@@ -61,7 +61,7 @@ public class TermUpdateImpl implements TermUpdate {
 	 */
 	public TermUpdateImpl(Collection<MonolingualTextValue> modified, Collection<String> removed) {
 		this.modified = Collections.unmodifiableMap(modified.stream()
-				.map(v -> new TermImpl(v.getLanguageCode(), v.getText()))
+				.map(TermImpl::new)
 				.collect(toMap(v -> v.getLanguageCode(), r -> r)));
 		this.removed = Collections.unmodifiableSet(new HashSet<>(removed));
 	}
@@ -84,11 +84,11 @@ public class TermUpdateImpl implements TermUpdate {
 		return removed;
 	}
 
-	static class RemovedMonolingualTextValue {
+	static class RemovedTerm {
 
 		private final String language;
 
-		RemovedMonolingualTextValue(String language) {
+		RemovedTerm(String language) {
 			this.language = language;
 		}
 
@@ -111,7 +111,7 @@ public class TermUpdateImpl implements TermUpdate {
 			map.put(value.getLanguageCode(), value);
 		}
 		for (String language : removed) {
-			map.put(language, new RemovedMonolingualTextValue(language));
+			map.put(language, new RemovedTerm(language));
 		}
 		return map;
 	}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermUpdateImpl.java
@@ -74,13 +74,13 @@ public class TermUpdateImpl implements TermUpdate {
 
 	@JsonIgnore
 	@Override
-	public Map<String, MonolingualTextValue> getModifiedTerms() {
+	public Map<String, MonolingualTextValue> getModified() {
 		return modified;
 	}
 
 	@JsonIgnore
 	@Override
-	public Set<String> getRemovedTerms() {
+	public Set<String> getRemoved() {
 		return removed;
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermedDocumentUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermedDocumentUpdateImpl.java
@@ -39,7 +39,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 /**
  * Jackson implementation of {@link TermedStatementDocumentUpdate}.
  */
-public abstract class TermedStatementDocumentUpdateImpl extends LabeledStatementDocumentUpdateImpl
+public abstract class TermedDocumentUpdateImpl extends LabeledDocumentUpdateImpl
 		implements TermedStatementDocumentUpdate {
 
 	@JsonIgnore
@@ -67,7 +67,7 @@ public abstract class TermedStatementDocumentUpdateImpl extends LabeledStatement
 	 * @throws IllegalArgumentException
 	 *             if any parameters or their combination is invalid
 	 */
-	protected TermedStatementDocumentUpdateImpl(
+	protected TermedDocumentUpdateImpl(
 			EntityIdValue entityId,
 			long revisionId,
 			TermUpdate labels,

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermedDocumentUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermedDocumentUpdateImpl.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
+import org.apache.commons.lang3.Validate;
 import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
@@ -63,7 +64,7 @@ public abstract class TermedDocumentUpdateImpl extends LabeledDocumentUpdateImpl
 	 * @param statements
 	 *            changes in entity statements, possibly empty
 	 * @throws NullPointerException
-	 *             if any required parameter is {@code null}
+	 *             if any required parameter or its part is {@code null}
 	 * @throws IllegalArgumentException
 	 *             if any parameters or their combination is invalid
 	 */
@@ -77,6 +78,14 @@ public abstract class TermedDocumentUpdateImpl extends LabeledDocumentUpdateImpl
 		super(entityId, revisionId, labels, statements);
 		Objects.requireNonNull(descriptions, "Description update cannot be null.");
 		Objects.requireNonNull(aliases, "Alias map cannot be null.");
+		for (Map.Entry<String, AliasUpdate> entry : aliases.entrySet()) {
+			Validate.notBlank(entry.getKey(), "Alias language code cannot be null or blank.");
+			Objects.requireNonNull(entry.getValue(), "Alias update cannot be null.");
+			if (entry.getValue().getLanguageCode().isPresent()) {
+				Validate.isTrue(entry.getValue().getLanguageCode().get().equals(entry.getKey()),
+						"Inconsistent alias language codes.");
+			}
+		}
 		this.descriptions = descriptions;
 		this.aliases = Collections.unmodifiableMap(aliases.keySet().stream()
 				.filter(k -> !aliases.get(k).isEmpty())

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermedStatementDocumentUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermedStatementDocumentUpdateImpl.java
@@ -29,15 +29,14 @@ import java.util.Objects;
 
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
-import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
-import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocument;
+import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocumentUpdate;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
  * Jackson implementation of {@link TermedStatementDocumentUpdate}.
@@ -55,9 +54,8 @@ public abstract class TermedStatementDocumentUpdateImpl extends LabeledStatement
 	 * 
 	 * @param entityId
 	 *            ID of the entity that is to be updated
-	 * @param revision
-	 *            base entity revision to be updated or {@code null} if not
-	 *            available
+	 * @param revisionId
+	 *            base entity revision to be updated or zero if not available
 	 * @param labels
 	 *            changes in entity labels or {@code null} for no change
 	 * @param descriptions
@@ -73,12 +71,12 @@ public abstract class TermedStatementDocumentUpdateImpl extends LabeledStatement
 	 */
 	protected TermedStatementDocumentUpdateImpl(
 			EntityIdValue entityId,
-			TermedStatementDocument revision,
+			long revisionId,
 			TermUpdate labels,
 			TermUpdate descriptions,
 			Map<String, List<MonolingualTextValue>> aliases,
 			StatementUpdate statements) {
-		super(entityId, revision, labels, statements);
+		super(entityId, revisionId, labels, statements);
 		Objects.requireNonNull(descriptions, "Description update cannot be null.");
 		Objects.requireNonNull(aliases, "Alias map cannot be null.");
 		this.descriptions = descriptions;
@@ -86,12 +84,6 @@ public abstract class TermedStatementDocumentUpdateImpl extends LabeledStatement
 				.collect(toMap(k -> k, k -> Collections.unmodifiableList(aliases.get(k).stream()
 						.map(t -> new TermImpl(k, t.getText()))
 						.collect(toList())))));
-	}
-
-	@JsonIgnore
-	@Override
-	public TermedStatementDocument getBaseRevision() {
-		return (TermedStatementDocument) super.getBaseRevision();
 	}
 
 	@JsonIgnore

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermedStatementDocumentUpdateImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TermedStatementDocumentUpdateImpl.java
@@ -19,16 +19,14 @@
  */
 package org.wikidata.wdtk.datamodel.implementation;
 
-import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocumentUpdate;
@@ -47,7 +45,7 @@ public abstract class TermedStatementDocumentUpdateImpl extends LabeledStatement
 	@JsonIgnore
 	private final TermUpdate descriptions;
 	@JsonIgnore
-	private final Map<String, List<MonolingualTextValue>> aliases;
+	private final Map<String, AliasUpdate> aliases;
 
 	/**
 	 * Initializes new entity update.
@@ -74,16 +72,15 @@ public abstract class TermedStatementDocumentUpdateImpl extends LabeledStatement
 			long revisionId,
 			TermUpdate labels,
 			TermUpdate descriptions,
-			Map<String, List<MonolingualTextValue>> aliases,
+			Map<String, AliasUpdate> aliases,
 			StatementUpdate statements) {
 		super(entityId, revisionId, labels, statements);
 		Objects.requireNonNull(descriptions, "Description update cannot be null.");
 		Objects.requireNonNull(aliases, "Alias map cannot be null.");
 		this.descriptions = descriptions;
 		this.aliases = Collections.unmodifiableMap(aliases.keySet().stream()
-				.collect(toMap(k -> k, k -> Collections.unmodifiableList(aliases.get(k).stream()
-						.map(t -> new TermImpl(k, t.getText()))
-						.collect(toList())))));
+				.filter(k -> !aliases.get(k).isEmpty())
+				.collect(toMap(k -> k, k -> aliases.get(k))));
 	}
 
 	@JsonIgnore
@@ -107,7 +104,7 @@ public abstract class TermedStatementDocumentUpdateImpl extends LabeledStatement
 	@JsonProperty("aliases")
 	@JsonInclude(Include.NON_EMPTY)
 	@Override
-	public Map<String, List<MonolingualTextValue>> getAliases() {
+	public Map<String, AliasUpdate> getAliases() {
 		return aliases;
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueImpl.java
@@ -151,7 +151,7 @@ public class UnsupportedEntityIdValueImpl extends ValueImpl implements Unsupport
 
 	@JsonIgnore
 	@Override
-	public boolean isValid() {
+	public boolean isPlaceholder() {
 		return false;
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/AliasUpdate.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/AliasUpdate.java
@@ -1,0 +1,87 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.interfaces;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.wikidata.wdtk.datamodel.implementation.AliasUpdateImpl;
+
+/**
+ * Collection of changes made to entity aliases. This class represents changes
+ * in single language only. Alias update consists either of added (see
+ * {@link #getAdded()}) and removed (see {@link #getRemoved()}) aliases or a new
+ * list of aliases that completely replace old aliases (see
+ * {@link #getRecreated()}).
+ */
+public interface AliasUpdate {
+
+	/**
+	 * Empty update that does not alter or remove any aliases.
+	 */
+	AliasUpdate NULL = new AliasUpdateImpl(null, Collections.emptyList(), Collections.emptyList());
+
+	/**
+	 * Checks whether the update is empty. Empty update will not alter alias list in
+	 * any way.
+	 * 
+	 * @return {@code true} if the update is empty, {@code false} otherwise
+	 */
+	boolean isEmpty();
+
+	/**
+	 * Returns language code of aliases in this update. Language code is only
+	 * available for non-empty updates.
+	 * 
+	 * @return alias language code or {@link Optional#empty()} when the update is
+	 *         empty
+	 */
+	Optional<String> getLanguageCode();
+
+	/**
+	 * Returns the new list of aliases that completely replaces current aliases. If
+	 * this list is present, then the update contains no added/removed aliases.
+	 * 
+	 * @return new list of aliases or {@link Optional#empty()} if aliases are not
+	 *         being recreated
+	 */
+	Optional<List<MonolingualTextValue>> getRecreated();
+
+	/**
+	 * Returns aliases added in this update. If there are any added aliases, then
+	 * {@link #getRecreated()} must return {@link Optional#empty()}. It is however
+	 * possible to add and remove aliases in the same update.
+	 * 
+	 * @return added aliases
+	 */
+	List<MonolingualTextValue> getAdded();
+
+	/**
+	 * Returns aliases removed in this update. If there are any removed aliases,
+	 * then {@link #getRecreated()} must return {@link Optional#empty()}. It is
+	 * however possible to add and remove aliases in the same update.
+	 * 
+	 * @return removed aliases
+	 */
+	Set<MonolingualTextValue> getRemoved();
+
+}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/AliasUpdate.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/AliasUpdate.java
@@ -38,7 +38,7 @@ public interface AliasUpdate {
 	/**
 	 * Empty update that does not alter or remove any aliases.
 	 */
-	AliasUpdate NULL = new AliasUpdateImpl(null, Collections.emptyList(), Collections.emptyList());
+	AliasUpdate EMPTY = new AliasUpdateImpl(null, Collections.emptyList(), Collections.emptyList());
 
 	/**
 	 * Checks whether the update is empty. Empty update will not alter alias list in

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DataObjectFactory.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DataObjectFactory.java
@@ -29,13 +29,13 @@ import org.wikidata.wdtk.datamodel.helpers.ItemDocumentBuilder;
 import org.wikidata.wdtk.datamodel.helpers.ItemUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.LexemeUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.MediaInfoUpdateBuilder;
-import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.PropertyDocumentBuilder;
 import org.wikidata.wdtk.datamodel.helpers.PropertyUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.ReferenceBuilder;
 import org.wikidata.wdtk.datamodel.helpers.SenseUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.StatementBuilder;
 import org.wikidata.wdtk.datamodel.helpers.StatementUpdateBuilder;
+import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;
 
 /**
  * Interface for factories that create data objects that implement the
@@ -610,6 +610,30 @@ public interface DataObjectFactory {
 			Collection<String> removed);
 
 	/**
+	 * Creates new {@link AliasUpdate}. Callers should specify either
+	 * {@code recreated} parameter or {@code added} and {@code removed} parameters,
+	 * because combination of the two update approaches is not possible. To remove
+	 * all aliases, pass empty list in {@code recreated} parameter.
+	 * 
+	 * @param recreated
+	 *            new list of aliases that completely replaces the old ones or
+	 *            {@code null} to not recreate aliases
+	 * @param added
+	 *            aliases added in this update or empty collection for no additions
+	 * @param removed
+	 *            aliases removed in this update or empty collection for no removals
+	 * @return new {@link AliasUpdate}
+	 * @throws NullPointerException
+	 *             if {@code added}, {@code removed}, or any alias is {@code null}
+	 * @throws IllegalArgumentException
+	 *             if given invalid combination of parameters
+	 */
+	AliasUpdate getAliasUpdate(
+			List<MonolingualTextValue> recreated,
+			List<MonolingualTextValue> added,
+			Collection<MonolingualTextValue> removed);
+
+	/**
 	 * Creates new {@link StatementUpdate}. It might be more convenient to use
 	 * {@link StatementUpdateBuilder}.
 	 * 
@@ -784,7 +808,7 @@ public interface DataObjectFactory {
 			long revisionId,
 			TermUpdate labels,
 			TermUpdate descriptions,
-			Map<String, List<MonolingualTextValue>> aliases,
+			Map<String, AliasUpdate> aliases,
 			StatementUpdate statements,
 			Collection<SiteLink> modifiedSiteLinks,
 			Collection<String> removedSiteLinks);
@@ -816,7 +840,7 @@ public interface DataObjectFactory {
 			long revisionId,
 			TermUpdate labels,
 			TermUpdate descriptions,
-			Map<String, List<MonolingualTextValue>> aliases,
+			Map<String, AliasUpdate> aliases,
 			StatementUpdate statements);
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DataObjectFactory.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DataObjectFactory.java
@@ -604,8 +604,8 @@ public interface DataObjectFactory {
 	 * 
 	 * @param entityId
 	 *            ID of the sense that is to be updated
-	 * @param document
-	 *            sense revision to be updated or {@code null} if not available
+	 * @param revisionId
+	 *            base sense revision to be updated or zero if not available
 	 * @param glosses
 	 *            changes in sense glosses or {@code null} for no change
 	 * @param statements
@@ -618,7 +618,7 @@ public interface DataObjectFactory {
 	 */
 	SenseUpdate getSenseUpdate(
 			SenseIdValue entityId,
-			SenseDocument document,
+			long revisionId,
 			TermUpdate glosses,
 			StatementUpdate statements);
 
@@ -628,8 +628,8 @@ public interface DataObjectFactory {
 	 * 
 	 * @param entityId
 	 *            ID of the form that is to be updated
-	 * @param document
-	 *            form revision to be updated or {@code null} if not available
+	 * @param revisionId
+	 *            base form revision to be updated or zero if not available
 	 * @param representations
 	 *            changes in form representations or {@code null} for no change
 	 * @param grammaticalFeatures
@@ -644,7 +644,7 @@ public interface DataObjectFactory {
 	 */
 	FormUpdate getFormUpdate(
 			FormIdValue entityId,
-			FormDocument document,
+			long revisionId,
 			TermUpdate representations,
 			Collection<ItemIdValue> grammaticalFeatures,
 			StatementUpdate statements);
@@ -655,8 +655,8 @@ public interface DataObjectFactory {
 	 * 
 	 * @param entityId
 	 *            ID of the lexeme that is to be updated
-	 * @param document
-	 *            lexeme revision to be updated or {@code null} if not available
+	 * @param revisionId
+	 *            base lexeme revision to be updated or zero if not available
 	 * @param language
 	 *            new lexeme language or {@code null} for no change
 	 * @param lexicalCategory
@@ -685,7 +685,7 @@ public interface DataObjectFactory {
 	 */
 	LexemeUpdate getLexemeUpdate(
 			LexemeIdValue entityId,
-			LexemeDocument document,
+			long revisionId,
 			ItemIdValue language,
 			ItemIdValue lexicalCategory,
 			TermUpdate lemmas,
@@ -703,8 +703,8 @@ public interface DataObjectFactory {
 	 * 
 	 * @param entityId
 	 *            ID of the media that is to be updated
-	 * @param document
-	 *            media revision to be updated or {@code null} if not available
+	 * @param revisionId
+	 *            base media revision to be updated or zero if not available
 	 * @param labels
 	 *            changes in entity labels or {@code null} for no change
 	 * @param statements
@@ -717,7 +717,7 @@ public interface DataObjectFactory {
 	 */
 	MediaInfoUpdate getMediaInfoUpdate(
 			MediaInfoIdValue entityId,
-			MediaInfoDocument document,
+			long revisionId,
 			TermUpdate labels,
 			StatementUpdate statements);
 
@@ -727,8 +727,8 @@ public interface DataObjectFactory {
 	 * 
 	 * @param entityId
 	 *            ID of the item that is to be updated
-	 * @param document
-	 *            item revision to be updated or {@code null} if not available
+	 * @param revisionId
+	 *            base item revision to be updated or zero if not available
 	 * @param labels
 	 *            changes in entity labels or {@code null} for no change
 	 * @param descriptions
@@ -749,7 +749,7 @@ public interface DataObjectFactory {
 	 */
 	ItemUpdate getItemUpdate(
 			ItemIdValue entityId,
-			ItemDocument document,
+			long revisionId,
 			TermUpdate labels,
 			TermUpdate descriptions,
 			Map<String, List<MonolingualTextValue>> aliases,
@@ -763,9 +763,8 @@ public interface DataObjectFactory {
 	 * 
 	 * @param entityId
 	 *            ID of the property entity that is to be updated
-	 * @param document
-	 *            property entity revision to be updated or {@code null} if not
-	 *            available
+	 * @param revisionId
+	 *            base property revision to be updated or zero if not available
 	 * @param labels
 	 *            changes in entity labels or {@code null} for no change
 	 * @param descriptions
@@ -782,7 +781,7 @@ public interface DataObjectFactory {
 	 */
 	PropertyUpdate getPropertyUpdate(
 			PropertyIdValue entityId,
-			PropertyDocument document,
+			long revisionId,
 			TermUpdate labels,
 			TermUpdate descriptions,
 			Map<String, List<MonolingualTextValue>> aliases,

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/EntityIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/EntityIdValue.java
@@ -108,14 +108,11 @@ public interface EntityIdValue extends IriIdentifiedValue {
 	String getSiteIri();
 
 	/**
-	 * Checks whether this entity ID is valid. Invalid IDs are commonly used as
-	 * placeholders when creating new entitites.
+	 * Checks whether this is a placeholder ID. Placeholder IDs, for example
+	 * {@link ItemIdValue#NULL}, are often used when creating new entities.
 	 * 
-	 * @return {@code true} if this is a valid ID, {@code false} for placeholder or
-	 *         otherwise invalid ID
+	 * @return {@code true} if this is a placeholder ID, {@code false} otherwise
 	 */
-	default boolean isValid() {
-		return !getSiteIri().equals(SITE_LOCAL);
-	}
+	boolean isPlaceholder();
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/EntityUpdate.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/EntityUpdate.java
@@ -33,13 +33,12 @@ public interface EntityUpdate {
 
 	/**
 	 * Returns entity revision, upon which this update is built. This might not be
-	 * the latest revision of the entity as currently stored in Wikibase. Providing
-	 * base revision of the entity is optional when constructing the update. If not
-	 * provided, this method returns {@code null}.
+	 * the latest revision of the entity as currently stored in Wikibase. If base
+	 * revision was not provided, this method returns zero.
 	 * 
-	 * @return entity revision that is being updated or {@code null}
+	 * @return entity revision that is being updated or zero
 	 */
-	EntityDocument getBaseRevision();
+	long getBaseRevisionId();
 
 	/**
 	 * Checks whether the update is empty. Empty update will not change the entity

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/EntityUpdate.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/EntityUpdate.java
@@ -37,7 +37,7 @@ public interface EntityUpdate {
 	 * base revision of the entity is optional when constructing the update. If not
 	 * provided, this method returns {@code null}.
 	 * 
-	 * @return entity revision that is being updated
+	 * @return entity revision that is being updated or {@code null}
 	 */
 	EntityDocument getBaseRevision();
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/FormIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/FormIdValue.java
@@ -85,6 +85,11 @@ public interface FormIdValue extends EntityIdValue {
 			return Hash.hashCode(this);
 		}
 
+		@Override
+		public boolean isPlaceholder() {
+			return true;
+		}
+
 	};
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/FormUpdate.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/FormUpdate.java
@@ -30,9 +30,6 @@ public interface FormUpdate extends StatementDocumentUpdate {
 	@Override
 	FormIdValue getEntityId();
 
-	@Override
-	FormDocument getBaseRevision();
-
 	/**
 	 * Returns changes in form representations.
 	 * 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/ItemIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/ItemIdValue.java
@@ -74,6 +74,11 @@ public interface ItemIdValue extends EntityIdValue {
 			return Hash.hashCode(this);
 		}
 
+		@Override
+		public boolean isPlaceholder() {
+			return true;
+		}
+
 	};
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/ItemUpdate.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/ItemUpdate.java
@@ -30,9 +30,6 @@ public interface ItemUpdate extends TermedStatementDocumentUpdate {
 	@Override
 	ItemIdValue getEntityId();
 
-	@Override
-	ItemDocument getBaseRevision();
-
 	/**
 	 * Returns site links added or modified in this update. Existing site links are
 	 * preserved if their site key is not listed here.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/LabeledDocumentUpdate.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/LabeledDocumentUpdate.java
@@ -24,9 +24,6 @@ package org.wikidata.wdtk.datamodel.interfaces;
  */
 public interface LabeledDocumentUpdate extends EntityUpdate {
 
-	@Override
-	LabeledDocument getBaseRevision();
-
 	/**
 	 * Returns changes in entity labels.
 	 * 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/LabeledStatementDocumentUpdate.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/LabeledStatementDocumentUpdate.java
@@ -25,7 +25,4 @@ package org.wikidata.wdtk.datamodel.interfaces;
  */
 public interface LabeledStatementDocumentUpdate extends LabeledDocumentUpdate, StatementDocumentUpdate {
 
-	@Override
-	LabeledStatementDocument getBaseRevision();
-
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/LexemeIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/LexemeIdValue.java
@@ -74,6 +74,11 @@ public interface LexemeIdValue extends EntityIdValue {
 			return Hash.hashCode(this);
 		}
 
+		@Override
+		public boolean isPlaceholder() {
+			return true;
+		}
+
 	};
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/LexemeUpdate.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/LexemeUpdate.java
@@ -32,9 +32,6 @@ public interface LexemeUpdate extends StatementDocumentUpdate {
 	@Override
 	LexemeIdValue getEntityId();
 
-	@Override
-	LexemeDocument getBaseRevision();
-
 	/**
 	 * Returns new lexeme language assigned in this update. If language code is not
 	 * changing, this method returns {@link Optional#empty()}.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/MediaInfoIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/MediaInfoIdValue.java
@@ -74,6 +74,11 @@ public interface MediaInfoIdValue extends EntityIdValue {
 			return Hash.hashCode(this);
 		}
 
+		@Override
+		public boolean isPlaceholder() {
+			return true;
+		}
+
 	};
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/MediaInfoUpdate.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/MediaInfoUpdate.java
@@ -27,7 +27,4 @@ public interface MediaInfoUpdate extends LabeledStatementDocumentUpdate {
 	@Override
 	MediaInfoIdValue getEntityId();
 
-	@Override
-	MediaInfoDocument getBaseRevision();
-
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/PropertyIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/PropertyIdValue.java
@@ -74,5 +74,10 @@ public interface PropertyIdValue extends EntityIdValue {
 			return Hash.hashCode(this);
 		}
 
+		@Override
+		public boolean isPlaceholder() {
+			return true;
+		}
+
 	};
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/PropertyUpdate.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/PropertyUpdate.java
@@ -27,7 +27,4 @@ public interface PropertyUpdate extends TermedStatementDocumentUpdate {
 	@Override
 	PropertyIdValue getEntityId();
 
-	@Override
-	PropertyDocument getBaseRevision();
-
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/SenseIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/SenseIdValue.java
@@ -85,6 +85,11 @@ public interface SenseIdValue extends EntityIdValue {
 			return Hash.hashCode(this);
 		}
 
+		@Override
+		public boolean isPlaceholder() {
+			return true;
+		}
+
 	};
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/SenseUpdate.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/SenseUpdate.java
@@ -27,9 +27,6 @@ public interface SenseUpdate extends StatementDocumentUpdate {
 	@Override
 	SenseIdValue getEntityId();
 
-	@Override
-	SenseDocument getBaseRevision();
-
 	/**
 	 * Returns changes in sense glosses.
 	 * 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/StatementDocumentUpdate.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/StatementDocumentUpdate.java
@@ -26,9 +26,6 @@ package org.wikidata.wdtk.datamodel.interfaces;
  */
 public interface StatementDocumentUpdate extends EntityUpdate {
 
-	@Override
-	StatementDocument getBaseRevision();
-
 	/**
 	 * Returns statement changes included in this update.
 	 * 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/StatementUpdate.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/StatementUpdate.java
@@ -36,7 +36,7 @@ public interface StatementUpdate {
 	/**
 	 * Empty update that does not alter or add any statements.
 	 */
-	StatementUpdate NULL = new StatementUpdateImpl(
+	StatementUpdate EMPTY = new StatementUpdateImpl(
 			Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/StatementUpdate.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/StatementUpdate.java
@@ -52,20 +52,20 @@ public interface StatementUpdate {
 	 * 
 	 * @return list of added statements
 	 */
-	List<Statement> getAddedStatements();
+	List<Statement> getAdded();
 
 	/**
 	 * Returns entity statements modified in this update.
 	 * 
 	 * @return modified statements indexed by statement ID
 	 */
-	Map<String, Statement> getReplacedStatements();
+	Map<String, Statement> getReplaced();
 
 	/**
 	 * Returns IDs of statements removed from the entity in this update.
 	 * 
 	 * @return list of IDs of removed statements
 	 */
-	Set<String> getRemovedStatements();
+	Set<String> getRemoved();
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/TermUpdate.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/TermUpdate.java
@@ -49,13 +49,13 @@ public interface TermUpdate {
 	 * 
 	 * @return added or modified terms indexed by language code
 	 */
-	Map<String, MonolingualTextValue> getModifiedTerms();
+	Map<String, MonolingualTextValue> getModified();
 
 	/**
 	 * Returns language codes of terms removed in this update.
 	 * 
 	 * @return language codes of removed terms
 	 */
-	Set<String> getRemovedTerms();
+	Set<String> getRemoved();
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/TermUpdate.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/TermUpdate.java
@@ -33,7 +33,7 @@ public interface TermUpdate {
 	/**
 	 * Empty update that does not alter or remove any terms.
 	 */
-	TermUpdate NULL = new TermUpdateImpl(Collections.emptyList(), Collections.emptyList());
+	TermUpdate EMPTY = new TermUpdateImpl(Collections.emptyList(), Collections.emptyList());
 
 	/**
 	 * Checks whether the update is empty. Empty update will not change or remove

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/TermedDocumentUpdate.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/TermedDocumentUpdate.java
@@ -28,9 +28,6 @@ import java.util.Map;
  */
 public interface TermedDocumentUpdate extends LabeledDocumentUpdate {
 
-	@Override
-	TermedDocument getBaseRevision();
-
 	/**
 	 * Returns changes in entity descriptions.
 	 * 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/TermedDocumentUpdate.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/TermedDocumentUpdate.java
@@ -19,7 +19,6 @@
  */
 package org.wikidata.wdtk.datamodel.interfaces;
 
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -36,12 +35,12 @@ public interface TermedDocumentUpdate extends LabeledDocumentUpdate {
 	TermUpdate getDescriptions();
 
 	/**
-	 * Returns changes in entity aliases. If language code is not in the returned
-	 * map, aliases for that language do not change. If alias list is empty, any
-	 * existing aliases for that language will be removed.
+	 * Returns changes in entity aliases. All {@link AliasUpdate} instances are
+	 * non-empty. If language code is not in the returned map, aliases for that
+	 * language do not change.
 	 * 
 	 * @return changes in aliases
 	 */
-	Map<String, List<MonolingualTextValue>> getAliases();
+	Map<String, AliasUpdate> getAliases();
 
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/TermedStatementDocumentUpdate.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/TermedStatementDocumentUpdate.java
@@ -25,7 +25,4 @@ package org.wikidata.wdtk.datamodel.interfaces;
  */
 public interface TermedStatementDocumentUpdate extends TermedDocumentUpdate, LabeledStatementDocumentUpdate {
 
-	@Override
-	TermedStatementDocument getBaseRevision();
-
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/AliasUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/AliasUpdateBuilderTest.java
@@ -1,0 +1,236 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.helpers;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+
+public class AliasUpdateBuilderTest {
+
+	static final MonolingualTextValue WALK = Datamodel.makeMonolingualTextValue("walk", "en");
+	static final MonolingualTextValue STROLL = Datamodel.makeMonolingualTextValue("stroll", "en");
+	static final MonolingualTextValue TRAVEL = Datamodel.makeMonolingualTextValue("travel", "en");
+	static final MonolingualTextValue WANDER = Datamodel.makeMonolingualTextValue("wander", "en");
+	static final MonolingualTextValue GEHEN = Datamodel.makeMonolingualTextValue("gehen", "de");
+
+	@Test
+	public void testCreate() {
+		AliasUpdate update = AliasUpdateBuilder.create().build();
+		assertFalse(update.getRecreated().isPresent());
+		assertThat(update.getAdded(), is(empty()));
+		assertThat(update.getRemoved(), is(empty()));
+	}
+
+	@Test
+	public void testForTerms() {
+		assertThrows(NullPointerException.class, () -> AliasUpdateBuilder.forAliases(null));
+		assertThrows(NullPointerException.class, () -> AliasUpdateBuilder.forAliases(Arrays.asList(WALK, null)));
+		assertThrows(IllegalArgumentException.class, () -> AliasUpdateBuilder.forAliases(Arrays.asList(WALK, WALK)));
+		assertThrows(IllegalArgumentException.class, () -> AliasUpdateBuilder.forAliases(Arrays.asList(WALK, GEHEN)));
+		AliasUpdate update = AliasUpdateBuilder.forAliases(Arrays.asList(WALK, STROLL)).build();
+		assertFalse(update.getRecreated().isPresent());
+		assertThat(update.getAdded(), is(empty()));
+		assertThat(update.getRemoved(), is(empty()));
+	}
+
+	@Test
+	public void testBlindAddition() {
+		AliasUpdateBuilder builder = AliasUpdateBuilder.create();
+		assertThrows(NullPointerException.class, () -> builder.add(null));
+		builder.add(WALK); // simple case
+		assertThrows(IllegalArgumentException.class, () -> builder.add(GEHEN));
+		builder.remove(TRAVEL);
+		builder.remove(WANDER);
+		builder.add(STROLL);
+		builder.add(STROLL); // add twice
+		builder.add(TRAVEL); // previously removed
+		AliasUpdate update = builder.build();
+		assertFalse(update.getRecreated().isPresent());
+		assertThat(update.getRemoved(), containsInAnyOrder(WANDER));
+		assertThat(update.getAdded(), contains(WALK, STROLL));
+	}
+
+	@Test
+	public void testRecreatedAddition() {
+		AliasUpdateBuilder builder = AliasUpdateBuilder.create();
+		builder.recreate(Arrays.asList(WALK, WANDER, TRAVEL));
+		assertThrows(IllegalArgumentException.class, () -> builder.add(GEHEN));
+		builder.add(STROLL); // simple case
+		builder.add(WANDER); // duplicate
+		AliasUpdate update = builder.build();
+		assertThat(update.getRemoved(), is(empty()));
+		assertThat(update.getAdded(), is(empty()));
+		assertThat(update.getRecreated().get(), contains(WALK, WANDER, TRAVEL, STROLL));
+	}
+
+	@Test
+	public void testBaseAddition() {
+		AliasUpdateBuilder builder = AliasUpdateBuilder.forAliases(Arrays.asList(WALK, TRAVEL));
+		assertThrows(IllegalArgumentException.class, () -> builder.add(GEHEN));
+		builder.add(STROLL); // simple case
+		builder.add(WALK); // duplicate
+		AliasUpdate update = builder.build();
+		assertThat(update.getRemoved(), is(empty()));
+		assertThat(update.getAdded(), contains(STROLL));
+		assertFalse(update.getRecreated().isPresent());
+	}
+
+	@Test
+	public void testRecreatedBaseAddition() {
+		AliasUpdateBuilder builder = AliasUpdateBuilder.forAliases(Arrays.asList(WALK, TRAVEL, STROLL));
+		builder.recreate(Arrays.asList(WALK));
+		builder.add(TRAVEL); // add to recreated
+		assertThat(builder.build().getRecreated().get(), contains(WALK, TRAVEL));
+		builder.add(STROLL); // cancel recreation
+		assertTrue(builder.build().isEmpty());
+		builder.add(WALK); // duplicate
+		builder.add(WANDER); // add to base
+		AliasUpdate update = builder.build();
+		assertThat(update.getRemoved(), is(empty()));
+		assertThat(update.getAdded(), contains(WANDER));
+		assertFalse(update.getRecreated().isPresent());
+	}
+
+	@Test
+	public void testBlindRemoval() {
+		AliasUpdateBuilder builder = AliasUpdateBuilder.create();
+		assertThrows(NullPointerException.class, () -> builder.remove(null));
+		builder.remove(WALK); // simple case
+		assertThrows(IllegalArgumentException.class, () -> builder.remove(GEHEN));
+		builder.add(TRAVEL);
+		builder.add(WANDER);
+		builder.remove(STROLL);
+		builder.remove(STROLL); // remove twice
+		builder.remove(TRAVEL); // previously added
+		AliasUpdate update = builder.build();
+		assertFalse(update.getRecreated().isPresent());
+		assertThat(update.getAdded(), contains(WANDER));
+		assertThat(update.getRemoved(), containsInAnyOrder(WALK, STROLL));
+	}
+
+	@Test
+	public void testRecreatedRemoval() {
+		AliasUpdateBuilder builder = AliasUpdateBuilder.create();
+		builder.recreate(Arrays.asList(WALK, WANDER, TRAVEL));
+		assertThrows(IllegalArgumentException.class, () -> builder.remove(GEHEN));
+		builder.remove(WANDER); // simple case
+		builder.remove(STROLL); // not present
+		AliasUpdate update = builder.build();
+		assertThat(update.getRemoved(), is(empty()));
+		assertThat(update.getAdded(), is(empty()));
+		assertThat(update.getRecreated().get(), contains(WALK, TRAVEL));
+	}
+
+	@Test
+	public void testBaseRemoval() {
+		AliasUpdateBuilder builder = AliasUpdateBuilder.forAliases(Arrays.asList(WALK, TRAVEL, WANDER));
+		assertThrows(IllegalArgumentException.class, () -> builder.remove(GEHEN));
+		builder.remove(TRAVEL); // simple case
+		builder.remove(STROLL); // not found
+		AliasUpdate update = builder.build();
+		assertThat(update.getAdded(), is(empty()));
+		assertThat(update.getRemoved(), contains(TRAVEL));
+		assertFalse(update.getRecreated().isPresent());
+	}
+
+	@Test
+	public void testRecreatedBaseRemoval() {
+		AliasUpdateBuilder builder = AliasUpdateBuilder.forAliases(Arrays.asList(WALK));
+		builder.recreate(Arrays.asList(WALK, TRAVEL, STROLL));
+		builder.remove(TRAVEL); // remove from recreated
+		assertThat(builder.build().getRecreated().get(), contains(WALK, STROLL));
+		builder.remove(STROLL); // cancel recreation
+		assertTrue(builder.build().isEmpty());
+		builder.remove(WANDER); // not found
+		builder.remove(WALK); // remove from base
+		AliasUpdate update = builder.build();
+		assertThat(update.getAdded(), is(empty()));
+		assertThat(update.getRemoved(), contains(WALK));
+		assertFalse(update.getRecreated().isPresent());
+	}
+
+	@Test
+	public void testBlindRecreation() {
+		AliasUpdateBuilder builder = AliasUpdateBuilder.create();
+		assertThrows(NullPointerException.class, () -> builder.recreate(null));
+		assertThrows(NullPointerException.class, () -> builder.recreate(Arrays.asList(WALK, null)));
+		assertThrows(IllegalArgumentException.class, () -> builder.recreate(Arrays.asList(WALK, WALK)));
+		assertThrows(IllegalArgumentException.class, () -> builder.recreate(Arrays.asList(WALK, GEHEN)));
+		builder.add(WANDER);
+		builder.remove(WALK);
+		builder.recreate(Arrays.asList(WALK, STROLL));
+		AliasUpdate update = builder.build();
+		assertThat(update.getRecreated().get(), contains(WALK, STROLL));
+		assertThat(update.getRemoved(), is(empty()));
+		assertThat(update.getAdded(), is(empty()));
+	}
+
+	@Test
+	public void testBaseRecreation() {
+		AliasUpdateBuilder builder = AliasUpdateBuilder.forAliases(Arrays.asList(STROLL, TRAVEL, WALK));
+		builder.add(WANDER);
+		builder.remove(WALK);
+		builder.recreate(Arrays.asList(WALK, STROLL));
+		AliasUpdate update = builder.build();
+		assertThat(update.getRecreated().get(), contains(WALK, STROLL));
+		assertThat(update.getRemoved(), is(empty()));
+		assertThat(update.getAdded(), is(empty()));
+		builder.recreate(Arrays.asList(STROLL, TRAVEL, WALK));
+		assertTrue(builder.build().isEmpty());
+	}
+
+	@Test
+	public void testMerge() {
+		assertThrows(NullPointerException.class, () -> AliasUpdateBuilder.create().append(null));
+		AliasUpdate update = AliasUpdateBuilder.create()
+				.add(WALK) // prior addition
+				.remove(STROLL) // prior removal
+				.append(AliasUpdateBuilder.create()
+						.add(TRAVEL) // another addition
+						.remove(WANDER) // another removal
+						.build())
+				.build();
+		assertFalse(update.getRecreated().isPresent());
+		assertThat(update.getAdded(), contains(WALK, TRAVEL));
+		assertThat(update.getRemoved(), containsInAnyOrder(STROLL, WANDER));
+		update = AliasUpdateBuilder.create()
+				.add(WALK) // any prior change
+				.append(AliasUpdateBuilder.create()
+						.recreate(Arrays.asList(WALK, STROLL))
+						.build())
+				.build();
+		assertThat(update.getRecreated().get(), contains(WALK, STROLL));
+		assertThat(update.getRemoved(), is(empty()));
+		assertThat(update.getAdded(), is(empty()));
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverterTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverterTest.java
@@ -94,6 +94,11 @@ public class DatamodelConverterTest {
 			return valueVisitor.visit(this);
 		}
 
+		@Override
+		public boolean isPlaceholder() {
+			return false;
+		}
+
 	}
 
 	private Statement getBrokenStatement() {

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/EntityUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/EntityUpdateBuilderTest.java
@@ -47,38 +47,38 @@ import org.wikidata.wdtk.datamodel.interfaces.SenseIdValue;
 
 public class EntityUpdateBuilderTest {
 
-	private final ItemIdValue q1 = Datamodel.makeWikidataItemIdValue("Q1");
-	private final PropertyIdValue p1 = Datamodel.makeWikidataPropertyIdValue("P1");
-	private final MediaInfoIdValue m1 = Datamodel.makeWikimediaCommonsMediaInfoIdValue("M1");
-	private final LexemeIdValue l1 = Datamodel.makeWikidataLexemeIdValue("L1");
-	private final FormIdValue f1 = Datamodel.makeWikidataFormIdValue("L1-F1");
-	private final SenseIdValue s1 = Datamodel.makeWikidataSenseIdValue("L1-S1");
-	private final ItemDocument item = Datamodel.makeItemDocument(q1);
-	private final PropertyDocument property = Datamodel.makePropertyDocument(
-			p1, Datamodel.makeDatatypeIdValue(DatatypeIdValue.DT_ITEM));
-	private final MediaInfoDocument media = Datamodel.makeMediaInfoDocument(m1);
-	private final LexemeDocument lexeme = Datamodel.makeLexemeDocument(l1, q1, q1,
+	static final ItemIdValue Q1 = Datamodel.makeWikidataItemIdValue("Q1");
+	static final PropertyIdValue P1 = Datamodel.makeWikidataPropertyIdValue("P1");
+	static final MediaInfoIdValue M1 = Datamodel.makeWikimediaCommonsMediaInfoIdValue("M1");
+	static final LexemeIdValue L1 = Datamodel.makeWikidataLexemeIdValue("L1");
+	static final FormIdValue F1 = Datamodel.makeWikidataFormIdValue("L1-F1");
+	static final SenseIdValue S1 = Datamodel.makeWikidataSenseIdValue("L1-S1");
+	static final ItemDocument ITEM = Datamodel.makeItemDocument(Q1);
+	static final PropertyDocument PROPERTY = Datamodel.makePropertyDocument(
+			P1, Datamodel.makeDatatypeIdValue(DatatypeIdValue.DT_ITEM));
+	static final MediaInfoDocument MEDIA = Datamodel.makeMediaInfoDocument(M1);
+	static final LexemeDocument LEXEME = Datamodel.makeLexemeDocument(L1, Q1, Q1,
 			Arrays.asList(Datamodel.makeMonolingualTextValue("hello", "en")));
-	private final FormDocument form = Datamodel.makeFormDocument(
-			f1,
+	static final FormDocument FORM = Datamodel.makeFormDocument(
+			F1,
 			Arrays.asList(Datamodel.makeMonolingualTextValue("hello", "en")),
 			Collections.emptyList(),
 			Collections.emptyList());
-	private final SenseDocument sense = Datamodel.makeSenseDocument(
-			s1, Arrays.asList(Datamodel.makeMonolingualTextValue("something", "en")), Collections.emptyList());
+	static final SenseDocument SENSE = Datamodel.makeSenseDocument(
+			S1, Arrays.asList(Datamodel.makeMonolingualTextValue("something", "en")), Collections.emptyList());
 
 	@Test
 	public void testForEntityId() {
 		assertThrows(NullPointerException.class, () -> EntityUpdateBuilder.forEntityId(null));
 		assertThrows(IllegalArgumentException.class, () -> EntityUpdateBuilder.forEntityId(ItemIdValue.NULL));
-		assertThat(EntityUpdateBuilder.forEntityId(q1), is(instanceOf(ItemUpdateBuilder.class)));
-		assertThat(EntityUpdateBuilder.forEntityId(p1), is(instanceOf(PropertyUpdateBuilder.class)));
-		assertThat(EntityUpdateBuilder.forEntityId(m1), is(instanceOf(MediaInfoUpdateBuilder.class)));
-		assertThat(EntityUpdateBuilder.forEntityId(l1), is(instanceOf(LexemeUpdateBuilder.class)));
-		assertThat(EntityUpdateBuilder.forEntityId(f1), is(instanceOf(FormUpdateBuilder.class)));
-		assertThat(EntityUpdateBuilder.forEntityId(s1), is(instanceOf(SenseUpdateBuilder.class)));
-		EntityUpdateBuilder builder = EntityUpdateBuilder.forEntityId(q1);
-		assertEquals(q1, builder.getEntityId());
+		assertThat(EntityUpdateBuilder.forEntityId(Q1), is(instanceOf(ItemUpdateBuilder.class)));
+		assertThat(EntityUpdateBuilder.forEntityId(P1), is(instanceOf(PropertyUpdateBuilder.class)));
+		assertThat(EntityUpdateBuilder.forEntityId(M1), is(instanceOf(MediaInfoUpdateBuilder.class)));
+		assertThat(EntityUpdateBuilder.forEntityId(L1), is(instanceOf(LexemeUpdateBuilder.class)));
+		assertThat(EntityUpdateBuilder.forEntityId(F1), is(instanceOf(FormUpdateBuilder.class)));
+		assertThat(EntityUpdateBuilder.forEntityId(S1), is(instanceOf(SenseUpdateBuilder.class)));
+		EntityUpdateBuilder builder = EntityUpdateBuilder.forEntityId(Q1);
+		assertEquals(Q1, builder.getEntityId());
 		assertNull(builder.getBaseRevision());
 	}
 
@@ -87,15 +87,15 @@ public class EntityUpdateBuilderTest {
 		assertThrows(NullPointerException.class, () -> EntityUpdateBuilder.forBaseRevision(null));
 		assertThrows(IllegalArgumentException.class,
 				() -> EntityUpdateBuilder.forBaseRevision(Datamodel.makeItemDocument(ItemIdValue.NULL)));
-		assertThat(EntityUpdateBuilder.forBaseRevision(item), is(instanceOf(ItemUpdateBuilder.class)));
-		assertThat(EntityUpdateBuilder.forBaseRevision(property), is(instanceOf(PropertyUpdateBuilder.class)));
-		assertThat(EntityUpdateBuilder.forBaseRevision(media), is(instanceOf(MediaInfoUpdateBuilder.class)));
-		assertThat(EntityUpdateBuilder.forBaseRevision(lexeme), is(instanceOf(LexemeUpdateBuilder.class)));
-		assertThat(EntityUpdateBuilder.forBaseRevision(form), is(instanceOf(FormUpdateBuilder.class)));
-		assertThat(EntityUpdateBuilder.forBaseRevision(sense), is(instanceOf(SenseUpdateBuilder.class)));
-		EntityUpdateBuilder builder = EntityUpdateBuilder.forBaseRevision(item);
-		assertEquals(q1, builder.getEntityId());
-		assertSame(item, builder.getBaseRevision());
+		assertThat(EntityUpdateBuilder.forBaseRevision(ITEM), is(instanceOf(ItemUpdateBuilder.class)));
+		assertThat(EntityUpdateBuilder.forBaseRevision(PROPERTY), is(instanceOf(PropertyUpdateBuilder.class)));
+		assertThat(EntityUpdateBuilder.forBaseRevision(MEDIA), is(instanceOf(MediaInfoUpdateBuilder.class)));
+		assertThat(EntityUpdateBuilder.forBaseRevision(LEXEME), is(instanceOf(LexemeUpdateBuilder.class)));
+		assertThat(EntityUpdateBuilder.forBaseRevision(FORM), is(instanceOf(FormUpdateBuilder.class)));
+		assertThat(EntityUpdateBuilder.forBaseRevision(SENSE), is(instanceOf(SenseUpdateBuilder.class)));
+		EntityUpdateBuilder builder = EntityUpdateBuilder.forBaseRevision(ITEM);
+		assertEquals(Q1, builder.getEntityId());
+		assertSame(ITEM, builder.getBaseRevision());
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/EntityUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/EntityUpdateBuilderTest.java
@@ -1,0 +1,101 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.helpers;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
+import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
+import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.LexemeDocument;
+import org.wikidata.wdtk.datamodel.interfaces.LexemeIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.MediaInfoDocument;
+import org.wikidata.wdtk.datamodel.interfaces.MediaInfoIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.SenseDocument;
+import org.wikidata.wdtk.datamodel.interfaces.SenseIdValue;
+
+public class EntityUpdateBuilderTest {
+
+	private final ItemIdValue q1 = Datamodel.makeWikidataItemIdValue("Q1");
+	private final PropertyIdValue p1 = Datamodel.makeWikidataPropertyIdValue("P1");
+	private final MediaInfoIdValue m1 = Datamodel.makeWikimediaCommonsMediaInfoIdValue("M1");
+	private final LexemeIdValue l1 = Datamodel.makeWikidataLexemeIdValue("L1");
+	private final FormIdValue f1 = Datamodel.makeWikidataFormIdValue("L1-F1");
+	private final SenseIdValue s1 = Datamodel.makeWikidataSenseIdValue("L1-S1");
+	private final ItemDocument item = Datamodel.makeItemDocument(q1);
+	private final PropertyDocument property = Datamodel.makePropertyDocument(
+			p1, Datamodel.makeDatatypeIdValue(DatatypeIdValue.DT_ITEM));
+	private final MediaInfoDocument media = Datamodel.makeMediaInfoDocument(m1);
+	private final LexemeDocument lexeme = Datamodel.makeLexemeDocument(l1, q1, q1,
+			Arrays.asList(Datamodel.makeMonolingualTextValue("hello", "en")));
+	private final FormDocument form = Datamodel.makeFormDocument(
+			f1,
+			Arrays.asList(Datamodel.makeMonolingualTextValue("hello", "en")),
+			Collections.emptyList(),
+			Collections.emptyList());
+	private final SenseDocument sense = Datamodel.makeSenseDocument(
+			s1, Arrays.asList(Datamodel.makeMonolingualTextValue("something", "en")), Collections.emptyList());
+
+	@Test
+	public void testForEntityId() {
+		assertThrows(NullPointerException.class, () -> EntityUpdateBuilder.forEntityId(null));
+		assertThrows(IllegalArgumentException.class, () -> EntityUpdateBuilder.forEntityId(ItemIdValue.NULL));
+		assertThat(EntityUpdateBuilder.forEntityId(q1), is(instanceOf(ItemUpdateBuilder.class)));
+		assertThat(EntityUpdateBuilder.forEntityId(p1), is(instanceOf(PropertyUpdateBuilder.class)));
+		assertThat(EntityUpdateBuilder.forEntityId(m1), is(instanceOf(MediaInfoUpdateBuilder.class)));
+		assertThat(EntityUpdateBuilder.forEntityId(l1), is(instanceOf(LexemeUpdateBuilder.class)));
+		assertThat(EntityUpdateBuilder.forEntityId(f1), is(instanceOf(FormUpdateBuilder.class)));
+		assertThat(EntityUpdateBuilder.forEntityId(s1), is(instanceOf(SenseUpdateBuilder.class)));
+		EntityUpdateBuilder builder = EntityUpdateBuilder.forEntityId(q1);
+		assertEquals(q1, builder.getEntityId());
+		assertNull(builder.getBaseRevision());
+	}
+
+	@Test
+	public void testForBaseRevision() {
+		assertThrows(NullPointerException.class, () -> EntityUpdateBuilder.forBaseRevision(null));
+		assertThrows(IllegalArgumentException.class,
+				() -> EntityUpdateBuilder.forBaseRevision(Datamodel.makeItemDocument(ItemIdValue.NULL)));
+		assertThat(EntityUpdateBuilder.forBaseRevision(item), is(instanceOf(ItemUpdateBuilder.class)));
+		assertThat(EntityUpdateBuilder.forBaseRevision(property), is(instanceOf(PropertyUpdateBuilder.class)));
+		assertThat(EntityUpdateBuilder.forBaseRevision(media), is(instanceOf(MediaInfoUpdateBuilder.class)));
+		assertThat(EntityUpdateBuilder.forBaseRevision(lexeme), is(instanceOf(LexemeUpdateBuilder.class)));
+		assertThat(EntityUpdateBuilder.forBaseRevision(form), is(instanceOf(FormUpdateBuilder.class)));
+		assertThat(EntityUpdateBuilder.forBaseRevision(sense), is(instanceOf(SenseUpdateBuilder.class)));
+		EntityUpdateBuilder builder = EntityUpdateBuilder.forBaseRevision(item);
+		assertEquals(q1, builder.getEntityId());
+		assertSame(item, builder.getBaseRevision());
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/EntityUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/EntityUpdateBuilderTest.java
@@ -53,7 +53,7 @@ public class EntityUpdateBuilderTest {
 	static final LexemeIdValue L1 = Datamodel.makeWikidataLexemeIdValue("L1");
 	static final FormIdValue F1 = Datamodel.makeWikidataFormIdValue("L1-F1");
 	static final SenseIdValue S1 = Datamodel.makeWikidataSenseIdValue("L1-S1");
-	static final ItemDocument ITEM = Datamodel.makeItemDocument(Q1);
+	static final ItemDocument ITEM = Datamodel.makeItemDocument(Q1).withRevisionId(123);
 	static final PropertyDocument PROPERTY = Datamodel.makePropertyDocument(
 			P1, Datamodel.makeDatatypeIdValue(DatatypeIdValue.DT_ITEM));
 	static final MediaInfoDocument MEDIA = Datamodel.makeMediaInfoDocument(M1);
@@ -80,6 +80,21 @@ public class EntityUpdateBuilderTest {
 		EntityUpdateBuilder builder = EntityUpdateBuilder.forEntityId(Q1);
 		assertEquals(Q1, builder.getEntityId());
 		assertNull(builder.getBaseRevision());
+		assertEquals(0, builder.getBaseRevisionId());
+	}
+
+	@Test
+	public void testForBaseRevisionId() {
+		EntityUpdateBuilder builder = EntityUpdateBuilder.forBaseRevisionId(Q1, 123);
+		assertEquals(Q1, builder.getEntityId());
+		assertNull(builder.getBaseRevision());
+		assertEquals(123, builder.getBaseRevisionId());
+		assertEquals(123, EntityUpdateBuilder.forBaseRevisionId(Q1, 123).getBaseRevisionId());
+		assertEquals(123, EntityUpdateBuilder.forBaseRevisionId(P1, 123).getBaseRevisionId());
+		assertEquals(123, EntityUpdateBuilder.forBaseRevisionId(M1, 123).getBaseRevisionId());
+		assertEquals(123, EntityUpdateBuilder.forBaseRevisionId(L1, 123).getBaseRevisionId());
+		assertEquals(123, EntityUpdateBuilder.forBaseRevisionId(F1, 123).getBaseRevisionId());
+		assertEquals(123, EntityUpdateBuilder.forBaseRevisionId(S1, 123).getBaseRevisionId());
 	}
 
 	@Test
@@ -96,6 +111,7 @@ public class EntityUpdateBuilderTest {
 		EntityUpdateBuilder builder = EntityUpdateBuilder.forBaseRevision(ITEM);
 		assertEquals(Q1, builder.getEntityId());
 		assertSame(ITEM, builder.getBaseRevision());
+		assertEquals(123, builder.getBaseRevisionId());
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/EntityUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/EntityUpdateBuilderTest.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.Arrays;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
@@ -57,15 +56,11 @@ public class EntityUpdateBuilderTest {
 	static final PropertyDocument PROPERTY = Datamodel.makePropertyDocument(
 			P1, Datamodel.makeDatatypeIdValue(DatatypeIdValue.DT_ITEM));
 	static final MediaInfoDocument MEDIA = Datamodel.makeMediaInfoDocument(M1);
-	static final LexemeDocument LEXEME = Datamodel.makeLexemeDocument(L1, Q1, Q1,
-			Arrays.asList(Datamodel.makeMonolingualTextValue("hello", "en")));
-	static final FormDocument FORM = Datamodel.makeFormDocument(
-			F1,
-			Arrays.asList(Datamodel.makeMonolingualTextValue("hello", "en")),
-			Collections.emptyList(),
-			Collections.emptyList());
-	static final SenseDocument SENSE = Datamodel.makeSenseDocument(
-			S1, Arrays.asList(Datamodel.makeMonolingualTextValue("something", "en")), Collections.emptyList());
+	static final LexemeDocument LEXEME = Datamodel.makeLexemeDocument(L1, Q1, Q1, Collections.emptyList());
+	static final FormDocument FORM = Datamodel.makeFormDocument(F1,
+			Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+	static final SenseDocument SENSE = Datamodel.makeSenseDocument(S1,
+			Collections.emptyList(), Collections.emptyList());
 
 	@Test
 	public void testForEntityId() {

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/FormUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/FormUpdateBuilderTest.java
@@ -1,0 +1,144 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.helpers;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
+import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.FormUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
+
+public class FormUpdateBuilderTest {
+
+	private static final FormIdValue F1 = EntityUpdateBuilderTest.F1;
+	private static final FormDocument FORM = EntityUpdateBuilderTest.FORM;
+	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateBuilderTest.JOHN_HAS_BROWN_HAIR;
+	private static final Statement JOHN_HAS_BLUE_EYES = StatementUpdateBuilderTest.JOHN_HAS_BLUE_EYES;
+	private static final MonolingualTextValue EN = TermUpdateBuilderTest.EN;
+	private static final MonolingualTextValue SK = TermUpdateBuilderTest.SK;
+	private static final ItemIdValue Q1 = EntityUpdateBuilderTest.Q1;
+	private static final ItemIdValue Q2 = Datamodel.makeWikidataItemIdValue("Q2");
+	private static final ItemIdValue Q3 = Datamodel.makeWikidataItemIdValue("Q3");
+
+	@Test
+	public void testForEntityId() {
+		assertThrows(NullPointerException.class, () -> FormUpdateBuilder.forEntityId(null));
+		assertThrows(IllegalArgumentException.class, () -> FormUpdateBuilder.forEntityId(FormIdValue.NULL));
+		FormUpdateBuilder.forEntityId(F1);
+	}
+
+	@Test
+	public void testForBaseRevision() {
+		assertThrows(NullPointerException.class, () -> FormUpdateBuilder.forBaseRevision(null));
+		assertThrows(IllegalArgumentException.class,
+				() -> FormUpdateBuilder.forBaseRevision(FORM.withEntityId(FormIdValue.NULL)));
+		FormUpdateBuilder.forBaseRevision(FORM);
+	}
+
+	@Test
+	public void testStatementUpdate() {
+		FormUpdate update = FormUpdateBuilder.forEntityId(F1)
+				.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())
+				.build();
+		assertThat(update.getStatements().getAdded(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
+	}
+
+	@Test
+	public void testBlindRepresentationUpdate() {
+		assertThrows(NullPointerException.class, () -> FormUpdateBuilder.forEntityId(F1).updateRepresentations(null));
+		FormUpdate update = FormUpdateBuilder.forEntityId(F1)
+				.updateRepresentations(TermUpdateBuilder.create().remove("en").build())
+				.updateRepresentations(TermUpdateBuilder.create().remove("sk").build())
+				.build();
+		assertThat(update.getRepresentations().getRemoved(), containsInAnyOrder("en", "sk"));
+	}
+
+	@Test
+	public void testBaseRepresentationUpdate() {
+		FormUpdate update = FormUpdateBuilder
+				.forBaseRevision(FORM
+						.withRepresentation(EN)
+						.withRepresentation(SK))
+				.updateRepresentations(TermUpdateBuilder.create()
+						.put(SK) // ignored
+						.remove("en") // checked
+						.build())
+				.build();
+		assertThat(update.getRepresentations().getModified(), is(anEmptyMap()));
+		assertThat(update.getRepresentations().getRemoved(), containsInAnyOrder("en"));
+	}
+
+	@Test
+	public void testBlindFeatureChange() {
+		FormUpdateBuilder builder = FormUpdateBuilder.forEntityId(F1);
+		assertThrows(NullPointerException.class, () -> builder.setGrammaticalFeatures(null));
+		assertThrows(NullPointerException.class, () -> builder.setGrammaticalFeatures(Arrays.asList(Q1, null)));
+		assertThrows(IllegalArgumentException.class,
+				() -> builder.setGrammaticalFeatures(Arrays.asList(ItemIdValue.NULL)));
+		assertThrows(IllegalArgumentException.class, () -> builder.setGrammaticalFeatures(Arrays.asList(Q1, Q1)));
+		assertFalse(builder.build().getGrammaticalFeatures().isPresent());
+		FormUpdate update = builder.setGrammaticalFeatures(Arrays.asList(Q1, Q2)).build();
+		assertThat(update.getGrammaticalFeatures().get(), containsInAnyOrder(Q1, Q2));
+	}
+
+	@Test
+	public void testBaseFeatureChange() {
+		FormDocument base = FORM
+				.withGrammaticalFeature(Q1)
+				.withGrammaticalFeature(Q2);
+		assertFalse(FormUpdateBuilder.forBaseRevision(base).build().getGrammaticalFeatures().isPresent());
+		assertFalse(FormUpdateBuilder.forBaseRevision(base)
+				.setGrammaticalFeatures(Arrays.asList(Q1, Q2))
+				.build()
+				.getGrammaticalFeatures().isPresent());
+		FormUpdate update = FormUpdateBuilder.forBaseRevision(base)
+				.setGrammaticalFeatures(Arrays.asList(Q2, Q3))
+				.build();
+		assertThat(update.getGrammaticalFeatures().get(), containsInAnyOrder(Q2, Q3));
+	}
+
+	@Test
+	public void testMerge() {
+		assertThrows(NullPointerException.class, () -> FormUpdateBuilder.forEntityId(F1).append(null));
+		FormUpdate update = FormUpdateBuilder.forEntityId(F1)
+				.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())
+				.updateRepresentations(TermUpdateBuilder.create().remove("en").build())
+				.append(FormUpdateBuilder.forEntityId(F1)
+						.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BLUE_EYES).build())
+						.updateRepresentations(TermUpdateBuilder.create().remove("sk").build())
+						.build())
+				.build();
+		assertThat(update.getStatements().getAdded(),
+				containsInAnyOrder(JOHN_HAS_BROWN_HAIR, JOHN_HAS_BLUE_EYES));
+		assertThat(update.getRepresentations().getRemoved(), containsInAnyOrder("en", "sk"));
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/FormUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/FormUpdateBuilderTest.java
@@ -40,8 +40,14 @@ public class FormUpdateBuilderTest {
 
 	private static final FormIdValue F1 = EntityUpdateBuilderTest.F1;
 	private static final FormDocument FORM = EntityUpdateBuilderTest.FORM;
-	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateBuilderTest.JOHN_HAS_BROWN_HAIR;
-	private static final Statement JOHN_HAS_BLUE_EYES = StatementUpdateBuilderTest.JOHN_HAS_BLUE_EYES;
+	private static final Statement F1_DESCRIBES_SOMETHING = StatementBuilder
+			.forSubjectAndProperty(F1, Datamodel.makeWikidataPropertyIdValue("P1"))
+			.withValue(Datamodel.makeStringValue("something"))
+			.build();
+	private static final Statement F1_EVOKES_FEELING = StatementBuilder
+			.forSubjectAndProperty(F1, Datamodel.makeWikidataPropertyIdValue("P2"))
+			.withValue(Datamodel.makeStringValue("feeling"))
+			.build();
 	private static final MonolingualTextValue EN = TermUpdateBuilderTest.EN;
 	private static final MonolingualTextValue SK = TermUpdateBuilderTest.SK;
 	private static final ItemIdValue Q1 = EntityUpdateBuilderTest.Q1;
@@ -66,9 +72,9 @@ public class FormUpdateBuilderTest {
 	@Test
 	public void testStatementUpdate() {
 		FormUpdate update = FormUpdateBuilder.forEntityId(F1)
-				.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())
+				.updateStatements(StatementUpdateBuilder.create().add(F1_DESCRIBES_SOMETHING).build())
 				.build();
-		assertThat(update.getStatements().getAdded(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
+		assertThat(update.getStatements().getAdded(), containsInAnyOrder(F1_DESCRIBES_SOMETHING));
 	}
 
 	@Test
@@ -129,15 +135,15 @@ public class FormUpdateBuilderTest {
 	public void testMerge() {
 		assertThrows(NullPointerException.class, () -> FormUpdateBuilder.forEntityId(F1).append(null));
 		FormUpdate update = FormUpdateBuilder.forEntityId(F1)
-				.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())
+				.updateStatements(StatementUpdateBuilder.create().add(F1_DESCRIBES_SOMETHING).build())
 				.updateRepresentations(TermUpdateBuilder.create().remove("en").build())
 				.append(FormUpdateBuilder.forEntityId(F1)
-						.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BLUE_EYES).build())
+						.updateStatements(StatementUpdateBuilder.create().add(F1_EVOKES_FEELING).build())
 						.updateRepresentations(TermUpdateBuilder.create().remove("sk").build())
 						.build())
 				.build();
 		assertThat(update.getStatements().getAdded(),
-				containsInAnyOrder(JOHN_HAS_BROWN_HAIR, JOHN_HAS_BLUE_EYES));
+				containsInAnyOrder(F1_DESCRIBES_SOMETHING, F1_EVOKES_FEELING));
 		assertThat(update.getRepresentations().getRemoved(), containsInAnyOrder("en", "sk"));
 	}
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/FormUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/FormUpdateBuilderTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -59,6 +60,11 @@ public class FormUpdateBuilderTest {
 		assertThrows(NullPointerException.class, () -> FormUpdateBuilder.forEntityId(null));
 		assertThrows(IllegalArgumentException.class, () -> FormUpdateBuilder.forEntityId(FormIdValue.NULL));
 		FormUpdateBuilder.forEntityId(F1);
+	}
+
+	@Test
+	public void testForBaseRevisionId() {
+		assertEquals(123, FormUpdateBuilder.forBaseRevisionId(F1, 123).getBaseRevisionId());
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilderTest.java
@@ -27,8 +27,6 @@ import static org.hamcrest.Matchers.empty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.Arrays;
-
 import org.junit.jupiter.api.Test;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
@@ -97,10 +95,9 @@ public class ItemUpdateBuilderTest {
 	@Test
 	public void testAliasUpdate() {
 		ItemUpdate update = ItemUpdateBuilder.forEntityId(Q1)
-				.putAliases("sk", Arrays.asList(TermUpdateBuilderTest.SK))
-				.putAliasesAsStrings("en", Arrays.asList("hello"))
+				.updateAliases("sk", AliasUpdateBuilder.create().add(TermUpdateBuilderTest.SK).build())
 				.build();
-		assertThat(update.getAliases().keySet(), containsInAnyOrder("en", "sk"));
+		assertThat(update.getAliases().keySet(), containsInAnyOrder("sk"));
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilderTest.java
@@ -58,6 +58,11 @@ public class ItemUpdateBuilderTest {
 	}
 
 	@Test
+	public void testForBaseRevisionId() {
+		assertEquals(123, ItemUpdateBuilder.forBaseRevisionId(Q1, 123).getBaseRevisionId());
+	}
+
+	@Test
 	public void testForBaseRevision() {
 		assertThrows(NullPointerException.class, () -> ItemUpdateBuilder.forBaseRevision(null));
 		assertThrows(IllegalArgumentException.class,

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilderTest.java
@@ -68,43 +68,44 @@ public class ItemUpdateBuilderTest {
 	@Test
 	public void testStatementUpdate() {
 		ItemUpdate update = ItemUpdateBuilder.forEntityId(Q1)
-				.updateStatements(StatementUpdateBuilder.create().addStatement(JOHN_HAS_BROWN_HAIR).build())
+				.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())
 				.build();
-		assertThat(update.getStatements().getAddedStatements(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
+		assertThat(update.getStatements().getAdded(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
 	}
 
 	@Test
 	public void testLabelUpdate() {
 		ItemUpdate update = ItemUpdateBuilder.forEntityId(Q1)
-				.updateLabels(TermUpdateBuilder.create().removeTerm("en").build())
+				.updateLabels(TermUpdateBuilder.create().remove("en").build())
 				.build();
-		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("en"));
+		assertThat(update.getLabels().getRemoved(), containsInAnyOrder("en"));
 	}
 
 	@Test
 	public void testDescriptionUpdate() {
 		ItemUpdate update = ItemUpdateBuilder.forEntityId(Q1)
-				.updateDescriptions(TermUpdateBuilder.create().removeTerm("en").build())
+				.updateDescriptions(TermUpdateBuilder.create().remove("en").build())
 				.build();
-		assertThat(update.getDescriptions().getRemovedTerms(), containsInAnyOrder("en"));
+		assertThat(update.getDescriptions().getRemoved(), containsInAnyOrder("en"));
 	}
 
 	@Test
 	public void testAliasUpdate() {
 		ItemUpdate update = ItemUpdateBuilder.forEntityId(Q1)
-				.setAliases("en", Arrays.asList("hello"))
+				.putAliases("sk", Arrays.asList(TermUpdateBuilderTest.SK))
+				.putAliasesAsStrings("en", Arrays.asList("hello"))
 				.build();
-		assertThat(update.getAliases().keySet(), containsInAnyOrder("en"));
+		assertThat(update.getAliases().keySet(), containsInAnyOrder("en", "sk"));
 	}
 
 	@Test
 	public void testBlindSiteLinkAssignment() {
 		ItemUpdateBuilder builder = ItemUpdateBuilder.forEntityId(Q1);
-		assertThrows(NullPointerException.class, () -> builder.setSiteLink(null));
+		assertThrows(NullPointerException.class, () -> builder.putSiteLink(null));
 		builder.removeSiteLink("skwiki");
 		builder.removeSiteLink("dewiki");
-		builder.setSiteLink(EN); // simple case
-		builder.setSiteLink(SK); // previously removed
+		builder.putSiteLink(EN); // simple case
+		builder.putSiteLink(SK); // previously removed
 		ItemUpdate update = builder.build();
 		assertThat(update.getRemovedSiteLinks(), containsInAnyOrder("dewiki"));
 		assertThat(update.getModifiedSiteLinks().keySet(), containsInAnyOrder("skwiki", "enwiki"));
@@ -117,8 +118,8 @@ public class ItemUpdateBuilderTest {
 		ItemUpdateBuilder builder = ItemUpdateBuilder.forEntityId(Q1);
 		assertThrows(NullPointerException.class, () -> builder.removeSiteLink(null));
 		assertThrows(IllegalArgumentException.class, () -> builder.removeSiteLink(" "));
-		builder.setSiteLink(EN);
-		builder.setSiteLink(SK);
+		builder.putSiteLink(EN);
+		builder.putSiteLink(SK);
 		builder.removeSiteLink("dewiki"); // simple case
 		builder.removeSiteLink("skwiki"); // previously assigned
 		ItemUpdate update = builder.build();
@@ -136,11 +137,11 @@ public class ItemUpdateBuilderTest {
 				.build());
 		builder.removeSiteLink("skwiki");
 		builder.removeSiteLink("dewiki");
-		builder.setSiteLink(FR); // new language key
-		builder.setSiteLink(EN2); // new value
-		builder.setSiteLink(CS); // same value
-		builder.setSiteLink(SK); // same value for previously removed
-		builder.setSiteLink(DE2); // new value for previously removed
+		builder.putSiteLink(FR); // new language key
+		builder.putSiteLink(EN2); // new value
+		builder.putSiteLink(CS); // same value
+		builder.putSiteLink(SK); // same value for previously removed
+		builder.putSiteLink(DE2); // new value for previously removed
 		ItemUpdate update = builder.build();
 		assertThat(update.getRemovedSiteLinks(), is(empty()));
 		assertThat(update.getModifiedSiteLinks().keySet(), containsInAnyOrder("enwiki", "dewiki", "frwiki"));
@@ -156,8 +157,8 @@ public class ItemUpdateBuilderTest {
 				.withSiteLink(SK)
 				.withSiteLink(CS)
 				.build());
-		builder.setSiteLink(EN2);
-		builder.setSiteLink(DE);
+		builder.putSiteLink(EN2);
+		builder.putSiteLink(DE);
 		builder.removeSiteLink("skwiki"); // simple case
 		builder.removeSiteLink("frwiki"); // not found
 		builder.removeSiteLink("enwiki"); // previously modified
@@ -170,14 +171,14 @@ public class ItemUpdateBuilderTest {
 	@Test
 	public void testMerge() {
 		ItemUpdate update = ItemUpdateBuilder.forEntityId(Q1)
-				.updateDescriptions(TermUpdateBuilder.create().removeTerm("en").build())
+				.updateDescriptions(TermUpdateBuilder.create().remove("en").build())
 				.removeSiteLink("enwiki")
-				.apply(ItemUpdateBuilder.forEntityId(Q1)
-						.updateDescriptions(TermUpdateBuilder.create().removeTerm("sk").build())
+				.append(ItemUpdateBuilder.forEntityId(Q1)
+						.updateDescriptions(TermUpdateBuilder.create().remove("sk").build())
 						.removeSiteLink("skwiki")
 						.build())
 				.build();
-		assertThat(update.getDescriptions().getRemovedTerms(), containsInAnyOrder("sk", "en"));
+		assertThat(update.getDescriptions().getRemoved(), containsInAnyOrder("sk", "en"));
 		assertThat(update.getRemovedSiteLinks(), containsInAnyOrder("skwiki", "enwiki"));
 	}
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilderTest.java
@@ -1,0 +1,184 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.helpers;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
+import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.ItemUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
+
+public class ItemUpdateBuilderTest {
+
+	private static final ItemIdValue Q1 = EntityUpdateBuilderTest.Q1;
+	private static final ItemDocument ITEM = EntityUpdateBuilderTest.ITEM;
+	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateBuilderTest.JOHN_HAS_BROWN_HAIR;
+	private static final SiteLink EN = Datamodel.makeSiteLink("hello", "enwiki");
+	private static final SiteLink EN2 = Datamodel.makeSiteLink("hi", "enwiki");
+	private static final SiteLink SK = Datamodel.makeSiteLink("ahoj", "skwiki");
+	private static final SiteLink CS = Datamodel.makeSiteLink("nazdar", "cswiki");
+	private static final SiteLink DE = Datamodel.makeSiteLink("Hallo", "dewiki");
+	private static final SiteLink DE2 = Datamodel.makeSiteLink("Guten Tag", "dewiki");
+	private static final SiteLink FR = Datamodel.makeSiteLink("Bonjour", "frwiki");
+
+	@Test
+	public void testForEntityId() {
+		assertThrows(NullPointerException.class, () -> ItemUpdateBuilder.forEntityId(null));
+		assertThrows(IllegalArgumentException.class, () -> ItemUpdateBuilder.forEntityId(PropertyIdValue.NULL));
+		ItemUpdateBuilder.forEntityId(Q1);
+	}
+
+	@Test
+	public void testForBaseRevision() {
+		assertThrows(NullPointerException.class, () -> ItemUpdateBuilder.forBaseRevision(null));
+		assertThrows(IllegalArgumentException.class,
+				() -> ItemUpdateBuilder.forBaseRevision(Datamodel.makeItemDocument(ItemIdValue.NULL)));
+		ItemUpdateBuilder.forBaseRevision(ITEM);
+	}
+
+	@Test
+	public void testStatementUpdate() {
+		ItemUpdate update = ItemUpdateBuilder.forEntityId(Q1)
+				.updateStatements(StatementUpdateBuilder.create().addStatement(JOHN_HAS_BROWN_HAIR).build())
+				.build();
+		assertThat(update.getStatements().getAddedStatements(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
+	}
+
+	@Test
+	public void testLabelUpdate() {
+		ItemUpdate update = ItemUpdateBuilder.forEntityId(Q1)
+				.updateLabels(TermUpdateBuilder.create().removeTerm("en").build())
+				.build();
+		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("en"));
+	}
+
+	@Test
+	public void testDescriptionUpdate() {
+		ItemUpdate update = ItemUpdateBuilder.forEntityId(Q1)
+				.updateDescriptions(TermUpdateBuilder.create().removeTerm("en").build())
+				.build();
+		assertThat(update.getDescriptions().getRemovedTerms(), containsInAnyOrder("en"));
+	}
+
+	@Test
+	public void testAliasUpdate() {
+		ItemUpdate update = ItemUpdateBuilder.forEntityId(Q1)
+				.setAliases("en", Arrays.asList("hello"))
+				.build();
+		assertThat(update.getAliases().keySet(), containsInAnyOrder("en"));
+	}
+
+	@Test
+	public void testBlindSiteLinkAssignment() {
+		ItemUpdateBuilder builder = ItemUpdateBuilder.forEntityId(Q1);
+		assertThrows(NullPointerException.class, () -> builder.setSiteLink(null));
+		builder.removeSiteLink("skwiki");
+		builder.removeSiteLink("dewiki");
+		builder.setSiteLink(EN); // simple case
+		builder.setSiteLink(SK); // previously removed
+		ItemUpdate update = builder.build();
+		assertThat(update.getRemovedSiteLinks(), containsInAnyOrder("dewiki"));
+		assertThat(update.getModifiedSiteLinks().keySet(), containsInAnyOrder("skwiki", "enwiki"));
+		assertEquals(EN, update.getModifiedSiteLinks().get("enwiki"));
+		assertEquals(SK, update.getModifiedSiteLinks().get("skwiki"));
+	}
+
+	@Test
+	public void testBlindSiteLinkRemoval() {
+		ItemUpdateBuilder builder = ItemUpdateBuilder.forEntityId(Q1);
+		assertThrows(NullPointerException.class, () -> builder.removeSiteLink(null));
+		assertThrows(IllegalArgumentException.class, () -> builder.removeSiteLink(" "));
+		builder.setSiteLink(EN);
+		builder.setSiteLink(SK);
+		builder.removeSiteLink("dewiki"); // simple case
+		builder.removeSiteLink("skwiki"); // previously assigned
+		ItemUpdate update = builder.build();
+		assertThat(update.getRemovedSiteLinks(), containsInAnyOrder("skwiki", "dewiki"));
+		assertThat(update.getModifiedSiteLinks().keySet(), containsInAnyOrder("enwiki"));
+	}
+
+	@Test
+	public void testBaseSiteLinkAssignment() {
+		ItemUpdateBuilder builder = ItemUpdateBuilder.forBaseRevision(ItemDocumentBuilder.fromItemDocument(ITEM)
+				.withSiteLink(SK)
+				.withSiteLink(EN)
+				.withSiteLink(DE)
+				.withSiteLink(CS)
+				.build());
+		builder.removeSiteLink("skwiki");
+		builder.removeSiteLink("dewiki");
+		builder.setSiteLink(FR); // new language key
+		builder.setSiteLink(EN2); // new value
+		builder.setSiteLink(CS); // same value
+		builder.setSiteLink(SK); // same value for previously removed
+		builder.setSiteLink(DE2); // new value for previously removed
+		ItemUpdate update = builder.build();
+		assertThat(update.getRemovedSiteLinks(), is(empty()));
+		assertThat(update.getModifiedSiteLinks().keySet(), containsInAnyOrder("enwiki", "dewiki", "frwiki"));
+		assertEquals(FR, update.getModifiedSiteLinks().get("frwiki"));
+		assertEquals(EN2, update.getModifiedSiteLinks().get("enwiki"));
+		assertEquals(DE2, update.getModifiedSiteLinks().get("dewiki"));
+	}
+
+	@Test
+	public void testBaseSiteLinkRemoval() {
+		ItemUpdateBuilder builder = ItemUpdateBuilder.forBaseRevision(ItemDocumentBuilder.fromItemDocument(ITEM)
+				.withSiteLink(EN)
+				.withSiteLink(SK)
+				.withSiteLink(CS)
+				.build());
+		builder.setSiteLink(EN2);
+		builder.setSiteLink(DE);
+		builder.removeSiteLink("skwiki"); // simple case
+		builder.removeSiteLink("frwiki"); // not found
+		builder.removeSiteLink("enwiki"); // previously modified
+		builder.removeSiteLink("dewiki"); // previously added
+		ItemUpdate update = builder.build();
+		assertThat(update.getModifiedSiteLinks(), anEmptyMap());
+		assertThat(update.getRemovedSiteLinks(), containsInAnyOrder("enwiki", "skwiki"));
+	}
+
+	@Test
+	public void testMerge() {
+		ItemUpdate update = ItemUpdateBuilder.forEntityId(Q1)
+				.updateDescriptions(TermUpdateBuilder.create().removeTerm("en").build())
+				.removeSiteLink("enwiki")
+				.apply(ItemUpdateBuilder.forEntityId(Q1)
+						.updateDescriptions(TermUpdateBuilder.create().removeTerm("sk").build())
+						.removeSiteLink("skwiki")
+						.build())
+				.build();
+		assertThat(update.getDescriptions().getRemovedTerms(), containsInAnyOrder("sk", "en"));
+		assertThat(update.getRemovedSiteLinks(), containsInAnyOrder("skwiki", "enwiki"));
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LabeledDocumentUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LabeledDocumentUpdateBuilderTest.java
@@ -76,19 +76,19 @@ public class LabeledDocumentUpdateBuilderTest {
 	@Test
 	public void testStatementUpdate() {
 		LabeledStatementDocumentUpdate update = LabeledDocumentUpdateBuilder.forEntityId(Q1)
-				.updateStatements(StatementUpdateBuilder.create().addStatement(JOHN_HAS_BROWN_HAIR).build())
+				.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())
 				.build();
-		assertThat(update.getStatements().getAddedStatements(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
+		assertThat(update.getStatements().getAdded(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
 	}
 
 	@Test
 	public void testBlindLabelUpdate() {
 		assertThrows(NullPointerException.class, () -> LabeledDocumentUpdateBuilder.forEntityId(Q1).updateLabels(null));
 		LabeledDocumentUpdate update = LabeledDocumentUpdateBuilder.forEntityId(Q1)
-				.updateLabels(TermUpdateBuilder.create().removeTerm("en").build())
-				.updateLabels(TermUpdateBuilder.create().removeTerm("sk").build())
+				.updateLabels(TermUpdateBuilder.create().remove("en").build())
+				.updateLabels(TermUpdateBuilder.create().remove("sk").build())
 				.build();
-		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("en", "sk"));
+		assertThat(update.getLabels().getRemoved(), containsInAnyOrder("en", "sk"));
 	}
 
 	@Test
@@ -98,28 +98,28 @@ public class LabeledDocumentUpdateBuilderTest {
 						.withLabel(EN)
 						.withLabel(SK))
 				.updateLabels(TermUpdateBuilder.create()
-						.setTerm(SK) // ignored
-						.removeTerm("en") // checked
+						.put(SK) // ignored
+						.remove("en") // checked
 						.build())
 				.build();
-		assertThat(update.getLabels().getModifiedTerms(), is(anEmptyMap()));
-		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("en"));
+		assertThat(update.getLabels().getModified(), is(anEmptyMap()));
+		assertThat(update.getLabels().getRemoved(), containsInAnyOrder("en"));
 	}
 
 	@Test
 	public void testMerge() {
-		assertThrows(NullPointerException.class, () -> LabeledDocumentUpdateBuilder.forEntityId(Q1).apply(null));
+		assertThrows(NullPointerException.class, () -> LabeledDocumentUpdateBuilder.forEntityId(Q1).append(null));
 		LabeledDocumentUpdateBuilder builder = LabeledDocumentUpdateBuilder.forEntityId(Q1)
-				.updateStatements(StatementUpdateBuilder.create().addStatement(JOHN_HAS_BROWN_HAIR).build())
-				.updateLabels(TermUpdateBuilder.create().removeTerm("en").build());
-		builder.apply(LabeledDocumentUpdateBuilder.forEntityId(Q1)
-				.updateStatements(StatementUpdateBuilder.create().addStatement(JOHN_HAS_BLUE_EYES).build())
-				.updateLabels(TermUpdateBuilder.create().removeTerm("sk").build())
+				.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())
+				.updateLabels(TermUpdateBuilder.create().remove("en").build());
+		builder.append(LabeledDocumentUpdateBuilder.forEntityId(Q1)
+				.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BLUE_EYES).build())
+				.updateLabels(TermUpdateBuilder.create().remove("sk").build())
 				.build());
 		LabeledStatementDocumentUpdate update = builder.build();
-		assertThat(update.getStatements().getAddedStatements(),
+		assertThat(update.getStatements().getAdded(),
 				containsInAnyOrder(JOHN_HAS_BROWN_HAIR, JOHN_HAS_BLUE_EYES));
-		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("en", "sk"));
+		assertThat(update.getLabels().getRemoved(), containsInAnyOrder("en", "sk"));
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LabeledDocumentUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LabeledDocumentUpdateBuilderTest.java
@@ -49,8 +49,7 @@ public class LabeledDocumentUpdateBuilderTest {
 	private static final PropertyDocument PROPERTY = EntityUpdateBuilderTest.PROPERTY;
 	private static final MediaInfoDocument MEDIA = EntityUpdateBuilderTest.MEDIA;
 	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateBuilderTest.JOHN_HAS_BROWN_HAIR;
-	private static final Statement JOHN_ALREADY_HAS_BROWN_HAIR = StatementUpdateBuilderTest.JOHN_ALREADY_HAS_BROWN_HAIR;
-	private static final Statement JOHN_ALREADY_HAS_BLUE_EYES = StatementUpdateBuilderTest.JOHN_ALREADY_HAS_BLUE_EYES;
+	private static final Statement JOHN_HAS_BLUE_EYES = StatementUpdateBuilderTest.JOHN_HAS_BLUE_EYES;
 	private static final MonolingualTextValue EN = TermUpdateBuilderTest.EN;
 	private static final MonolingualTextValue SK = TermUpdateBuilderTest.SK;
 
@@ -77,9 +76,7 @@ public class LabeledDocumentUpdateBuilderTest {
 	@Test
 	public void testStatementUpdate() {
 		LabeledStatementDocumentUpdate update = LabeledDocumentUpdateBuilder.forEntityId(Q1)
-				.updateStatements(StatementUpdateBuilder.create()
-						.addStatement(JOHN_HAS_BROWN_HAIR)
-						.build())
+				.updateStatements(StatementUpdateBuilder.create().addStatement(JOHN_HAS_BROWN_HAIR).build())
 				.build();
 		assertThat(update.getStatements().getAddedStatements(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
 	}
@@ -88,15 +85,10 @@ public class LabeledDocumentUpdateBuilderTest {
 	public void testBlindLabelUpdate() {
 		assertThrows(NullPointerException.class, () -> LabeledDocumentUpdateBuilder.forEntityId(Q1).updateLabels(null));
 		LabeledDocumentUpdate update = LabeledDocumentUpdateBuilder.forEntityId(Q1)
-				.updateLabels(TermUpdateBuilder.create()
-						.setTerm(EN)
-						.build())
-				.updateLabels(TermUpdateBuilder.create()
-						.removeTerm("sk")
-						.build())
+				.updateLabels(TermUpdateBuilder.create().removeTerm("en").build())
+				.updateLabels(TermUpdateBuilder.create().removeTerm("sk").build())
 				.build();
-		assertThat(update.getLabels().getModifiedTerms().values(), containsInAnyOrder(EN));
-		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("sk"));
+		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("en", "sk"));
 	}
 
 	@Test
@@ -118,25 +110,15 @@ public class LabeledDocumentUpdateBuilderTest {
 	public void testMerge() {
 		assertThrows(NullPointerException.class, () -> LabeledDocumentUpdateBuilder.forEntityId(Q1).apply(null));
 		LabeledDocumentUpdateBuilder builder = LabeledDocumentUpdateBuilder.forEntityId(Q1)
-				.updateStatements(StatementUpdateBuilder.create()
-						.replaceStatement(JOHN_ALREADY_HAS_BROWN_HAIR)
-						.build())
-				.updateLabels(TermUpdateBuilder.create()
-						.setTerm(EN)
-						.build());
+				.updateStatements(StatementUpdateBuilder.create().addStatement(JOHN_HAS_BROWN_HAIR).build())
+				.updateLabels(TermUpdateBuilder.create().setTerm(EN).build());
 		builder.apply(LabeledDocumentUpdateBuilder.forEntityId(Q1)
-				.updateStatements(StatementUpdateBuilder.create()
-						.removeStatement(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId())
-						.build())
-				.updateLabels(TermUpdateBuilder.create()
-						.removeTerm("sk")
-						.build())
+				.updateStatements(StatementUpdateBuilder.create().addStatement(JOHN_HAS_BLUE_EYES).build())
+				.updateLabels(TermUpdateBuilder.create().removeTerm("sk").build())
 				.build());
 		LabeledStatementDocumentUpdate update = builder.build();
-		assertThat(update.getStatements().getReplacedStatements().values(),
-				containsInAnyOrder(JOHN_ALREADY_HAS_BROWN_HAIR));
-		assertThat(update.getStatements().getRemovedStatements(),
-				containsInAnyOrder(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId()));
+		assertThat(update.getStatements().getAddedStatements(),
+				containsInAnyOrder(JOHN_HAS_BROWN_HAIR, JOHN_HAS_BLUE_EYES));
 		assertThat(update.getLabels().getModifiedTerms().values(), containsInAnyOrder(EN));
 		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("sk"));
 	}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LabeledDocumentUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LabeledDocumentUpdateBuilderTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -61,6 +62,13 @@ public class LabeledDocumentUpdateBuilderTest {
 		assertThat(LabeledDocumentUpdateBuilder.forEntityId(Q1), is(instanceOf(ItemUpdateBuilder.class)));
 		assertThat(LabeledDocumentUpdateBuilder.forEntityId(P1), is(instanceOf(PropertyUpdateBuilder.class)));
 		assertThat(LabeledDocumentUpdateBuilder.forEntityId(M1), is(instanceOf(MediaInfoUpdateBuilder.class)));
+	}
+
+	@Test
+	public void testForBaseRevisionId() {
+		assertEquals(123, LabeledDocumentUpdateBuilder.forBaseRevisionId(Q1, 123).getBaseRevisionId());
+		assertEquals(123, LabeledDocumentUpdateBuilder.forBaseRevisionId(P1, 123).getBaseRevisionId());
+		assertEquals(123, LabeledDocumentUpdateBuilder.forBaseRevisionId(M1, 123).getBaseRevisionId());
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LabeledDocumentUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LabeledDocumentUpdateBuilderTest.java
@@ -1,0 +1,144 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.helpers;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
+import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.LabeledDocumentUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.LabeledStatementDocumentUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.LexemeIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.MediaInfoDocument;
+import org.wikidata.wdtk.datamodel.interfaces.MediaInfoIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
+
+public class LabeledDocumentUpdateBuilderTest {
+
+	private static final ItemIdValue Q1 = EntityUpdateBuilderTest.Q1;
+	private static final PropertyIdValue P1 = EntityUpdateBuilderTest.P1;
+	private static final MediaInfoIdValue M1 = EntityUpdateBuilderTest.M1;
+	private static final LexemeIdValue L1 = EntityUpdateBuilderTest.L1;
+	private static final ItemDocument ITEM = EntityUpdateBuilderTest.ITEM;
+	private static final PropertyDocument PROPERTY = EntityUpdateBuilderTest.PROPERTY;
+	private static final MediaInfoDocument MEDIA = EntityUpdateBuilderTest.MEDIA;
+	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateBuilderTest.JOHN_HAS_BROWN_HAIR;
+	private static final Statement JOHN_ALREADY_HAS_BROWN_HAIR = StatementUpdateBuilderTest.JOHN_ALREADY_HAS_BROWN_HAIR;
+	private static final Statement JOHN_ALREADY_HAS_BLUE_EYES = StatementUpdateBuilderTest.JOHN_ALREADY_HAS_BLUE_EYES;
+	private static final MonolingualTextValue EN = TermUpdateBuilderTest.EN;
+	private static final MonolingualTextValue SK = TermUpdateBuilderTest.SK;
+
+	@Test
+	public void testForEntityId() {
+		assertThrows(NullPointerException.class, () -> LabeledDocumentUpdateBuilder.forEntityId(null));
+		assertThrows(IllegalArgumentException.class, () -> LabeledDocumentUpdateBuilder.forEntityId(ItemIdValue.NULL));
+		assertThrows(IllegalArgumentException.class, () -> LabeledDocumentUpdateBuilder.forEntityId(L1));
+		assertThat(LabeledDocumentUpdateBuilder.forEntityId(Q1), is(instanceOf(ItemUpdateBuilder.class)));
+		assertThat(LabeledDocumentUpdateBuilder.forEntityId(P1), is(instanceOf(PropertyUpdateBuilder.class)));
+		assertThat(LabeledDocumentUpdateBuilder.forEntityId(M1), is(instanceOf(MediaInfoUpdateBuilder.class)));
+	}
+
+	@Test
+	public void testForBaseRevision() {
+		assertThrows(NullPointerException.class, () -> LabeledDocumentUpdateBuilder.forBaseRevision(null));
+		assertThrows(IllegalArgumentException.class,
+				() -> LabeledDocumentUpdateBuilder.forBaseRevision(Datamodel.makeItemDocument(ItemIdValue.NULL)));
+		assertThat(LabeledDocumentUpdateBuilder.forBaseRevision(ITEM), is(instanceOf(ItemUpdateBuilder.class)));
+		assertThat(LabeledDocumentUpdateBuilder.forBaseRevision(PROPERTY), is(instanceOf(PropertyUpdateBuilder.class)));
+		assertThat(LabeledDocumentUpdateBuilder.forBaseRevision(MEDIA), is(instanceOf(MediaInfoUpdateBuilder.class)));
+	}
+
+	@Test
+	public void testStatementUpdate() {
+		LabeledStatementDocumentUpdate update = LabeledDocumentUpdateBuilder.forEntityId(Q1)
+				.updateStatements(StatementUpdateBuilder.create()
+						.addStatement(JOHN_HAS_BROWN_HAIR)
+						.build())
+				.build();
+		assertThat(update.getStatements().getAddedStatements(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
+	}
+
+	@Test
+	public void testBlindLabelUpdate() {
+		assertThrows(NullPointerException.class, () -> LabeledDocumentUpdateBuilder.forEntityId(Q1).updateLabels(null));
+		LabeledDocumentUpdate update = LabeledDocumentUpdateBuilder.forEntityId(Q1)
+				.updateLabels(TermUpdateBuilder.create()
+						.setTerm(EN)
+						.build())
+				.updateLabels(TermUpdateBuilder.create()
+						.removeTerm("sk")
+						.build())
+				.build();
+		assertThat(update.getLabels().getModifiedTerms().values(), containsInAnyOrder(EN));
+		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("sk"));
+	}
+
+	@Test
+	public void testBaseLabelUpdate() {
+		LabeledDocumentUpdate update = LabeledDocumentUpdateBuilder
+				.forBaseRevision(ITEM
+						.withLabel(EN)
+						.withLabel(SK))
+				.updateLabels(TermUpdateBuilder.create()
+						.setTerm(SK) // ignored
+						.removeTerm("en") // checked
+						.build())
+				.build();
+		assertThat(update.getLabels().getModifiedTerms(), is(anEmptyMap()));
+		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("en"));
+	}
+
+	@Test
+	public void testMerge() {
+		assertThrows(NullPointerException.class, () -> LabeledDocumentUpdateBuilder.forEntityId(Q1).apply(null));
+		LabeledDocumentUpdateBuilder builder = LabeledDocumentUpdateBuilder.forEntityId(Q1)
+				.updateStatements(StatementUpdateBuilder.create()
+						.replaceStatement(JOHN_ALREADY_HAS_BROWN_HAIR)
+						.build())
+				.updateLabels(TermUpdateBuilder.create()
+						.setTerm(EN)
+						.build());
+		builder.apply(LabeledDocumentUpdateBuilder.forEntityId(Q1)
+				.updateStatements(StatementUpdateBuilder.create()
+						.removeStatement(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId())
+						.build())
+				.updateLabels(TermUpdateBuilder.create()
+						.removeTerm("sk")
+						.build())
+				.build());
+		LabeledStatementDocumentUpdate update = builder.build();
+		assertThat(update.getStatements().getReplacedStatements().values(),
+				containsInAnyOrder(JOHN_ALREADY_HAS_BROWN_HAIR));
+		assertThat(update.getStatements().getRemovedStatements(),
+				containsInAnyOrder(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId()));
+		assertThat(update.getLabels().getModifiedTerms().values(), containsInAnyOrder(EN));
+		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("sk"));
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LabeledDocumentUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LabeledDocumentUpdateBuilderTest.java
@@ -111,7 +111,7 @@ public class LabeledDocumentUpdateBuilderTest {
 		assertThrows(NullPointerException.class, () -> LabeledDocumentUpdateBuilder.forEntityId(Q1).apply(null));
 		LabeledDocumentUpdateBuilder builder = LabeledDocumentUpdateBuilder.forEntityId(Q1)
 				.updateStatements(StatementUpdateBuilder.create().addStatement(JOHN_HAS_BROWN_HAIR).build())
-				.updateLabels(TermUpdateBuilder.create().setTerm(EN).build());
+				.updateLabels(TermUpdateBuilder.create().removeTerm("en").build());
 		builder.apply(LabeledDocumentUpdateBuilder.forEntityId(Q1)
 				.updateStatements(StatementUpdateBuilder.create().addStatement(JOHN_HAS_BLUE_EYES).build())
 				.updateLabels(TermUpdateBuilder.create().removeTerm("sk").build())
@@ -119,8 +119,7 @@ public class LabeledDocumentUpdateBuilderTest {
 		LabeledStatementDocumentUpdate update = builder.build();
 		assertThat(update.getStatements().getAddedStatements(),
 				containsInAnyOrder(JOHN_HAS_BROWN_HAIR, JOHN_HAS_BLUE_EYES));
-		assertThat(update.getLabels().getModifiedTerms().values(), containsInAnyOrder(EN));
-		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("sk"));
+		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("en", "sk"));
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilderTest.java
@@ -49,8 +49,14 @@ import org.wikidata.wdtk.datamodel.interfaces.Statement;
 public class LexemeUpdateBuilderTest {
 
 	private static final LexemeIdValue L1 = EntityUpdateBuilderTest.L1;
-	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateBuilderTest.JOHN_HAS_BROWN_HAIR;
-	private static final Statement JOHN_HAS_BLUE_EYES = StatementUpdateBuilderTest.JOHN_HAS_BLUE_EYES;
+	private static final Statement L1_DESCRIBES_SOMETHING = StatementBuilder
+			.forSubjectAndProperty(L1, Datamodel.makeWikidataPropertyIdValue("P1"))
+			.withValue(Datamodel.makeStringValue("something"))
+			.build();
+	private static final Statement L1_EVOKES_FEELING = StatementBuilder
+			.forSubjectAndProperty(L1, Datamodel.makeWikidataPropertyIdValue("P2"))
+			.withValue(Datamodel.makeStringValue("feeling"))
+			.build();
 	private static final MonolingualTextValue EN = TermUpdateBuilderTest.EN;
 	private static final MonolingualTextValue SK = TermUpdateBuilderTest.SK;
 	private static final ItemIdValue Q1 = EntityUpdateBuilderTest.Q1;
@@ -79,9 +85,9 @@ public class LexemeUpdateBuilderTest {
 	@Test
 	public void testStatementUpdate() {
 		LexemeUpdate update = LexemeUpdateBuilder.forEntityId(L1)
-				.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())
+				.updateStatements(StatementUpdateBuilder.create().add(L1_DESCRIBES_SOMETHING).build())
 				.build();
-		assertThat(update.getStatements().getAdded(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
+		assertThat(update.getStatements().getAdded(), containsInAnyOrder(L1_DESCRIBES_SOMETHING));
 	}
 
 	@Test
@@ -406,7 +412,7 @@ public class LexemeUpdateBuilderTest {
 	public void testMerge() {
 		assertThrows(NullPointerException.class, () -> LexemeUpdateBuilder.forEntityId(L1).append(null));
 		LexemeUpdate update = LexemeUpdateBuilder.forEntityId(L1)
-				.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())
+				.updateStatements(StatementUpdateBuilder.create().add(L1_DESCRIBES_SOMETHING).build())
 				.updateLemmas(TermUpdateBuilder.create().remove("en").build())
 				.addForm(form("swim"))
 				.updateForm(formUpdate(2, RARE))
@@ -415,7 +421,7 @@ public class LexemeUpdateBuilderTest {
 				.updateSense(senseUpdate(2, RARE))
 				.removeSense(senseId(3))
 				.append(LexemeUpdateBuilder.forEntityId(L1)
-						.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BLUE_EYES).build())
+						.updateStatements(StatementUpdateBuilder.create().add(L1_EVOKES_FEELING).build())
 						.updateLemmas(TermUpdateBuilder.create().remove("sk").build())
 						.addForm(form("swims"))
 						.updateForm(formUpdate(2, OBSOLETE))
@@ -426,7 +432,7 @@ public class LexemeUpdateBuilderTest {
 						.build())
 				.build();
 		assertThat(update.getStatements().getAdded(),
-				containsInAnyOrder(JOHN_HAS_BROWN_HAIR, JOHN_HAS_BLUE_EYES));
+				containsInAnyOrder(L1_DESCRIBES_SOMETHING, L1_EVOKES_FEELING));
 		assertThat(update.getLemmas().getRemoved(), containsInAnyOrder("en", "sk"));
 		assertEquals(Arrays.asList(form("swim"), form("swims")), update.getAddedForms());
 		assertThat(update.getUpdatedForms().keySet(), containsInAnyOrder(formId(2)));

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilderTest.java
@@ -210,8 +210,9 @@ public class LexemeUpdateBuilderTest {
 				.addForm(form("swim")) // simple case
 				.addForm(form("swim")) // duplicates allowed
 				.addForm(form(2, "swimming")) // strip ID
+				.addForm(form("swam").withRevisionId(123)) // strip revision ID
 				.build();
-		assertEquals(Arrays.asList(form("swim"), form("swim"), form("swimming")), update.getAddedForms());
+		assertEquals(Arrays.asList(form("swim"), form("swim"), form("swimming"), form("swam")), update.getAddedForms());
 	}
 
 	@Test
@@ -231,6 +232,13 @@ public class LexemeUpdateBuilderTest {
 		assertThat(update.getUpdatedForms().keySet(), containsInAnyOrder(formId(1), formId(2)));
 		assertEquals(formUpdate(1, OBSOLETE), update.getUpdatedForms().get(formId(1)));
 		assertEquals(formUpdate(2, RARE, OBSOLETE), update.getUpdatedForms().get(formId(2)));
+		// synchronize revision IDs
+		assertEquals(123, LexemeUpdateBuilder.forBaseRevisionId(L1, 123)
+				.updateForm(formUpdate(1, OBSOLETE))
+				.build()
+				.getUpdatedForms()
+				.get(formId(1))
+				.getBaseRevisionId());
 	}
 
 	@Test
@@ -335,8 +343,11 @@ public class LexemeUpdateBuilderTest {
 				.addSense(sense("move")) // simple case
 				.addSense(sense("move")) // duplicates allowed
 				.addSense(sense(2, "immerse")) // strip ID
+				.addSense(sense("float").withRevisionId(123)) // strip revision ID
 				.build();
-		assertEquals(Arrays.asList(sense("move"), sense("move"), sense("immerse")), update.getAddedSenses());
+		assertEquals(
+				Arrays.asList(sense("move"), sense("move"), sense("immerse"), sense("float")),
+				update.getAddedSenses());
 	}
 
 	@Test
@@ -356,6 +367,13 @@ public class LexemeUpdateBuilderTest {
 		assertThat(update.getUpdatedSenses().keySet(), containsInAnyOrder(senseId(1), senseId(2)));
 		assertEquals(senseUpdate(1, OBSOLETE), update.getUpdatedSenses().get(senseId(1)));
 		assertEquals(senseUpdate(2, RARE, OBSOLETE), update.getUpdatedSenses().get(senseId(2)));
+		// synchronize revision IDs
+		assertEquals(123, LexemeUpdateBuilder.forBaseRevisionId(L1, 123)
+				.updateSense(senseUpdate(1, OBSOLETE))
+				.build()
+				.getUpdatedSenses()
+				.get(senseId(1))
+				.getBaseRevisionId());
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilderTest.java
@@ -23,18 +23,27 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
+import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.FormUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.LexemeDocument;
 import org.wikidata.wdtk.datamodel.interfaces.LexemeIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.LexemeUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.SenseDocument;
+import org.wikidata.wdtk.datamodel.interfaces.SenseIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.SenseUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 
 public class LexemeUpdateBuilderTest {
@@ -48,6 +57,9 @@ public class LexemeUpdateBuilderTest {
 	private static final ItemIdValue Q2 = Datamodel.makeWikidataItemIdValue("Q2");
 	private static final ItemIdValue Q3 = Datamodel.makeWikidataItemIdValue("Q3");
 	private static final LexemeDocument LEXEME = Datamodel.makeLexemeDocument(L1, Q1, Q2, Arrays.asList(EN));
+	private static final PropertyIdValue INSTANCE_OF = Datamodel.makeWikidataPropertyIdValue("P31");
+	private static final ItemIdValue OBSOLETE = Datamodel.makeWikidataItemIdValue("Q11");
+	private static final ItemIdValue RARE = Datamodel.makeWikidataItemIdValue("Q12");
 
 	@Test
 	public void testForEntityId() {
@@ -139,20 +151,291 @@ public class LexemeUpdateBuilderTest {
 		assertThat(update.getLemmas().getRemoved(), containsInAnyOrder("en"));
 	}
 
+	private static FormDocument form(String representation) {
+		return Datamodel.makeFormDocument(
+				FormIdValue.NULL,
+				Arrays.asList(Datamodel.makeMonolingualTextValue(representation, "en")),
+				Collections.emptyList(),
+				Collections.emptyList());
+	}
+
+	private static FormIdValue formId(int id) {
+		return Datamodel.makeWikidataFormIdValue("L1-F" + id);
+	}
+
+	private static FormDocument form(int id, String representation) {
+		return form(representation).withEntityId(formId(id));
+	}
+
+	private static FormUpdate formUpdate(int id, String representation) {
+		return FormUpdateBuilder.forEntityId(formId(id))
+				.updateRepresentations(TermUpdateBuilder.create()
+						.put(Datamodel.makeMonolingualTextValue(representation, "en"))
+						.build())
+				.build();
+	}
+
+	private static FormUpdate withBase(LexemeDocument base, FormUpdate update) {
+		return FormUpdateBuilder.forBaseRevision(base.getForm(update.getEntityId())).append(update).build();
+	}
+
+	private static FormUpdate formUpdate(int id, ItemIdValue... classes) {
+		FormIdValue formId = formId(id);
+		StatementUpdateBuilder statements = StatementUpdateBuilder.create();
+		for (ItemIdValue clazz : classes) {
+			statements.add(StatementBuilder.forSubjectAndProperty(formId, INSTANCE_OF)
+					.withValue(clazz)
+					.build());
+		}
+		return FormUpdateBuilder.forEntityId(formId)
+				.updateStatements(statements.build())
+				.build();
+	}
+
+	@Test
+	public void testFormAddition() {
+		assertThrows(NullPointerException.class, () -> LexemeUpdateBuilder.forEntityId(L1).addForm(null));
+		LexemeUpdate update = LexemeUpdateBuilder.forEntityId(L1)
+				.addForm(form("swim")) // simple case
+				.addForm(form("swim")) // duplicates allowed
+				.addForm(form(2, "swimming")) // strip ID
+				.build();
+		assertEquals(Arrays.asList(form("swim"), form("swim"), form("swimming")), update.getAddedForms());
+	}
+
+	@Test
+	public void testBlindFormUpdate() {
+		assertThrows(NullPointerException.class, () -> LexemeUpdateBuilder.forEntityId(L1).updateForm(null));
+		// cannot update removed form
+		assertThrows(IllegalStateException.class, () -> LexemeUpdateBuilder.forEntityId(L1)
+				.removeForm(formId(1))
+				.updateForm(formUpdate(1, RARE)));
+		LexemeUpdate update = LexemeUpdateBuilder.forEntityId(L1)
+				.updateForm(formUpdate(1, OBSOLETE)) // simple case
+				.updateForm(formUpdate(2, RARE))
+				.updateForm(formUpdate(2, OBSOLETE)) // merge updates
+				.updateForm(formUpdate(3)) // empty update
+				.build();
+		assertThat(update.getRemovedForms(), is(empty()));
+		assertThat(update.getUpdatedForms().keySet(), containsInAnyOrder(formId(1), formId(2)));
+		assertEquals(formUpdate(1, OBSOLETE), update.getUpdatedForms().get(formId(1)));
+		assertEquals(formUpdate(2, RARE, OBSOLETE), update.getUpdatedForms().get(formId(2)));
+	}
+
+	@Test
+	public void testBaseFormUpdate() {
+		assertThrows(IllegalArgumentException.class,
+				() -> LexemeUpdateBuilder.forBaseRevision(LEXEME).updateForm(formUpdate(99, RARE)));
+		LexemeDocument base = LEXEME
+				.withForm(form(1, "swim"))
+				.withForm(form(2, "swims"))
+				.withForm(form(3, "swimming"))
+				.withForm(form(4, "swam"));
+		LexemeUpdate update = LexemeUpdateBuilder.forBaseRevision(base)
+				.updateForm(formUpdate(1, "swims")) // simple case
+				.updateForm(formUpdate(2, "swims")) // replace with the same
+				.updateForm(formUpdate(3, "swam"))
+				.updateForm(formUpdate(3, "swimming")) // revert previous update
+				.updateForm(formUpdate(4, RARE))
+				.updateForm(formUpdate(4, OBSOLETE)) // merge updates
+				.build();
+		assertThat(update.getRemovedForms(), is(empty()));
+		assertThat(update.getUpdatedForms().keySet(), containsInAnyOrder(formId(1), formId(4)));
+		assertEquals(withBase(base, formUpdate(1, "swims")), update.getUpdatedForms().get(formId(1)));
+		assertEquals(withBase(base, formUpdate(4, RARE, OBSOLETE)), update.getUpdatedForms().get(formId(4)));
+	}
+
+	@Test
+	public void testBlindFormRemoval() {
+		assertThrows(NullPointerException.class, () -> LexemeUpdateBuilder.forEntityId(L1).removeForm(null));
+		assertThrows(IllegalArgumentException.class,
+				() -> LexemeUpdateBuilder.forEntityId(L1).removeForm(FormIdValue.NULL));
+		LexemeUpdate update = LexemeUpdateBuilder.forEntityId(L1)
+				.updateForm(formUpdate(2, RARE))
+				.removeForm(formId(1)) // simple case
+				.removeForm(formId(2)) // previously updated
+				.removeForm(formId(3))
+				.removeForm(formId(3)) // duplicate removal allowed
+				.build();
+		assertThat(update.getRemovedForms(), containsInAnyOrder(formId(1), formId(2), formId(3)));
+		assertThat(update.getUpdatedForms(), is(anEmptyMap()));
+	}
+
+	@Test
+	public void testBaseFormRemoval() {
+		assertThrows(IllegalArgumentException.class,
+				() -> LexemeUpdateBuilder.forBaseRevision(LEXEME).removeForm(formId(1)));
+		LexemeUpdate update = LexemeUpdateBuilder
+				.forBaseRevision(LEXEME
+						.withForm(form(1, "swim"))
+						.withForm(form(2, "swims")))
+				.updateForm(formUpdate(2, RARE))
+				.removeForm(formId(1)) // simple case
+				.removeForm(formId(2)) // previously updated
+				.build();
+		assertThat(update.getRemovedForms(), containsInAnyOrder(formId(1), formId(2)));
+		assertThat(update.getUpdatedForms(), is(anEmptyMap()));
+	}
+
+	private static SenseDocument sense(String gloss) {
+		return Datamodel.makeSenseDocument(
+				SenseIdValue.NULL,
+				Arrays.asList(Datamodel.makeMonolingualTextValue(gloss, "en")),
+				Collections.emptyList());
+	}
+
+	private static SenseIdValue senseId(int id) {
+		return Datamodel.makeWikidataSenseIdValue("L1-S" + id);
+	}
+
+	private static SenseDocument sense(int id, String gloss) {
+		return sense(gloss).withEntityId(senseId(id));
+	}
+
+	private static SenseUpdate senseUpdate(int id, String gloss) {
+		return SenseUpdateBuilder.forEntityId(senseId(id))
+				.updateGlosses(TermUpdateBuilder.create()
+						.put(Datamodel.makeMonolingualTextValue(gloss, "en"))
+						.build())
+				.build();
+	}
+
+	private static SenseUpdate withBase(LexemeDocument base, SenseUpdate update) {
+		return SenseUpdateBuilder.forBaseRevision(base.getSense(update.getEntityId())).append(update).build();
+	}
+
+	private static SenseUpdate senseUpdate(int id, ItemIdValue... classes) {
+		SenseIdValue senseId = senseId(id);
+		StatementUpdateBuilder statements = StatementUpdateBuilder.create();
+		for (ItemIdValue clazz : classes) {
+			statements.add(StatementBuilder.forSubjectAndProperty(senseId, INSTANCE_OF)
+					.withValue(clazz)
+					.build());
+		}
+		return SenseUpdateBuilder.forEntityId(senseId)
+				.updateStatements(statements.build())
+				.build();
+	}
+
+	@Test
+	public void testSenseAddition() {
+		assertThrows(NullPointerException.class, () -> LexemeUpdateBuilder.forEntityId(L1).addSense(null));
+		LexemeUpdate update = LexemeUpdateBuilder.forEntityId(L1)
+				.addSense(sense("move")) // simple case
+				.addSense(sense("move")) // duplicates allowed
+				.addSense(sense(2, "immerse")) // strip ID
+				.build();
+		assertEquals(Arrays.asList(sense("move"), sense("move"), sense("immerse")), update.getAddedSenses());
+	}
+
+	@Test
+	public void testBlindSenseUpdate() {
+		assertThrows(NullPointerException.class, () -> LexemeUpdateBuilder.forEntityId(L1).updateSense(null));
+		// cannot update removed form
+		assertThrows(IllegalStateException.class, () -> LexemeUpdateBuilder.forEntityId(L1)
+				.removeSense(senseId(1))
+				.updateSense(senseUpdate(1, RARE)));
+		LexemeUpdate update = LexemeUpdateBuilder.forEntityId(L1)
+				.updateSense(senseUpdate(1, OBSOLETE)) // simple case
+				.updateSense(senseUpdate(2, RARE))
+				.updateSense(senseUpdate(2, OBSOLETE)) // merge updates
+				.updateSense(senseUpdate(3)) // empty update
+				.build();
+		assertThat(update.getRemovedSenses(), is(empty()));
+		assertThat(update.getUpdatedSenses().keySet(), containsInAnyOrder(senseId(1), senseId(2)));
+		assertEquals(senseUpdate(1, OBSOLETE), update.getUpdatedSenses().get(senseId(1)));
+		assertEquals(senseUpdate(2, RARE, OBSOLETE), update.getUpdatedSenses().get(senseId(2)));
+	}
+
+	@Test
+	public void testBaseSenseUpdate() {
+		assertThrows(IllegalArgumentException.class,
+				() -> LexemeUpdateBuilder.forBaseRevision(LEXEME).updateSense(senseUpdate(99, RARE)));
+		LexemeDocument base = LEXEME
+				.withSense(sense(1, "move"))
+				.withSense(sense(2, "immerse"))
+				.withSense(sense(3, "traverse"))
+				.withSense(sense(4, "float"));
+		LexemeUpdate update = LexemeUpdateBuilder.forBaseRevision(base)
+				.updateSense(senseUpdate(1, "move in water")) // simple case
+				.updateSense(senseUpdate(2, "immerse")) // replace with the same
+				.updateSense(senseUpdate(3, "traversal"))
+				.updateSense(senseUpdate(3, "traverse")) // revert previous update
+				.updateSense(senseUpdate(4, RARE))
+				.updateSense(senseUpdate(4, OBSOLETE)) // merge updates
+				.build();
+		assertThat(update.getRemovedSenses(), is(empty()));
+		assertThat(update.getUpdatedSenses().keySet(), containsInAnyOrder(senseId(1), senseId(4)));
+		assertEquals(withBase(base, senseUpdate(1, "move in water")), update.getUpdatedSenses().get(senseId(1)));
+		assertEquals(withBase(base, senseUpdate(4, RARE, OBSOLETE)), update.getUpdatedSenses().get(senseId(4)));
+	}
+
+	@Test
+	public void testBlindSenseRemoval() {
+		assertThrows(NullPointerException.class, () -> LexemeUpdateBuilder.forEntityId(L1).removeSense(null));
+		assertThrows(IllegalArgumentException.class,
+				() -> LexemeUpdateBuilder.forEntityId(L1).removeSense(SenseIdValue.NULL));
+		LexemeUpdate update = LexemeUpdateBuilder.forEntityId(L1)
+				.updateSense(senseUpdate(2, RARE))
+				.removeSense(senseId(1)) // simple case
+				.removeSense(senseId(2)) // previously updated
+				.removeSense(senseId(3))
+				.removeSense(senseId(3)) // duplicate removal allowed
+				.build();
+		assertThat(update.getRemovedSenses(), containsInAnyOrder(senseId(1), senseId(2), senseId(3)));
+		assertThat(update.getUpdatedSenses(), is(anEmptyMap()));
+	}
+
+	@Test
+	public void testBaseSenseRemoval() {
+		assertThrows(IllegalArgumentException.class,
+				() -> LexemeUpdateBuilder.forBaseRevision(LEXEME).removeSense(senseId(1)));
+		LexemeUpdate update = LexemeUpdateBuilder
+				.forBaseRevision(LEXEME
+						.withSense(sense(1, "move"))
+						.withSense(sense(2, "float")))
+				.updateSense(senseUpdate(2, RARE))
+				.removeSense(senseId(1)) // simple case
+				.removeSense(senseId(2)) // previously updated
+				.build();
+		assertThat(update.getRemovedSenses(), containsInAnyOrder(senseId(1), senseId(2)));
+		assertThat(update.getUpdatedSenses(), is(anEmptyMap()));
+	}
+
 	@Test
 	public void testMerge() {
 		assertThrows(NullPointerException.class, () -> LexemeUpdateBuilder.forEntityId(L1).append(null));
 		LexemeUpdate update = LexemeUpdateBuilder.forEntityId(L1)
 				.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())
 				.updateLemmas(TermUpdateBuilder.create().remove("en").build())
+				.addForm(form("swim"))
+				.updateForm(formUpdate(2, RARE))
+				.removeForm(formId(3))
+				.addSense(sense("move"))
+				.updateSense(senseUpdate(2, RARE))
+				.removeSense(senseId(3))
 				.append(LexemeUpdateBuilder.forEntityId(L1)
 						.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BLUE_EYES).build())
 						.updateLemmas(TermUpdateBuilder.create().remove("sk").build())
+						.addForm(form("swims"))
+						.updateForm(formUpdate(2, OBSOLETE))
+						.removeForm(formId(4))
+						.addSense(sense("float"))
+						.updateSense(senseUpdate(2, OBSOLETE))
+						.removeSense(senseId(4))
 						.build())
 				.build();
 		assertThat(update.getStatements().getAdded(),
 				containsInAnyOrder(JOHN_HAS_BROWN_HAIR, JOHN_HAS_BLUE_EYES));
 		assertThat(update.getLemmas().getRemoved(), containsInAnyOrder("en", "sk"));
+		assertEquals(Arrays.asList(form("swim"), form("swims")), update.getAddedForms());
+		assertThat(update.getUpdatedForms().keySet(), containsInAnyOrder(formId(2)));
+		assertEquals(formUpdate(2, RARE, OBSOLETE), update.getUpdatedForms().get(formId(2)));
+		assertThat(update.getRemovedForms(), containsInAnyOrder(formId(3), formId(4)));
+		assertEquals(Arrays.asList(sense("move"), sense("float")), update.getAddedSenses());
+		assertThat(update.getUpdatedSenses().keySet(), containsInAnyOrder(senseId(2)));
+		assertEquals(senseUpdate(2, RARE, OBSOLETE), update.getUpdatedSenses().get(senseId(2)));
+		assertThat(update.getRemovedSenses(), containsInAnyOrder(senseId(3), senseId(4)));
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilderTest.java
@@ -75,6 +75,11 @@ public class LexemeUpdateBuilderTest {
 	}
 
 	@Test
+	public void testForBaseRevisionId() {
+		assertEquals(123, LexemeUpdateBuilder.forBaseRevisionId(L1, 123).getBaseRevisionId());
+	}
+
+	@Test
 	public void testForBaseRevision() {
 		assertThrows(NullPointerException.class, () -> LexemeUpdateBuilder.forBaseRevision(null));
 		assertThrows(IllegalArgumentException.class,

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilderTest.java
@@ -1,0 +1,158 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.helpers;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.LexemeDocument;
+import org.wikidata.wdtk.datamodel.interfaces.LexemeIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.LexemeUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
+
+public class LexemeUpdateBuilderTest {
+
+	private static final LexemeIdValue L1 = EntityUpdateBuilderTest.L1;
+	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateBuilderTest.JOHN_HAS_BROWN_HAIR;
+	private static final Statement JOHN_HAS_BLUE_EYES = StatementUpdateBuilderTest.JOHN_HAS_BLUE_EYES;
+	private static final MonolingualTextValue EN = TermUpdateBuilderTest.EN;
+	private static final MonolingualTextValue SK = TermUpdateBuilderTest.SK;
+	private static final ItemIdValue Q1 = EntityUpdateBuilderTest.Q1;
+	private static final ItemIdValue Q2 = Datamodel.makeWikidataItemIdValue("Q2");
+	private static final ItemIdValue Q3 = Datamodel.makeWikidataItemIdValue("Q3");
+	private static final LexemeDocument LEXEME = Datamodel.makeLexemeDocument(L1, Q1, Q2, Arrays.asList(EN));
+
+	@Test
+	public void testForEntityId() {
+		assertThrows(NullPointerException.class, () -> LexemeUpdateBuilder.forEntityId(null));
+		assertThrows(IllegalArgumentException.class, () -> LexemeUpdateBuilder.forEntityId(LexemeIdValue.NULL));
+		LexemeUpdateBuilder.forEntityId(L1);
+	}
+
+	@Test
+	public void testForBaseRevision() {
+		assertThrows(NullPointerException.class, () -> LexemeUpdateBuilder.forBaseRevision(null));
+		assertThrows(IllegalArgumentException.class,
+				() -> LexemeUpdateBuilder.forBaseRevision(LEXEME.withEntityId(LexemeIdValue.NULL)));
+		LexemeUpdateBuilder.forBaseRevision(LEXEME);
+	}
+
+	@Test
+	public void testStatementUpdate() {
+		LexemeUpdate update = LexemeUpdateBuilder.forEntityId(L1)
+				.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())
+				.build();
+		assertThat(update.getStatements().getAdded(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
+	}
+
+	@Test
+	public void testLanguageChange() {
+		assertThrows(NullPointerException.class, () -> LexemeUpdateBuilder.forEntityId(L1).setLanguage(null));
+		assertThrows(IllegalArgumentException.class,
+				() -> LexemeUpdateBuilder.forEntityId(L1).setLanguage(ItemIdValue.NULL));
+		assertEquals(Q3, LexemeUpdateBuilder.forEntityId(L1).setLanguage(Q3).build().getLanguage().get());
+		// different value
+		assertEquals(Q3, LexemeUpdateBuilder.forBaseRevision(LEXEME).setLanguage(Q3).build().getLanguage().get());
+		// same value
+		assertFalse(LexemeUpdateBuilder.forBaseRevision(LEXEME).setLanguage(Q2).build().getLanguage().isPresent());
+		// restore previous value
+		assertFalse(LexemeUpdateBuilder.forBaseRevision(LEXEME)
+				.setLanguage(Q3)
+				.setLanguage(Q2)
+				.build()
+				.getLanguage().isPresent());
+	}
+
+	@Test
+	public void testLexicalCategoryChange() {
+		assertThrows(NullPointerException.class, () -> LexemeUpdateBuilder.forEntityId(L1).setLexicalCategory(null));
+		assertThrows(IllegalArgumentException.class,
+				() -> LexemeUpdateBuilder.forEntityId(L1).setLexicalCategory(ItemIdValue.NULL));
+		assertEquals(Q3, LexemeUpdateBuilder.forEntityId(L1).setLexicalCategory(Q3).build().getLexicalCategory().get());
+		// different value
+		assertEquals(Q3, LexemeUpdateBuilder.forBaseRevision(LEXEME)
+				.setLexicalCategory(Q3)
+				.build()
+				.getLexicalCategory().get());
+		// same value
+		assertFalse(LexemeUpdateBuilder.forBaseRevision(LEXEME)
+				.setLexicalCategory(Q1)
+				.build()
+				.getLexicalCategory().isPresent());
+		// restore previous value
+		assertFalse(LexemeUpdateBuilder.forBaseRevision(LEXEME)
+				.setLexicalCategory(Q3)
+				.setLexicalCategory(Q1)
+				.build()
+				.getLexicalCategory().isPresent());
+	}
+
+	@Test
+	public void testBlindLemmaUpdate() {
+		assertThrows(NullPointerException.class, () -> LexemeUpdateBuilder.forEntityId(L1).updateLemmas(null));
+		LexemeUpdate update = LexemeUpdateBuilder.forEntityId(L1)
+				.updateLemmas(TermUpdateBuilder.create().remove("en").build())
+				.updateLemmas(TermUpdateBuilder.create().remove("sk").build())
+				.build();
+		assertThat(update.getLemmas().getRemoved(), containsInAnyOrder("en", "sk"));
+	}
+
+	@Test
+	public void testBaseLemmaUpdate() {
+		LexemeUpdate update = LexemeUpdateBuilder
+				.forBaseRevision(LEXEME
+						.withLemma(EN)
+						.withLemma(SK))
+				.updateLemmas(TermUpdateBuilder.create()
+						.put(SK) // ignored
+						.remove("en") // checked
+						.build())
+				.build();
+		assertThat(update.getLemmas().getModified(), is(anEmptyMap()));
+		assertThat(update.getLemmas().getRemoved(), containsInAnyOrder("en"));
+	}
+
+	@Test
+	public void testMerge() {
+		assertThrows(NullPointerException.class, () -> LexemeUpdateBuilder.forEntityId(L1).append(null));
+		LexemeUpdate update = LexemeUpdateBuilder.forEntityId(L1)
+				.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())
+				.updateLemmas(TermUpdateBuilder.create().remove("en").build())
+				.append(LexemeUpdateBuilder.forEntityId(L1)
+						.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BLUE_EYES).build())
+						.updateLemmas(TermUpdateBuilder.create().remove("sk").build())
+						.build())
+				.build();
+		assertThat(update.getStatements().getAdded(),
+				containsInAnyOrder(JOHN_HAS_BROWN_HAIR, JOHN_HAS_BLUE_EYES));
+		assertThat(update.getLemmas().getRemoved(), containsInAnyOrder("en", "sk"));
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/MediaInfoUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/MediaInfoUpdateBuilderTest.java
@@ -1,0 +1,80 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.helpers;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.interfaces.MediaInfoDocument;
+import org.wikidata.wdtk.datamodel.interfaces.MediaInfoIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.MediaInfoUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
+
+public class MediaInfoUpdateBuilderTest {
+
+	private static final MediaInfoIdValue M1 = EntityUpdateBuilderTest.M1;
+	private static final MediaInfoDocument MEDIA = EntityUpdateBuilderTest.MEDIA;
+	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateBuilderTest.JOHN_HAS_BROWN_HAIR;
+
+	@Test
+	public void testForEntityId() {
+		assertThrows(NullPointerException.class, () -> MediaInfoUpdateBuilder.forEntityId(null));
+		assertThrows(IllegalArgumentException.class, () -> MediaInfoUpdateBuilder.forEntityId(MediaInfoIdValue.NULL));
+		MediaInfoUpdateBuilder.forEntityId(M1);
+	}
+
+	@Test
+	public void testForBaseRevision() {
+		assertThrows(NullPointerException.class, () -> MediaInfoUpdateBuilder.forBaseRevision(null));
+		assertThrows(IllegalArgumentException.class,
+				() -> MediaInfoUpdateBuilder.forBaseRevision(Datamodel.makeMediaInfoDocument(MediaInfoIdValue.NULL)));
+		MediaInfoUpdateBuilder.forBaseRevision(MEDIA);
+	}
+
+	@Test
+	public void testStatementUpdate() {
+		MediaInfoUpdate update = MediaInfoUpdateBuilder.forEntityId(M1)
+				.updateStatements(StatementUpdateBuilder.create().addStatement(JOHN_HAS_BROWN_HAIR).build())
+				.build();
+		assertThat(update.getStatements().getAddedStatements(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
+	}
+
+	@Test
+	public void testLabelUpdate() {
+		MediaInfoUpdate update = MediaInfoUpdateBuilder.forEntityId(M1)
+				.updateLabels(TermUpdateBuilder.create().removeTerm("en").build())
+				.build();
+		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("en"));
+	}
+
+	@Test
+	public void testMerge() {
+		MediaInfoUpdate update = MediaInfoUpdateBuilder.forEntityId(M1)
+				.updateLabels(TermUpdateBuilder.create().removeTerm("en").build())
+				.apply(MediaInfoUpdateBuilder.forEntityId(M1)
+						.updateLabels(TermUpdateBuilder.create().removeTerm("sk").build())
+						.build())
+				.build();
+		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("sk", "en"));
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/MediaInfoUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/MediaInfoUpdateBuilderTest.java
@@ -21,6 +21,7 @@ package org.wikidata.wdtk.datamodel.helpers;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,11 @@ public class MediaInfoUpdateBuilderTest {
 		assertThrows(NullPointerException.class, () -> MediaInfoUpdateBuilder.forEntityId(null));
 		assertThrows(IllegalArgumentException.class, () -> MediaInfoUpdateBuilder.forEntityId(MediaInfoIdValue.NULL));
 		MediaInfoUpdateBuilder.forEntityId(M1);
+	}
+
+	@Test
+	public void testForBaseRevisionId() {
+		assertEquals(123, MediaInfoUpdateBuilder.forBaseRevisionId(M1, 123).getBaseRevisionId());
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/MediaInfoUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/MediaInfoUpdateBuilderTest.java
@@ -53,28 +53,28 @@ public class MediaInfoUpdateBuilderTest {
 	@Test
 	public void testStatementUpdate() {
 		MediaInfoUpdate update = MediaInfoUpdateBuilder.forEntityId(M1)
-				.updateStatements(StatementUpdateBuilder.create().addStatement(JOHN_HAS_BROWN_HAIR).build())
+				.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())
 				.build();
-		assertThat(update.getStatements().getAddedStatements(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
+		assertThat(update.getStatements().getAdded(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
 	}
 
 	@Test
 	public void testLabelUpdate() {
 		MediaInfoUpdate update = MediaInfoUpdateBuilder.forEntityId(M1)
-				.updateLabels(TermUpdateBuilder.create().removeTerm("en").build())
+				.updateLabels(TermUpdateBuilder.create().remove("en").build())
 				.build();
-		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("en"));
+		assertThat(update.getLabels().getRemoved(), containsInAnyOrder("en"));
 	}
 
 	@Test
 	public void testMerge() {
 		MediaInfoUpdate update = MediaInfoUpdateBuilder.forEntityId(M1)
-				.updateLabels(TermUpdateBuilder.create().removeTerm("en").build())
+				.updateLabels(TermUpdateBuilder.create().remove("en").build())
 				.apply(MediaInfoUpdateBuilder.forEntityId(M1)
-						.updateLabels(TermUpdateBuilder.create().removeTerm("sk").build())
+						.updateLabels(TermUpdateBuilder.create().remove("sk").build())
 						.build())
 				.build();
-		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("sk", "en"));
+		assertThat(update.getLabels().getRemoved(), containsInAnyOrder("sk", "en"));
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/MediaInfoUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/MediaInfoUpdateBuilderTest.java
@@ -33,7 +33,10 @@ public class MediaInfoUpdateBuilderTest {
 
 	private static final MediaInfoIdValue M1 = EntityUpdateBuilderTest.M1;
 	private static final MediaInfoDocument MEDIA = EntityUpdateBuilderTest.MEDIA;
-	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateBuilderTest.JOHN_HAS_BROWN_HAIR;
+	private static final Statement M1_DESCRIBES_SOMETHING = StatementBuilder
+			.forSubjectAndProperty(M1, Datamodel.makeWikidataPropertyIdValue("P1"))
+			.withValue(Datamodel.makeStringValue("something"))
+			.build();
 
 	@Test
 	public void testForEntityId() {
@@ -53,9 +56,9 @@ public class MediaInfoUpdateBuilderTest {
 	@Test
 	public void testStatementUpdate() {
 		MediaInfoUpdate update = MediaInfoUpdateBuilder.forEntityId(M1)
-				.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())
+				.updateStatements(StatementUpdateBuilder.create().add(M1_DESCRIBES_SOMETHING).build())
 				.build();
-		assertThat(update.getStatements().getAdded(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
+		assertThat(update.getStatements().getAdded(), containsInAnyOrder(M1_DESCRIBES_SOMETHING));
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilderTest.java
@@ -21,6 +21,7 @@ package org.wikidata.wdtk.datamodel.helpers;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
@@ -48,6 +49,11 @@ public class PropertyUpdateBuilderTest {
 		assertThrows(NullPointerException.class, () -> PropertyUpdateBuilder.forEntityId(null));
 		assertThrows(IllegalArgumentException.class, () -> PropertyUpdateBuilder.forEntityId(PropertyIdValue.NULL));
 		PropertyUpdateBuilder.forEntityId(P1);
+	}
+
+	@Test
+	public void testForBaseRevisionId() {
+		assertEquals(123, PropertyUpdateBuilder.forBaseRevisionId(P1, 123).getBaseRevisionId());
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilderTest.java
@@ -24,11 +24,8 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.Arrays;
-
 import org.junit.jupiter.api.Test;
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyUpdate;
@@ -42,7 +39,6 @@ public class PropertyUpdateBuilderTest {
 			.forSubjectAndProperty(P1, Datamodel.makeWikidataPropertyIdValue("P2"))
 			.withValue(Datamodel.makeStringValue("something"))
 			.build();
-	private static final MonolingualTextValue SK = TermUpdateBuilderTest.SK;
 
 	@Test
 	public void testForEntityId() {
@@ -93,10 +89,9 @@ public class PropertyUpdateBuilderTest {
 	@Test
 	public void testAliasUpdate() {
 		PropertyUpdate update = PropertyUpdateBuilder.forEntityId(P1)
-				.putAliases("sk", Arrays.asList(SK))
-				.putAliasesAsStrings("en", Arrays.asList("hello"))
+				.updateAliases("sk", AliasUpdateBuilder.create().add(TermUpdateBuilderTest.SK).build())
 				.build();
-		assertThat(update.getAliases().keySet(), containsInAnyOrder("en", "sk"));
+		assertThat(update.getAliases().keySet(), containsInAnyOrder("sk"));
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilderTest.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyUpdate;
@@ -37,6 +38,7 @@ public class PropertyUpdateBuilderTest {
 	private static final PropertyIdValue P1 = EntityUpdateBuilderTest.P1;
 	private static final PropertyDocument PROPERTY = EntityUpdateBuilderTest.PROPERTY;
 	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateBuilderTest.JOHN_HAS_BROWN_HAIR;
+	private static final MonolingualTextValue SK = TermUpdateBuilderTest.SK;
 
 	@Test
 	public void testForEntityId() {
@@ -58,44 +60,45 @@ public class PropertyUpdateBuilderTest {
 	@Test
 	public void testStatementUpdate() {
 		PropertyUpdate update = PropertyUpdateBuilder.forEntityId(P1)
-				.updateStatements(StatementUpdateBuilder.create().addStatement(JOHN_HAS_BROWN_HAIR).build())
+				.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())
 				.build();
-		assertThat(update.getStatements().getAddedStatements(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
+		assertThat(update.getStatements().getAdded(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
 	}
 
 	@Test
 	public void testLabelUpdate() {
 		PropertyUpdate update = PropertyUpdateBuilder.forEntityId(P1)
-				.updateLabels(TermUpdateBuilder.create().removeTerm("en").build())
+				.updateLabels(TermUpdateBuilder.create().remove("en").build())
 				.build();
-		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("en"));
+		assertThat(update.getLabels().getRemoved(), containsInAnyOrder("en"));
 	}
 
 	@Test
 	public void testDescriptionUpdate() {
 		PropertyUpdate update = PropertyUpdateBuilder.forEntityId(P1)
-				.updateDescriptions(TermUpdateBuilder.create().removeTerm("en").build())
+				.updateDescriptions(TermUpdateBuilder.create().remove("en").build())
 				.build();
-		assertThat(update.getDescriptions().getRemovedTerms(), containsInAnyOrder("en"));
+		assertThat(update.getDescriptions().getRemoved(), containsInAnyOrder("en"));
 	}
 
 	@Test
 	public void testAliasUpdate() {
 		PropertyUpdate update = PropertyUpdateBuilder.forEntityId(P1)
-				.setAliases("en", Arrays.asList("hello"))
+				.putAliases("sk", Arrays.asList(SK))
+				.putAliasesAsStrings("en", Arrays.asList("hello"))
 				.build();
-		assertThat(update.getAliases().keySet(), containsInAnyOrder("en"));
+		assertThat(update.getAliases().keySet(), containsInAnyOrder("en", "sk"));
 	}
 
 	@Test
 	public void testMerge() {
 		PropertyUpdate update = PropertyUpdateBuilder.forEntityId(P1)
-				.updateDescriptions(TermUpdateBuilder.create().removeTerm("en").build())
-				.apply(PropertyUpdateBuilder.forEntityId(P1)
-						.updateDescriptions(TermUpdateBuilder.create().removeTerm("sk").build())
+				.updateDescriptions(TermUpdateBuilder.create().remove("en").build())
+				.append(PropertyUpdateBuilder.forEntityId(P1)
+						.updateDescriptions(TermUpdateBuilder.create().remove("sk").build())
 						.build())
 				.build();
-		assertThat(update.getDescriptions().getRemovedTerms(), containsInAnyOrder("sk", "en"));
+		assertThat(update.getDescriptions().getRemoved(), containsInAnyOrder("sk", "en"));
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilderTest.java
@@ -37,7 +37,10 @@ public class PropertyUpdateBuilderTest {
 
 	private static final PropertyIdValue P1 = EntityUpdateBuilderTest.P1;
 	private static final PropertyDocument PROPERTY = EntityUpdateBuilderTest.PROPERTY;
-	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateBuilderTest.JOHN_HAS_BROWN_HAIR;
+	private static final Statement P1_DESCRIBES_SOMETHING = StatementBuilder
+			.forSubjectAndProperty(P1, Datamodel.makeWikidataPropertyIdValue("P2"))
+			.withValue(Datamodel.makeStringValue("something"))
+			.build();
 	private static final MonolingualTextValue SK = TermUpdateBuilderTest.SK;
 
 	@Test
@@ -60,9 +63,9 @@ public class PropertyUpdateBuilderTest {
 	@Test
 	public void testStatementUpdate() {
 		PropertyUpdate update = PropertyUpdateBuilder.forEntityId(P1)
-				.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())
+				.updateStatements(StatementUpdateBuilder.create().add(P1_DESCRIBES_SOMETHING).build())
 				.build();
-		assertThat(update.getStatements().getAdded(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
+		assertThat(update.getStatements().getAdded(), containsInAnyOrder(P1_DESCRIBES_SOMETHING));
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilderTest.java
@@ -1,0 +1,101 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.helpers;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
+
+public class PropertyUpdateBuilderTest {
+
+	private static final PropertyIdValue P1 = EntityUpdateBuilderTest.P1;
+	private static final PropertyDocument PROPERTY = EntityUpdateBuilderTest.PROPERTY;
+	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateBuilderTest.JOHN_HAS_BROWN_HAIR;
+
+	@Test
+	public void testForEntityId() {
+		assertThrows(NullPointerException.class, () -> PropertyUpdateBuilder.forEntityId(null));
+		assertThrows(IllegalArgumentException.class, () -> PropertyUpdateBuilder.forEntityId(PropertyIdValue.NULL));
+		PropertyUpdateBuilder.forEntityId(P1);
+	}
+
+	@Test
+	public void testForBaseRevision() {
+		assertThrows(NullPointerException.class, () -> PropertyUpdateBuilder.forBaseRevision(null));
+		assertThrows(IllegalArgumentException.class, () -> PropertyUpdateBuilder.forBaseRevision(
+				Datamodel.makePropertyDocument(
+						PropertyIdValue.NULL,
+						Datamodel.makeDatatypeIdValue(DatatypeIdValue.DT_ITEM))));
+		PropertyUpdateBuilder.forBaseRevision(PROPERTY);
+	}
+
+	@Test
+	public void testStatementUpdate() {
+		PropertyUpdate update = PropertyUpdateBuilder.forEntityId(P1)
+				.updateStatements(StatementUpdateBuilder.create().addStatement(JOHN_HAS_BROWN_HAIR).build())
+				.build();
+		assertThat(update.getStatements().getAddedStatements(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
+	}
+
+	@Test
+	public void testLabelUpdate() {
+		PropertyUpdate update = PropertyUpdateBuilder.forEntityId(P1)
+				.updateLabels(TermUpdateBuilder.create().removeTerm("en").build())
+				.build();
+		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("en"));
+	}
+
+	@Test
+	public void testDescriptionUpdate() {
+		PropertyUpdate update = PropertyUpdateBuilder.forEntityId(P1)
+				.updateDescriptions(TermUpdateBuilder.create().removeTerm("en").build())
+				.build();
+		assertThat(update.getDescriptions().getRemovedTerms(), containsInAnyOrder("en"));
+	}
+
+	@Test
+	public void testAliasUpdate() {
+		PropertyUpdate update = PropertyUpdateBuilder.forEntityId(P1)
+				.setAliases("en", Arrays.asList("hello"))
+				.build();
+		assertThat(update.getAliases().keySet(), containsInAnyOrder("en"));
+	}
+
+	@Test
+	public void testMerge() {
+		PropertyUpdate update = PropertyUpdateBuilder.forEntityId(P1)
+				.updateDescriptions(TermUpdateBuilder.create().removeTerm("en").build())
+				.apply(PropertyUpdateBuilder.forEntityId(P1)
+						.updateDescriptions(TermUpdateBuilder.create().removeTerm("sk").build())
+						.build())
+				.build();
+		assertThat(update.getDescriptions().getRemovedTerms(), containsInAnyOrder("sk", "en"));
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/SenseUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/SenseUpdateBuilderTest.java
@@ -1,0 +1,108 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.helpers;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+import org.wikidata.wdtk.datamodel.interfaces.SenseDocument;
+import org.wikidata.wdtk.datamodel.interfaces.SenseIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.SenseUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
+
+public class SenseUpdateBuilderTest {
+
+	private static final SenseIdValue S1 = EntityUpdateBuilderTest.S1;
+	private static final SenseDocument SENSE = EntityUpdateBuilderTest.SENSE;
+	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateBuilderTest.JOHN_HAS_BROWN_HAIR;
+	private static final Statement JOHN_HAS_BLUE_EYES = StatementUpdateBuilderTest.JOHN_HAS_BLUE_EYES;
+	private static final MonolingualTextValue EN = TermUpdateBuilderTest.EN;
+	private static final MonolingualTextValue SK = TermUpdateBuilderTest.SK;
+
+	@Test
+	public void testForEntityId() {
+		assertThrows(NullPointerException.class, () -> SenseUpdateBuilder.forEntityId(null));
+		assertThrows(IllegalArgumentException.class, () -> SenseUpdateBuilder.forEntityId(SenseIdValue.NULL));
+		SenseUpdateBuilder.forEntityId(S1);
+	}
+
+	@Test
+	public void testForBaseRevision() {
+		assertThrows(NullPointerException.class, () -> SenseUpdateBuilder.forBaseRevision(null));
+		assertThrows(IllegalArgumentException.class,
+				() -> SenseUpdateBuilder.forBaseRevision(SENSE.withEntityId(SenseIdValue.NULL)));
+		SenseUpdateBuilder.forBaseRevision(SENSE);
+	}
+
+	@Test
+	public void testStatementUpdate() {
+		SenseUpdate update = SenseUpdateBuilder.forEntityId(S1)
+				.updateStatements(StatementUpdateBuilder.create().addStatement(JOHN_HAS_BROWN_HAIR).build())
+				.build();
+		assertThat(update.getStatements().getAddedStatements(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
+	}
+
+	@Test
+	public void testBlindSenseUpdate() {
+		assertThrows(NullPointerException.class, () -> SenseUpdateBuilder.forEntityId(S1).updateGlosses(null));
+		SenseUpdate update = SenseUpdateBuilder.forEntityId(S1)
+				.updateGlosses(TermUpdateBuilder.create().removeTerm("en").build())
+				.updateGlosses(TermUpdateBuilder.create().removeTerm("sk").build())
+				.build();
+		assertThat(update.getGlosses().getRemovedTerms(), containsInAnyOrder("en", "sk"));
+	}
+
+	@Test
+	public void testBaseSenseUpdate() {
+		SenseUpdate update = SenseUpdateBuilder
+				.forBaseRevision(SENSE
+						.withGloss(EN)
+						.withGloss(SK))
+				.updateGlosses(TermUpdateBuilder.create()
+						.setTerm(SK) // ignored
+						.removeTerm("en") // checked
+						.build())
+				.build();
+		assertThat(update.getGlosses().getModifiedTerms(), is(anEmptyMap()));
+		assertThat(update.getGlosses().getRemovedTerms(), containsInAnyOrder("en"));
+	}
+
+	@Test
+	public void testMerge() {
+		assertThrows(NullPointerException.class, () -> SenseUpdateBuilder.forEntityId(S1).apply(null));
+		SenseUpdate update = SenseUpdateBuilder.forEntityId(S1)
+				.updateStatements(StatementUpdateBuilder.create().addStatement(JOHN_HAS_BROWN_HAIR).build())
+				.updateGlosses(TermUpdateBuilder.create().removeTerm("en").build())
+				.apply(SenseUpdateBuilder.forEntityId(S1)
+						.updateStatements(StatementUpdateBuilder.create().addStatement(JOHN_HAS_BLUE_EYES).build())
+						.updateGlosses(TermUpdateBuilder.create().removeTerm("sk").build())
+						.build())
+				.build();
+		assertThat(update.getStatements().getAddedStatements(),
+				containsInAnyOrder(JOHN_HAS_BROWN_HAIR, JOHN_HAS_BLUE_EYES));
+		assertThat(update.getGlosses().getRemovedTerms(), containsInAnyOrder("en", "sk"));
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/SenseUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/SenseUpdateBuilderTest.java
@@ -65,7 +65,7 @@ public class SenseUpdateBuilderTest {
 	}
 
 	@Test
-	public void testBlindSenseUpdate() {
+	public void testBlindGlossUpdate() {
 		assertThrows(NullPointerException.class, () -> SenseUpdateBuilder.forEntityId(S1).updateGlosses(null));
 		SenseUpdate update = SenseUpdateBuilder.forEntityId(S1)
 				.updateGlosses(TermUpdateBuilder.create().remove("en").build())
@@ -75,7 +75,7 @@ public class SenseUpdateBuilderTest {
 	}
 
 	@Test
-	public void testBaseSenseUpdate() {
+	public void testBaseGlossUpdate() {
 		SenseUpdate update = SenseUpdateBuilder
 				.forBaseRevision(SENSE
 						.withGloss(EN)

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/SenseUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/SenseUpdateBuilderTest.java
@@ -36,8 +36,14 @@ public class SenseUpdateBuilderTest {
 
 	private static final SenseIdValue S1 = EntityUpdateBuilderTest.S1;
 	private static final SenseDocument SENSE = EntityUpdateBuilderTest.SENSE;
-	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateBuilderTest.JOHN_HAS_BROWN_HAIR;
-	private static final Statement JOHN_HAS_BLUE_EYES = StatementUpdateBuilderTest.JOHN_HAS_BLUE_EYES;
+	private static final Statement S1_DESCRIBES_SOMETHING = StatementBuilder
+			.forSubjectAndProperty(S1, Datamodel.makeWikidataPropertyIdValue("P1"))
+			.withValue(Datamodel.makeStringValue("something"))
+			.build();
+	private static final Statement S1_EVOKES_FEELING = StatementBuilder
+			.forSubjectAndProperty(S1, Datamodel.makeWikidataPropertyIdValue("P2"))
+			.withValue(Datamodel.makeStringValue("feeling"))
+			.build();
 	private static final MonolingualTextValue EN = TermUpdateBuilderTest.EN;
 	private static final MonolingualTextValue SK = TermUpdateBuilderTest.SK;
 
@@ -59,9 +65,9 @@ public class SenseUpdateBuilderTest {
 	@Test
 	public void testStatementUpdate() {
 		SenseUpdate update = SenseUpdateBuilder.forEntityId(S1)
-				.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())
+				.updateStatements(StatementUpdateBuilder.create().add(S1_DESCRIBES_SOMETHING).build())
 				.build();
-		assertThat(update.getStatements().getAdded(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
+		assertThat(update.getStatements().getAdded(), containsInAnyOrder(S1_DESCRIBES_SOMETHING));
 	}
 
 	@Test
@@ -93,15 +99,15 @@ public class SenseUpdateBuilderTest {
 	public void testMerge() {
 		assertThrows(NullPointerException.class, () -> SenseUpdateBuilder.forEntityId(S1).append(null));
 		SenseUpdate update = SenseUpdateBuilder.forEntityId(S1)
-				.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())
+				.updateStatements(StatementUpdateBuilder.create().add(S1_DESCRIBES_SOMETHING).build())
 				.updateGlosses(TermUpdateBuilder.create().remove("en").build())
 				.append(SenseUpdateBuilder.forEntityId(S1)
-						.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BLUE_EYES).build())
+						.updateStatements(StatementUpdateBuilder.create().add(S1_EVOKES_FEELING).build())
 						.updateGlosses(TermUpdateBuilder.create().remove("sk").build())
 						.build())
 				.build();
 		assertThat(update.getStatements().getAdded(),
-				containsInAnyOrder(JOHN_HAS_BROWN_HAIR, JOHN_HAS_BLUE_EYES));
+				containsInAnyOrder(S1_DESCRIBES_SOMETHING, S1_EVOKES_FEELING));
 		assertThat(update.getGlosses().getRemoved(), containsInAnyOrder("en", "sk"));
 	}
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/SenseUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/SenseUpdateBuilderTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -52,6 +53,11 @@ public class SenseUpdateBuilderTest {
 		assertThrows(NullPointerException.class, () -> SenseUpdateBuilder.forEntityId(null));
 		assertThrows(IllegalArgumentException.class, () -> SenseUpdateBuilder.forEntityId(SenseIdValue.NULL));
 		SenseUpdateBuilder.forEntityId(S1);
+	}
+
+	@Test
+	public void testForBaseRevisionId() {
+		assertEquals(123, SenseUpdateBuilder.forBaseRevisionId(S1, 123).getBaseRevisionId());
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/SenseUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/SenseUpdateBuilderTest.java
@@ -59,19 +59,19 @@ public class SenseUpdateBuilderTest {
 	@Test
 	public void testStatementUpdate() {
 		SenseUpdate update = SenseUpdateBuilder.forEntityId(S1)
-				.updateStatements(StatementUpdateBuilder.create().addStatement(JOHN_HAS_BROWN_HAIR).build())
+				.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())
 				.build();
-		assertThat(update.getStatements().getAddedStatements(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
+		assertThat(update.getStatements().getAdded(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
 	}
 
 	@Test
 	public void testBlindSenseUpdate() {
 		assertThrows(NullPointerException.class, () -> SenseUpdateBuilder.forEntityId(S1).updateGlosses(null));
 		SenseUpdate update = SenseUpdateBuilder.forEntityId(S1)
-				.updateGlosses(TermUpdateBuilder.create().removeTerm("en").build())
-				.updateGlosses(TermUpdateBuilder.create().removeTerm("sk").build())
+				.updateGlosses(TermUpdateBuilder.create().remove("en").build())
+				.updateGlosses(TermUpdateBuilder.create().remove("sk").build())
 				.build();
-		assertThat(update.getGlosses().getRemovedTerms(), containsInAnyOrder("en", "sk"));
+		assertThat(update.getGlosses().getRemoved(), containsInAnyOrder("en", "sk"));
 	}
 
 	@Test
@@ -81,28 +81,28 @@ public class SenseUpdateBuilderTest {
 						.withGloss(EN)
 						.withGloss(SK))
 				.updateGlosses(TermUpdateBuilder.create()
-						.setTerm(SK) // ignored
-						.removeTerm("en") // checked
+						.put(SK) // ignored
+						.remove("en") // checked
 						.build())
 				.build();
-		assertThat(update.getGlosses().getModifiedTerms(), is(anEmptyMap()));
-		assertThat(update.getGlosses().getRemovedTerms(), containsInAnyOrder("en"));
+		assertThat(update.getGlosses().getModified(), is(anEmptyMap()));
+		assertThat(update.getGlosses().getRemoved(), containsInAnyOrder("en"));
 	}
 
 	@Test
 	public void testMerge() {
-		assertThrows(NullPointerException.class, () -> SenseUpdateBuilder.forEntityId(S1).apply(null));
+		assertThrows(NullPointerException.class, () -> SenseUpdateBuilder.forEntityId(S1).append(null));
 		SenseUpdate update = SenseUpdateBuilder.forEntityId(S1)
-				.updateStatements(StatementUpdateBuilder.create().addStatement(JOHN_HAS_BROWN_HAIR).build())
-				.updateGlosses(TermUpdateBuilder.create().removeTerm("en").build())
-				.apply(SenseUpdateBuilder.forEntityId(S1)
-						.updateStatements(StatementUpdateBuilder.create().addStatement(JOHN_HAS_BLUE_EYES).build())
-						.updateGlosses(TermUpdateBuilder.create().removeTerm("sk").build())
+				.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())
+				.updateGlosses(TermUpdateBuilder.create().remove("en").build())
+				.append(SenseUpdateBuilder.forEntityId(S1)
+						.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BLUE_EYES).build())
+						.updateGlosses(TermUpdateBuilder.create().remove("sk").build())
 						.build())
 				.build();
-		assertThat(update.getStatements().getAddedStatements(),
+		assertThat(update.getStatements().getAdded(),
 				containsInAnyOrder(JOHN_HAS_BROWN_HAIR, JOHN_HAS_BLUE_EYES));
-		assertThat(update.getGlosses().getRemovedTerms(), containsInAnyOrder("en", "sk"));
+		assertThat(update.getGlosses().getRemoved(), containsInAnyOrder("en", "sk"));
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilderTest.java
@@ -1,0 +1,139 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.helpers;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
+import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
+import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.LexemeDocument;
+import org.wikidata.wdtk.datamodel.interfaces.LexemeIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.MediaInfoDocument;
+import org.wikidata.wdtk.datamodel.interfaces.MediaInfoIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.SenseDocument;
+import org.wikidata.wdtk.datamodel.interfaces.SenseIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
+import org.wikidata.wdtk.datamodel.interfaces.StatementDocumentUpdate;
+
+public class StatementDocumentUpdateBuilderTest {
+
+	private static final ItemIdValue Q1 = EntityUpdateBuilderTest.Q1;
+	private static final PropertyIdValue P1 = EntityUpdateBuilderTest.P1;
+	private static final MediaInfoIdValue M1 = EntityUpdateBuilderTest.M1;
+	private static final LexemeIdValue L1 = EntityUpdateBuilderTest.L1;
+	private static final FormIdValue F1 = EntityUpdateBuilderTest.F1;
+	private static final SenseIdValue S1 = EntityUpdateBuilderTest.S1;
+	private static final ItemDocument ITEM = EntityUpdateBuilderTest.ITEM;
+	private static final PropertyDocument PROPERTY = EntityUpdateBuilderTest.PROPERTY;
+	private static final MediaInfoDocument MEDIA = EntityUpdateBuilderTest.MEDIA;
+	private static final LexemeDocument LEXEME = EntityUpdateBuilderTest.LEXEME;
+	private static final FormDocument FORM = EntityUpdateBuilderTest.FORM;
+	private static final SenseDocument SENSE = EntityUpdateBuilderTest.SENSE;
+	private static final Statement JOHN_ALREADY_HAS_BROWN_HAIR = StatementUpdateBuilderTest.JOHN_ALREADY_HAS_BROWN_HAIR;
+	private static final Statement JOHN_ALREADY_HAS_BLUE_EYES = StatementUpdateBuilderTest.JOHN_ALREADY_HAS_BLUE_EYES;
+
+	@Test
+	public void testForEntityId() {
+		assertThrows(NullPointerException.class, () -> StatementDocumentUpdateBuilder.forEntityId(null));
+		assertThrows(IllegalArgumentException.class,
+				() -> StatementDocumentUpdateBuilder.forEntityId(ItemIdValue.NULL));
+		assertThat(StatementDocumentUpdateBuilder.forEntityId(Q1), is(instanceOf(ItemUpdateBuilder.class)));
+		assertThat(StatementDocumentUpdateBuilder.forEntityId(P1), is(instanceOf(PropertyUpdateBuilder.class)));
+		assertThat(StatementDocumentUpdateBuilder.forEntityId(M1), is(instanceOf(MediaInfoUpdateBuilder.class)));
+		assertThat(StatementDocumentUpdateBuilder.forEntityId(L1), is(instanceOf(LexemeUpdateBuilder.class)));
+		assertThat(StatementDocumentUpdateBuilder.forEntityId(F1), is(instanceOf(FormUpdateBuilder.class)));
+		assertThat(StatementDocumentUpdateBuilder.forEntityId(S1), is(instanceOf(SenseUpdateBuilder.class)));
+	}
+
+	@Test
+	public void testForBaseRevision() {
+		assertThrows(NullPointerException.class, () -> StatementDocumentUpdateBuilder.forBaseRevision(null));
+		assertThrows(IllegalArgumentException.class,
+				() -> StatementDocumentUpdateBuilder.forBaseRevision(Datamodel.makeItemDocument(ItemIdValue.NULL)));
+		assertThat(StatementDocumentUpdateBuilder.forBaseRevision(ITEM), is(instanceOf(ItemUpdateBuilder.class)));
+		assertThat(StatementDocumentUpdateBuilder.forBaseRevision(PROPERTY),
+				is(instanceOf(PropertyUpdateBuilder.class)));
+		assertThat(StatementDocumentUpdateBuilder.forBaseRevision(MEDIA), is(instanceOf(MediaInfoUpdateBuilder.class)));
+		assertThat(StatementDocumentUpdateBuilder.forBaseRevision(LEXEME), is(instanceOf(LexemeUpdateBuilder.class)));
+		assertThat(StatementDocumentUpdateBuilder.forBaseRevision(FORM), is(instanceOf(FormUpdateBuilder.class)));
+		assertThat(StatementDocumentUpdateBuilder.forBaseRevision(SENSE), is(instanceOf(SenseUpdateBuilder.class)));
+	}
+
+	@Test
+	public void testBlindStatementUpdate() {
+		StatementDocumentUpdate update = StatementDocumentUpdateBuilder.forEntityId(Q1)
+				.updateStatements(StatementUpdateBuilder.create()
+						.replaceStatement(JOHN_ALREADY_HAS_BROWN_HAIR)
+						.build())
+				.updateStatements(StatementUpdateBuilder.create()
+						.removeStatement(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId())
+						.build())
+				.build();
+		assertThat(update.getStatements().getReplacedStatements().values(),
+				containsInAnyOrder(JOHN_ALREADY_HAS_BROWN_HAIR));
+		assertThat(update.getStatements().getRemovedStatements(),
+				containsInAnyOrder(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId()));
+	}
+
+	@Test
+	public void testBaseStatementUpdate() {
+		StatementDocumentUpdate update = StatementDocumentUpdateBuilder
+				.forBaseRevision(ITEM
+						.withStatement(JOHN_ALREADY_HAS_BROWN_HAIR)
+						.withStatement(JOHN_ALREADY_HAS_BLUE_EYES))
+				.updateStatements(StatementUpdateBuilder.create()
+						.replaceStatement(JOHN_ALREADY_HAS_BROWN_HAIR) // ignored
+						.removeStatement(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId()) // checked
+						.build())
+				.build();
+		assertThat(update.getStatements().getReplacedStatements(), is(anEmptyMap()));
+		assertThat(update.getStatements().getRemovedStatements(),
+				containsInAnyOrder(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId()));
+	}
+
+	@Test
+	public void testMerge() {
+		StatementDocumentUpdateBuilder builder = StatementDocumentUpdateBuilder.forEntityId(Q1)
+				.updateStatements(StatementUpdateBuilder.create()
+						.replaceStatement(JOHN_ALREADY_HAS_BROWN_HAIR)
+						.build());
+		builder.apply(StatementDocumentUpdateBuilder.forEntityId(Q1)
+				.updateStatements(StatementUpdateBuilder.create()
+						.removeStatement(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId())
+						.build())
+				.build());
+		StatementDocumentUpdate update = builder.build();
+		assertThat(update.getStatements().getReplacedStatements().values(),
+				containsInAnyOrder(JOHN_ALREADY_HAS_BROWN_HAIR));
+		assertThat(update.getStatements().getRemovedStatements(),
+				containsInAnyOrder(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId()));
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilderTest.java
@@ -27,6 +27,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
 import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
@@ -56,6 +57,8 @@ public class StatementDocumentUpdateBuilderTest {
 	private static final LexemeDocument LEXEME = EntityUpdateBuilderTest.LEXEME;
 	private static final FormDocument FORM = EntityUpdateBuilderTest.FORM;
 	private static final SenseDocument SENSE = EntityUpdateBuilderTest.SENSE;
+	private static final EntityIdValue JOHN = StatementUpdateBuilderTest.JOHN;
+	private static final EntityIdValue RITA = StatementUpdateBuilderTest.RITA;
 	private static final Statement JOHN_ALREADY_HAS_BROWN_HAIR = StatementUpdateBuilderTest.JOHN_ALREADY_HAS_BROWN_HAIR;
 	private static final Statement JOHN_ALREADY_HAS_BLUE_EYES = StatementUpdateBuilderTest.JOHN_ALREADY_HAS_BLUE_EYES;
 
@@ -90,7 +93,9 @@ public class StatementDocumentUpdateBuilderTest {
 	public void testBlindStatementUpdate() {
 		assertThrows(NullPointerException.class,
 				() -> StatementDocumentUpdateBuilder.forEntityId(Q1).updateStatements(null));
-		StatementDocumentUpdate update = StatementDocumentUpdateBuilder.forEntityId(Q1)
+		assertThrows(IllegalArgumentException.class, () -> StatementDocumentUpdateBuilder.forEntityId(RITA)
+				.updateStatements(StatementUpdateBuilder.create().replace(JOHN_ALREADY_HAS_BROWN_HAIR).build()));
+		StatementDocumentUpdate update = StatementDocumentUpdateBuilder.forEntityId(JOHN)
 				.updateStatements(StatementUpdateBuilder.create().replace(JOHN_ALREADY_HAS_BROWN_HAIR).build())
 				.updateStatements(StatementUpdateBuilder.create().replace(JOHN_ALREADY_HAS_BLUE_EYES).build())
 				.build();
@@ -117,9 +122,9 @@ public class StatementDocumentUpdateBuilderTest {
 	@Test
 	public void testMerge() {
 		assertThrows(NullPointerException.class, () -> StatementDocumentUpdateBuilder.forEntityId(Q1).append(null));
-		StatementDocumentUpdateBuilder builder = StatementDocumentUpdateBuilder.forEntityId(Q1)
+		StatementDocumentUpdateBuilder builder = StatementDocumentUpdateBuilder.forEntityId(JOHN)
 				.updateStatements(StatementUpdateBuilder.create().replace(JOHN_ALREADY_HAS_BROWN_HAIR).build());
-		builder.append(StatementDocumentUpdateBuilder.forEntityId(Q1)
+		builder.append(StatementDocumentUpdateBuilder.forEntityId(JOHN)
 				.updateStatements(StatementUpdateBuilder.create().replace(JOHN_ALREADY_HAS_BLUE_EYES).build())
 				.build());
 		StatementDocumentUpdate update = builder.build();

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilderTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
@@ -73,6 +74,16 @@ public class StatementDocumentUpdateBuilderTest {
 		assertThat(StatementDocumentUpdateBuilder.forEntityId(L1), is(instanceOf(LexemeUpdateBuilder.class)));
 		assertThat(StatementDocumentUpdateBuilder.forEntityId(F1), is(instanceOf(FormUpdateBuilder.class)));
 		assertThat(StatementDocumentUpdateBuilder.forEntityId(S1), is(instanceOf(SenseUpdateBuilder.class)));
+	}
+
+	@Test
+	public void testForBaseRevisionId() {
+		assertEquals(123, StatementDocumentUpdateBuilder.forBaseRevisionId(Q1, 123).getBaseRevisionId());
+		assertEquals(123, StatementDocumentUpdateBuilder.forBaseRevisionId(P1, 123).getBaseRevisionId());
+		assertEquals(123, StatementDocumentUpdateBuilder.forBaseRevisionId(M1, 123).getBaseRevisionId());
+		assertEquals(123, StatementDocumentUpdateBuilder.forBaseRevisionId(L1, 123).getBaseRevisionId());
+		assertEquals(123, StatementDocumentUpdateBuilder.forBaseRevisionId(F1, 123).getBaseRevisionId());
+		assertEquals(123, StatementDocumentUpdateBuilder.forBaseRevisionId(S1, 123).getBaseRevisionId());
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilderTest.java
@@ -95,13 +95,11 @@ public class StatementDocumentUpdateBuilderTest {
 						.replaceStatement(JOHN_ALREADY_HAS_BROWN_HAIR)
 						.build())
 				.updateStatements(StatementUpdateBuilder.create()
-						.removeStatement(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId())
+						.replaceStatement(JOHN_ALREADY_HAS_BLUE_EYES)
 						.build())
 				.build();
 		assertThat(update.getStatements().getReplacedStatements().values(),
-				containsInAnyOrder(JOHN_ALREADY_HAS_BROWN_HAIR));
-		assertThat(update.getStatements().getRemovedStatements(),
-				containsInAnyOrder(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId()));
+				containsInAnyOrder(JOHN_ALREADY_HAS_BROWN_HAIR, JOHN_ALREADY_HAS_BLUE_EYES));
 	}
 
 	@Test
@@ -129,14 +127,12 @@ public class StatementDocumentUpdateBuilderTest {
 						.build());
 		builder.apply(StatementDocumentUpdateBuilder.forEntityId(Q1)
 				.updateStatements(StatementUpdateBuilder.create()
-						.removeStatement(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId())
+						.replaceStatement(JOHN_ALREADY_HAS_BLUE_EYES)
 						.build())
 				.build());
 		StatementDocumentUpdate update = builder.build();
 		assertThat(update.getStatements().getReplacedStatements().values(),
-				containsInAnyOrder(JOHN_ALREADY_HAS_BROWN_HAIR));
-		assertThat(update.getStatements().getRemovedStatements(),
-				containsInAnyOrder(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId()));
+				containsInAnyOrder(JOHN_ALREADY_HAS_BROWN_HAIR, JOHN_ALREADY_HAS_BLUE_EYES));
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilderTest.java
@@ -88,6 +88,8 @@ public class StatementDocumentUpdateBuilderTest {
 
 	@Test
 	public void testBlindStatementUpdate() {
+		assertThrows(NullPointerException.class,
+				() -> StatementDocumentUpdateBuilder.forEntityId(Q1).updateStatements(null));
 		StatementDocumentUpdate update = StatementDocumentUpdateBuilder.forEntityId(Q1)
 				.updateStatements(StatementUpdateBuilder.create()
 						.replaceStatement(JOHN_ALREADY_HAS_BROWN_HAIR)
@@ -120,6 +122,7 @@ public class StatementDocumentUpdateBuilderTest {
 
 	@Test
 	public void testMerge() {
+		assertThrows(NullPointerException.class, () -> StatementDocumentUpdateBuilder.forEntityId(Q1).apply(null));
 		StatementDocumentUpdateBuilder builder = StatementDocumentUpdateBuilder.forEntityId(Q1)
 				.updateStatements(StatementUpdateBuilder.create()
 						.replaceStatement(JOHN_ALREADY_HAS_BROWN_HAIR)

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilderTest.java
@@ -91,14 +91,10 @@ public class StatementDocumentUpdateBuilderTest {
 		assertThrows(NullPointerException.class,
 				() -> StatementDocumentUpdateBuilder.forEntityId(Q1).updateStatements(null));
 		StatementDocumentUpdate update = StatementDocumentUpdateBuilder.forEntityId(Q1)
-				.updateStatements(StatementUpdateBuilder.create()
-						.replaceStatement(JOHN_ALREADY_HAS_BROWN_HAIR)
-						.build())
-				.updateStatements(StatementUpdateBuilder.create()
-						.replaceStatement(JOHN_ALREADY_HAS_BLUE_EYES)
-						.build())
+				.updateStatements(StatementUpdateBuilder.create().replace(JOHN_ALREADY_HAS_BROWN_HAIR).build())
+				.updateStatements(StatementUpdateBuilder.create().replace(JOHN_ALREADY_HAS_BLUE_EYES).build())
 				.build();
-		assertThat(update.getStatements().getReplacedStatements().values(),
+		assertThat(update.getStatements().getReplaced().values(),
 				containsInAnyOrder(JOHN_ALREADY_HAS_BROWN_HAIR, JOHN_ALREADY_HAS_BLUE_EYES));
 	}
 
@@ -109,29 +105,25 @@ public class StatementDocumentUpdateBuilderTest {
 						.withStatement(JOHN_ALREADY_HAS_BROWN_HAIR)
 						.withStatement(JOHN_ALREADY_HAS_BLUE_EYES))
 				.updateStatements(StatementUpdateBuilder.create()
-						.replaceStatement(JOHN_ALREADY_HAS_BROWN_HAIR) // ignored
-						.removeStatement(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId()) // checked
+						.replace(JOHN_ALREADY_HAS_BROWN_HAIR) // ignored
+						.remove(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId()) // checked
 						.build())
 				.build();
-		assertThat(update.getStatements().getReplacedStatements(), is(anEmptyMap()));
-		assertThat(update.getStatements().getRemovedStatements(),
+		assertThat(update.getStatements().getReplaced(), is(anEmptyMap()));
+		assertThat(update.getStatements().getRemoved(),
 				containsInAnyOrder(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId()));
 	}
 
 	@Test
 	public void testMerge() {
-		assertThrows(NullPointerException.class, () -> StatementDocumentUpdateBuilder.forEntityId(Q1).apply(null));
+		assertThrows(NullPointerException.class, () -> StatementDocumentUpdateBuilder.forEntityId(Q1).append(null));
 		StatementDocumentUpdateBuilder builder = StatementDocumentUpdateBuilder.forEntityId(Q1)
-				.updateStatements(StatementUpdateBuilder.create()
-						.replaceStatement(JOHN_ALREADY_HAS_BROWN_HAIR)
-						.build());
-		builder.apply(StatementDocumentUpdateBuilder.forEntityId(Q1)
-				.updateStatements(StatementUpdateBuilder.create()
-						.replaceStatement(JOHN_ALREADY_HAS_BLUE_EYES)
-						.build())
+				.updateStatements(StatementUpdateBuilder.create().replace(JOHN_ALREADY_HAS_BROWN_HAIR).build());
+		builder.append(StatementDocumentUpdateBuilder.forEntityId(Q1)
+				.updateStatements(StatementUpdateBuilder.create().replace(JOHN_ALREADY_HAS_BLUE_EYES).build())
 				.build());
 		StatementDocumentUpdate update = builder.build();
-		assertThat(update.getStatements().getReplacedStatements().values(),
+		assertThat(update.getStatements().getReplaced().values(),
 				containsInAnyOrder(JOHN_ALREADY_HAS_BROWN_HAIR, JOHN_ALREADY_HAS_BLUE_EYES));
 	}
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilderTest.java
@@ -28,6 +28,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
@@ -114,6 +115,8 @@ public class StatementUpdateBuilderTest {
 		// inconsistent statement subject
 		assertThrows(IllegalArgumentException.class, () -> StatementUpdateBuilder
 				.forStatements(Arrays.asList(johnAlreadyHasBrownHair, ritaAlreadyHasBrownHair)));
+		// no base statements
+		StatementUpdateBuilder.forStatements(Collections.emptyList());
 		StatementUpdate update = StatementUpdateBuilder
 				.forStatements(Arrays.asList(johnAlreadyHasBrownHair, johnAlreadyHasBrownEyes))
 				.build();
@@ -129,6 +132,8 @@ public class StatementUpdateBuilderTest {
 				Arrays.asList(johnAlreadyHasBrownHair, johnAlreadyHasSilverHair));
 		assertThrows(IllegalArgumentException.class,
 				() -> StatementUpdateBuilder.forStatementGroups(Arrays.asList(johnAlreadyHasBrownAndSilverHair, null)));
+		// no statement groups
+		StatementUpdateBuilder.forStatementGroups(Collections.emptyList());
 		StatementUpdate update = StatementUpdateBuilder
 				.forStatementGroups(Arrays.asList(johnAlreadyHasBrownAndSilverHair))
 				.build();

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilderTest.java
@@ -1,0 +1,235 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.helpers;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
+import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
+import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.StringValue;
+
+public class StatementUpdateBuilderTest {
+
+	private final EntityIdValue john = Datamodel.makeWikidataItemIdValue("Q1");
+	private final EntityIdValue rita = Datamodel.makeWikidataItemIdValue("Q2");
+	private final PropertyIdValue hair = Datamodel.makeWikidataPropertyIdValue("P1");
+	private final PropertyIdValue eyes = Datamodel.makeWikidataPropertyIdValue("P2");
+	private final PropertyIdValue shirt = Datamodel.makeWikidataPropertyIdValue("P3");
+	private final PropertyIdValue trousers = Datamodel.makeWikidataPropertyIdValue("P4");
+	private final StringValue brown = Datamodel.makeStringValue("brown");
+	private final StringValue silver = Datamodel.makeStringValue("silver");
+	private final StringValue blue = Datamodel.makeStringValue("blue");
+	private final Statement nobodyHasBrownHair = StatementBuilder
+			.forSubjectAndProperty(ItemIdValue.NULL, hair)
+			.withValue(brown)
+			.build();
+	private final Statement nobodyAlreadyHasBrownHair = nobodyHasBrownHair.withStatementId("ID1");
+	private final Statement johnHasBrownHair = StatementBuilder
+			.forSubjectAndProperty(john, hair)
+			.withValue(brown)
+			.build();
+	private final Statement johnAlreadyHasBrownHair = johnHasBrownHair.withStatementId("ID2");
+	private final Statement ritaHasBrownHair = StatementBuilder
+			.forSubjectAndProperty(rita, hair)
+			.withValue(brown)
+			.build();
+	private final Statement ritaAlreadyHasBrownHair = ritaHasBrownHair.withStatementId("ID3");
+	private final Statement johnHasBrownEyes = StatementBuilder
+			.forSubjectAndProperty(john, eyes)
+			.withValue(brown)
+			.build();
+	private final Statement johnAlreadyHasBrownEyes = johnHasBrownEyes.withStatementId("ID4");
+	private final Statement johnHasSilverHair = StatementBuilder
+			.forSubjectAndProperty(john, hair)
+			.withValue(silver)
+			.build();
+	private final Statement johnAlreadyHasSilverHair = johnHasSilverHair.withStatementId("ID5");
+	private final Statement johnHasBlueShirt = StatementBuilder
+			.forSubjectAndProperty(john, shirt)
+			.withValue(blue)
+			.build();
+	private final Statement johnAlreadyHasBlueShirt = johnHasBlueShirt.withStatementId("ID6");
+	private final Statement johnHasBrownTrousers = StatementBuilder
+			.forSubjectAndProperty(john, trousers)
+			.withValue(brown)
+			.build();
+	private final Statement johnAlreadyHasBrownTrousers = johnHasBrownTrousers.withStatementId("ID7");
+	private final Statement johnHasBlueTrousers = StatementBuilder
+			.forSubjectAndProperty(john, trousers)
+			.withValue(blue)
+			.build();
+
+	@Test
+	public void testCreate() {
+		StatementUpdate update = StatementUpdateBuilder.create().build();
+		assertThat(update.getAddedStatements(), is(empty()));
+		assertThat(update.getReplacedStatements(), is(anEmptyMap()));
+		assertThat(update.getRemovedStatements(), is(empty()));
+	}
+
+	@Test
+	public void testForStatements() {
+		assertThrows(NullPointerException.class, () -> StatementUpdateBuilder.forStatements(null));
+		assertThrows(IllegalArgumentException.class,
+				() -> StatementUpdateBuilder.forStatements(Arrays.asList(johnAlreadyHasBrownHair, null)));
+		// no statement subject
+		assertThrows(IllegalArgumentException.class,
+				() -> StatementUpdateBuilder.forStatements(Arrays.asList(nobodyAlreadyHasBrownHair)));
+		// no statement ID
+		assertThrows(IllegalArgumentException.class,
+				() -> StatementUpdateBuilder.forStatements(Arrays.asList(johnHasBrownHair)));
+		// duplicate statement ID
+		assertThrows(IllegalArgumentException.class, () -> StatementUpdateBuilder
+				.forStatements(Arrays.asList(johnAlreadyHasBrownHair, johnAlreadyHasBrownHair)));
+		// inconsistent statement subject
+		assertThrows(IllegalArgumentException.class, () -> StatementUpdateBuilder
+				.forStatements(Arrays.asList(johnAlreadyHasBrownHair, ritaAlreadyHasBrownHair)));
+		StatementUpdate update = StatementUpdateBuilder
+				.forStatements(Arrays.asList(johnAlreadyHasBrownHair, johnAlreadyHasBrownEyes))
+				.build();
+		assertThat(update.getAddedStatements(), is(empty()));
+		assertThat(update.getReplacedStatements(), is(anEmptyMap()));
+		assertThat(update.getRemovedStatements(), is(empty()));
+	}
+
+	@Test
+	public void testForStatementGroups() {
+		assertThrows(NullPointerException.class, () -> StatementUpdateBuilder.forStatementGroups(null));
+		StatementGroup johnAlreadyHasBrownAndSilverHair = Datamodel.makeStatementGroup(
+				Arrays.asList(johnAlreadyHasBrownHair, johnAlreadyHasSilverHair));
+		assertThrows(IllegalArgumentException.class,
+				() -> StatementUpdateBuilder.forStatementGroups(Arrays.asList(johnAlreadyHasBrownAndSilverHair, null)));
+		StatementUpdate update = StatementUpdateBuilder
+				.forStatementGroups(Arrays.asList(johnAlreadyHasBrownAndSilverHair))
+				.build();
+		assertThat(update.getAddedStatements(), is(empty()));
+		assertThat(update.getReplacedStatements(), is(anEmptyMap()));
+		assertThat(update.getRemovedStatements(), is(empty()));
+	}
+
+	@Test
+	public void testBlindAddition() {
+		StatementUpdateBuilder builder = StatementUpdateBuilder.create();
+		assertThrows(NullPointerException.class, () -> builder.addStatement(null));
+		builder.addStatement(johnHasBrownHair); // simple case
+		builder.addStatement(johnHasBrownHair); // duplicates allowed
+		builder.addStatement(johnAlreadyHasBrownEyes); // strip ID
+		// inconsistent subject
+		assertThrows(IllegalArgumentException.class, () -> builder.addStatement(ritaHasBrownHair));
+		StatementUpdate update = builder.build();
+		assertEquals(update.getAddedStatements(), Arrays.asList(johnHasBrownHair, johnHasBrownHair, johnHasBrownEyes));
+	}
+
+	@Test
+	public void testBlindReplacement() {
+		StatementUpdateBuilder builder = StatementUpdateBuilder.create();
+		assertThrows(NullPointerException.class, () -> builder.replaceStatement(null));
+		builder.removeStatement(johnAlreadyHasBrownEyes.getStatementId());
+		builder.replaceStatement(johnAlreadyHasBrownHair); // simple case
+		builder.replaceStatement(johnAlreadyHasBrownEyes); // previously removed
+		builder.replaceStatement(johnAlreadyHasBrownHair); // replace twice
+		// inconsistent subject
+		assertThrows(IllegalArgumentException.class, () -> builder.replaceStatement(ritaAlreadyHasBrownHair));
+		// no statement ID
+		assertThrows(IllegalArgumentException.class, () -> builder.replaceStatement(johnHasSilverHair));
+		StatementUpdate update = builder.build();
+		assertThat(update.getRemovedStatements(), is(empty()));
+		assertThat(
+				update.getReplacedStatements().values(),
+				containsInAnyOrder(johnAlreadyHasBrownHair, johnAlreadyHasBrownEyes));
+	}
+
+	@Test
+	public void testBlindRemoval() {
+		StatementUpdateBuilder builder = StatementUpdateBuilder.create();
+		assertThrows(NullPointerException.class, () -> builder.removeStatement(null));
+		assertThrows(IllegalArgumentException.class, () -> builder.removeStatement(""));
+		builder.replaceStatement(johnAlreadyHasBrownEyes);
+		builder.removeStatement(johnAlreadyHasBrownHair.getStatementId()); // simple case
+		builder.removeStatement(johnAlreadyHasBrownEyes.getStatementId()); // previously replaced
+		StatementUpdate update = builder.build();
+		assertThat(update.getReplacedStatements(), is(anEmptyMap()));
+		assertThat(
+				update.getRemovedStatements(),
+				containsInAnyOrder(johnAlreadyHasBrownHair.getStatementId(), johnAlreadyHasBrownEyes.getStatementId()));
+	}
+
+	@Test
+	public void testBaseAddition() {
+		StatementUpdateBuilder builder = StatementUpdateBuilder.forStatements(Arrays.asList(johnAlreadyHasBrownHair));
+		// inconsistent subject
+		assertThrows(IllegalArgumentException.class, () -> builder.addStatement(ritaHasBrownHair));
+		builder.addStatement(johnHasBrownEyes); // simple case
+		builder.addStatement(johnAlreadyHasBrownHair); // duplicating existing statements is allowed
+		StatementUpdate update = builder.build();
+		assertEquals(update.getAddedStatements(), Arrays.asList(johnHasBrownEyes, johnHasBrownHair));
+	}
+
+	@Test
+	public void testBaseReplacement() {
+		StatementUpdateBuilder builder = StatementUpdateBuilder.forStatements(Arrays.asList(
+				johnAlreadyHasBrownHair,
+				johnAlreadyHasBrownEyes,
+				johnAlreadyHasBlueShirt,
+				johnAlreadyHasBrownTrousers));
+		builder.removeStatement(johnAlreadyHasBrownEyes.getStatementId());
+		Statement johnChangesBrownTrousersToBlueTrousers = johnHasBlueTrousers
+				.withStatementId(johnAlreadyHasBrownTrousers.getStatementId());
+		builder.replaceStatement(johnChangesBrownTrousersToBlueTrousers);
+		// inconsistent subject
+		assertThrows(IllegalArgumentException.class, () -> builder
+				.replaceStatement(ritaAlreadyHasBrownHair.withStatementId(johnAlreadyHasBrownEyes.getStatementId())));
+		// unknown ID
+		assertThrows(IllegalArgumentException.class,
+				() -> builder.replaceStatement(johnAlreadyHasBrownHair.withStatementId("ID999")));
+		Statement johnChangesBrownHairToSilverHair = johnHasSilverHair
+				.withStatementId(johnAlreadyHasBrownHair.getStatementId());
+		builder.replaceStatement(johnChangesBrownHairToSilverHair); // simple case
+		builder.replaceStatement(johnAlreadyHasBlueShirt); // no change
+		builder.replaceStatement(johnAlreadyHasBrownEyes); // restore deleted
+		builder.replaceStatement(johnAlreadyHasBrownTrousers); // restore replaced
+		StatementUpdate update = builder.build();
+		assertThat(update.getRemovedStatements(), is(empty()));
+		assertThat(update.getReplacedStatements().values(), containsInAnyOrder(johnChangesBrownHairToSilverHair));
+	}
+
+	@Test
+	public void testBaseRemoval() {
+		StatementUpdateBuilder builder = StatementUpdateBuilder.forStatements(Arrays.asList(johnAlreadyHasBrownHair));
+		assertThrows(IllegalArgumentException.class, () -> builder.removeStatement("ID999")); // unknown ID
+		builder.removeStatement(johnAlreadyHasBrownHair.getStatementId()); // simple case
+		StatementUpdate update = builder.build();
+		assertThat(update.getRemovedStatements(), containsInAnyOrder(johnAlreadyHasBrownHair.getStatementId()));
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilderTest.java
@@ -101,7 +101,7 @@ public class StatementUpdateBuilderTest {
 	@Test
 	public void testForStatements() {
 		assertThrows(NullPointerException.class, () -> StatementUpdateBuilder.forStatements(null));
-		assertThrows(IllegalArgumentException.class,
+		assertThrows(NullPointerException.class,
 				() -> StatementUpdateBuilder.forStatements(Arrays.asList(johnAlreadyHasBrownHair, null)));
 		// no statement subject
 		assertThrows(IllegalArgumentException.class,

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilderTest.java
@@ -41,54 +41,59 @@ import org.wikidata.wdtk.datamodel.interfaces.StringValue;
 
 public class StatementUpdateBuilderTest {
 
-	private final EntityIdValue john = Datamodel.makeWikidataItemIdValue("Q1");
-	private final EntityIdValue rita = Datamodel.makeWikidataItemIdValue("Q2");
-	private final PropertyIdValue hair = Datamodel.makeWikidataPropertyIdValue("P1");
-	private final PropertyIdValue eyes = Datamodel.makeWikidataPropertyIdValue("P2");
-	private final PropertyIdValue shirt = Datamodel.makeWikidataPropertyIdValue("P3");
-	private final PropertyIdValue trousers = Datamodel.makeWikidataPropertyIdValue("P4");
-	private final StringValue brown = Datamodel.makeStringValue("brown");
-	private final StringValue silver = Datamodel.makeStringValue("silver");
-	private final StringValue blue = Datamodel.makeStringValue("blue");
-	private final Statement nobodyHasBrownHair = StatementBuilder
-			.forSubjectAndProperty(ItemIdValue.NULL, hair)
-			.withValue(brown)
+	static final EntityIdValue JOHN = Datamodel.makeWikidataItemIdValue("Q1");
+	static final EntityIdValue RITA = Datamodel.makeWikidataItemIdValue("Q2");
+	static final PropertyIdValue HAIR = Datamodel.makeWikidataPropertyIdValue("P1");
+	static final PropertyIdValue EYES = Datamodel.makeWikidataPropertyIdValue("P2");
+	static final PropertyIdValue SHIRT = Datamodel.makeWikidataPropertyIdValue("P3");
+	static final PropertyIdValue TROUSERS = Datamodel.makeWikidataPropertyIdValue("P4");
+	static final StringValue BROWN = Datamodel.makeStringValue("brown");
+	static final StringValue SILVER = Datamodel.makeStringValue("silver");
+	static final StringValue BLUE = Datamodel.makeStringValue("blue");
+	static final Statement NOBODY_HAS_BROWN_HAIR = StatementBuilder
+			.forSubjectAndProperty(ItemIdValue.NULL, HAIR)
+			.withValue(BROWN)
 			.build();
-	private final Statement nobodyAlreadyHasBrownHair = nobodyHasBrownHair.withStatementId("ID1");
-	private final Statement johnHasBrownHair = StatementBuilder
-			.forSubjectAndProperty(john, hair)
-			.withValue(brown)
+	static final Statement NOBODY_ALREADY_HAS_BROWN_HAIR = NOBODY_HAS_BROWN_HAIR.withStatementId("ID1");
+	static final Statement JOHN_HAS_BROWN_HAIR = StatementBuilder
+			.forSubjectAndProperty(JOHN, HAIR)
+			.withValue(BROWN)
 			.build();
-	private final Statement johnAlreadyHasBrownHair = johnHasBrownHair.withStatementId("ID2");
-	private final Statement ritaHasBrownHair = StatementBuilder
-			.forSubjectAndProperty(rita, hair)
-			.withValue(brown)
+	static final Statement JOHN_ALREADY_HAS_BROWN_HAIR = JOHN_HAS_BROWN_HAIR.withStatementId("ID2");
+	static final Statement RITA_HAS_BROWN_HAIR = StatementBuilder
+			.forSubjectAndProperty(RITA, HAIR)
+			.withValue(BROWN)
 			.build();
-	private final Statement ritaAlreadyHasBrownHair = ritaHasBrownHair.withStatementId("ID3");
-	private final Statement johnHasBrownEyes = StatementBuilder
-			.forSubjectAndProperty(john, eyes)
-			.withValue(brown)
+	static final Statement RITA_ALREADY_HAS_BROWN_HAIR = RITA_HAS_BROWN_HAIR.withStatementId("ID3");
+	static final Statement JOHN_HAS_BROWN_EYES = StatementBuilder
+			.forSubjectAndProperty(JOHN, EYES)
+			.withValue(BROWN)
 			.build();
-	private final Statement johnAlreadyHasBrownEyes = johnHasBrownEyes.withStatementId("ID4");
-	private final Statement johnHasSilverHair = StatementBuilder
-			.forSubjectAndProperty(john, hair)
-			.withValue(silver)
+	static final Statement JOHN_ALREADY_HAS_BROWN_EYES = JOHN_HAS_BROWN_EYES.withStatementId("ID4");
+	static final Statement JOHN_HAS_SILVER_HAIR = StatementBuilder
+			.forSubjectAndProperty(JOHN, HAIR)
+			.withValue(SILVER)
 			.build();
-	private final Statement johnAlreadyHasSilverHair = johnHasSilverHair.withStatementId("ID5");
-	private final Statement johnHasBlueShirt = StatementBuilder
-			.forSubjectAndProperty(john, shirt)
-			.withValue(blue)
+	static final Statement JOHN_ALREADY_HAS_SILVER_HAIR = JOHN_HAS_SILVER_HAIR.withStatementId("ID5");
+	static final Statement JOHN_HAS_BLUE_SHIRT = StatementBuilder
+			.forSubjectAndProperty(JOHN, SHIRT)
+			.withValue(BLUE)
 			.build();
-	private final Statement johnAlreadyHasBlueShirt = johnHasBlueShirt.withStatementId("ID6");
-	private final Statement johnHasBrownTrousers = StatementBuilder
-			.forSubjectAndProperty(john, trousers)
-			.withValue(brown)
+	static final Statement JOHN_ALREADY_HAS_BLUE_SHIRT = JOHN_HAS_BLUE_SHIRT.withStatementId("ID6");
+	static final Statement JOHN_HAS_BROWN_TROUSERS = StatementBuilder
+			.forSubjectAndProperty(JOHN, TROUSERS)
+			.withValue(BROWN)
 			.build();
-	private final Statement johnAlreadyHasBrownTrousers = johnHasBrownTrousers.withStatementId("ID7");
-	private final Statement johnHasBlueTrousers = StatementBuilder
-			.forSubjectAndProperty(john, trousers)
-			.withValue(blue)
+	static final Statement JOHN_ALREADY_HAS_BROWN_TROUSERS = JOHN_HAS_BROWN_TROUSERS.withStatementId("ID7");
+	static final Statement JOHN_HAS_BLUE_TROUSERS = StatementBuilder
+			.forSubjectAndProperty(JOHN, TROUSERS)
+			.withValue(BLUE)
 			.build();
+	static final Statement JOHN_HAS_BLUE_EYES = StatementBuilder
+			.forSubjectAndProperty(JOHN, EYES)
+			.withValue(BLUE)
+			.build();
+	static final Statement JOHN_ALREADY_HAS_BLUE_EYES = JOHN_HAS_BLUE_EYES.withStatementId("ID8");
 
 	@Test
 	public void testCreate() {
@@ -102,23 +107,23 @@ public class StatementUpdateBuilderTest {
 	public void testForStatements() {
 		assertThrows(NullPointerException.class, () -> StatementUpdateBuilder.forStatements(null));
 		assertThrows(NullPointerException.class,
-				() -> StatementUpdateBuilder.forStatements(Arrays.asList(johnAlreadyHasBrownHair, null)));
+				() -> StatementUpdateBuilder.forStatements(Arrays.asList(JOHN_ALREADY_HAS_BROWN_HAIR, null)));
 		// no statement subject
 		assertThrows(IllegalArgumentException.class,
-				() -> StatementUpdateBuilder.forStatements(Arrays.asList(nobodyAlreadyHasBrownHair)));
+				() -> StatementUpdateBuilder.forStatements(Arrays.asList(NOBODY_ALREADY_HAS_BROWN_HAIR)));
 		// no statement ID
 		assertThrows(IllegalArgumentException.class,
-				() -> StatementUpdateBuilder.forStatements(Arrays.asList(johnHasBrownHair)));
+				() -> StatementUpdateBuilder.forStatements(Arrays.asList(JOHN_HAS_BROWN_HAIR)));
 		// duplicate statement ID
 		assertThrows(IllegalArgumentException.class, () -> StatementUpdateBuilder
-				.forStatements(Arrays.asList(johnAlreadyHasBrownHair, johnAlreadyHasBrownHair)));
+				.forStatements(Arrays.asList(JOHN_ALREADY_HAS_BROWN_HAIR, JOHN_ALREADY_HAS_BROWN_HAIR)));
 		// inconsistent statement subject
 		assertThrows(IllegalArgumentException.class, () -> StatementUpdateBuilder
-				.forStatements(Arrays.asList(johnAlreadyHasBrownHair, ritaAlreadyHasBrownHair)));
+				.forStatements(Arrays.asList(JOHN_ALREADY_HAS_BROWN_HAIR, RITA_ALREADY_HAS_BROWN_HAIR)));
 		// no base statements
 		StatementUpdateBuilder.forStatements(Collections.emptyList());
 		StatementUpdate update = StatementUpdateBuilder
-				.forStatements(Arrays.asList(johnAlreadyHasBrownHair, johnAlreadyHasBrownEyes))
+				.forStatements(Arrays.asList(JOHN_ALREADY_HAS_BROWN_HAIR, JOHN_ALREADY_HAS_BROWN_EYES))
 				.build();
 		assertThat(update.getAddedStatements(), is(empty()));
 		assertThat(update.getReplacedStatements(), is(anEmptyMap()));
@@ -129,7 +134,7 @@ public class StatementUpdateBuilderTest {
 	public void testForStatementGroups() {
 		assertThrows(NullPointerException.class, () -> StatementUpdateBuilder.forStatementGroups(null));
 		StatementGroup johnAlreadyHasBrownAndSilverHair = Datamodel.makeStatementGroup(
-				Arrays.asList(johnAlreadyHasBrownHair, johnAlreadyHasSilverHair));
+				Arrays.asList(JOHN_ALREADY_HAS_BROWN_HAIR, JOHN_ALREADY_HAS_SILVER_HAIR));
 		assertThrows(IllegalArgumentException.class,
 				() -> StatementUpdateBuilder.forStatementGroups(Arrays.asList(johnAlreadyHasBrownAndSilverHair, null)));
 		// no statement groups
@@ -146,32 +151,33 @@ public class StatementUpdateBuilderTest {
 	public void testBlindAddition() {
 		StatementUpdateBuilder builder = StatementUpdateBuilder.create();
 		assertThrows(NullPointerException.class, () -> builder.addStatement(null));
-		builder.addStatement(johnHasBrownHair); // simple case
-		builder.addStatement(johnHasBrownHair); // duplicates allowed
-		builder.addStatement(johnAlreadyHasBrownEyes); // strip ID
+		builder.addStatement(JOHN_HAS_BROWN_HAIR); // simple case
+		builder.addStatement(JOHN_HAS_BROWN_HAIR); // duplicates allowed
+		builder.addStatement(JOHN_ALREADY_HAS_BROWN_EYES); // strip ID
 		// inconsistent subject
-		assertThrows(IllegalArgumentException.class, () -> builder.addStatement(ritaHasBrownHair));
+		assertThrows(IllegalArgumentException.class, () -> builder.addStatement(RITA_HAS_BROWN_HAIR));
 		StatementUpdate update = builder.build();
-		assertEquals(update.getAddedStatements(), Arrays.asList(johnHasBrownHair, johnHasBrownHair, johnHasBrownEyes));
+		assertEquals(update.getAddedStatements(),
+				Arrays.asList(JOHN_HAS_BROWN_HAIR, JOHN_HAS_BROWN_HAIR, JOHN_HAS_BROWN_EYES));
 	}
 
 	@Test
 	public void testBlindReplacement() {
 		StatementUpdateBuilder builder = StatementUpdateBuilder.create();
 		assertThrows(NullPointerException.class, () -> builder.replaceStatement(null));
-		builder.removeStatement(johnAlreadyHasBrownEyes.getStatementId());
-		builder.replaceStatement(johnAlreadyHasBrownHair); // simple case
-		builder.replaceStatement(johnAlreadyHasBrownEyes); // previously removed
-		builder.replaceStatement(johnAlreadyHasBrownHair); // replace twice
+		builder.removeStatement(JOHN_ALREADY_HAS_BROWN_EYES.getStatementId());
+		builder.replaceStatement(JOHN_ALREADY_HAS_BROWN_HAIR); // simple case
+		builder.replaceStatement(JOHN_ALREADY_HAS_BROWN_EYES); // previously removed
+		builder.replaceStatement(JOHN_ALREADY_HAS_BROWN_HAIR); // replace twice
 		// inconsistent subject
-		assertThrows(IllegalArgumentException.class, () -> builder.replaceStatement(ritaAlreadyHasBrownHair));
+		assertThrows(IllegalArgumentException.class, () -> builder.replaceStatement(RITA_ALREADY_HAS_BROWN_HAIR));
 		// no statement ID
-		assertThrows(IllegalArgumentException.class, () -> builder.replaceStatement(johnHasSilverHair));
+		assertThrows(IllegalArgumentException.class, () -> builder.replaceStatement(JOHN_HAS_SILVER_HAIR));
 		StatementUpdate update = builder.build();
 		assertThat(update.getRemovedStatements(), is(empty()));
 		assertThat(
 				update.getReplacedStatements().values(),
-				containsInAnyOrder(johnAlreadyHasBrownHair, johnAlreadyHasBrownEyes));
+				containsInAnyOrder(JOHN_ALREADY_HAS_BROWN_HAIR, JOHN_ALREADY_HAS_BROWN_EYES));
 	}
 
 	@Test
@@ -179,50 +185,51 @@ public class StatementUpdateBuilderTest {
 		StatementUpdateBuilder builder = StatementUpdateBuilder.create();
 		assertThrows(NullPointerException.class, () -> builder.removeStatement(null));
 		assertThrows(IllegalArgumentException.class, () -> builder.removeStatement(""));
-		builder.replaceStatement(johnAlreadyHasBrownEyes);
-		builder.removeStatement(johnAlreadyHasBrownHair.getStatementId()); // simple case
-		builder.removeStatement(johnAlreadyHasBrownEyes.getStatementId()); // previously replaced
+		builder.replaceStatement(JOHN_ALREADY_HAS_BROWN_EYES);
+		builder.removeStatement(JOHN_ALREADY_HAS_BROWN_HAIR.getStatementId()); // simple case
+		builder.removeStatement(JOHN_ALREADY_HAS_BROWN_EYES.getStatementId()); // previously replaced
 		StatementUpdate update = builder.build();
 		assertThat(update.getReplacedStatements(), is(anEmptyMap()));
-		assertThat(
-				update.getRemovedStatements(),
-				containsInAnyOrder(johnAlreadyHasBrownHair.getStatementId(), johnAlreadyHasBrownEyes.getStatementId()));
+		assertThat(update.getRemovedStatements(), containsInAnyOrder(
+				JOHN_ALREADY_HAS_BROWN_HAIR.getStatementId(),
+				JOHN_ALREADY_HAS_BROWN_EYES.getStatementId()));
 	}
 
 	@Test
 	public void testBaseAddition() {
-		StatementUpdateBuilder builder = StatementUpdateBuilder.forStatements(Arrays.asList(johnAlreadyHasBrownHair));
+		StatementUpdateBuilder builder = StatementUpdateBuilder
+				.forStatements(Arrays.asList(JOHN_ALREADY_HAS_BROWN_HAIR));
 		// inconsistent subject
-		assertThrows(IllegalArgumentException.class, () -> builder.addStatement(ritaHasBrownHair));
-		builder.addStatement(johnHasBrownEyes); // simple case
-		builder.addStatement(johnAlreadyHasBrownHair); // duplicating existing statements is allowed
+		assertThrows(IllegalArgumentException.class, () -> builder.addStatement(RITA_HAS_BROWN_HAIR));
+		builder.addStatement(JOHN_HAS_BROWN_EYES); // simple case
+		builder.addStatement(JOHN_ALREADY_HAS_BROWN_HAIR); // duplicating existing statements is allowed
 		StatementUpdate update = builder.build();
-		assertEquals(update.getAddedStatements(), Arrays.asList(johnHasBrownEyes, johnHasBrownHair));
+		assertEquals(update.getAddedStatements(), Arrays.asList(JOHN_HAS_BROWN_EYES, JOHN_HAS_BROWN_HAIR));
 	}
 
 	@Test
 	public void testBaseReplacement() {
 		StatementUpdateBuilder builder = StatementUpdateBuilder.forStatements(Arrays.asList(
-				johnAlreadyHasBrownHair,
-				johnAlreadyHasBrownEyes,
-				johnAlreadyHasBlueShirt,
-				johnAlreadyHasBrownTrousers));
-		builder.removeStatement(johnAlreadyHasBrownEyes.getStatementId());
-		Statement johnChangesBrownTrousersToBlueTrousers = johnHasBlueTrousers
-				.withStatementId(johnAlreadyHasBrownTrousers.getStatementId());
+				JOHN_ALREADY_HAS_BROWN_HAIR,
+				JOHN_ALREADY_HAS_BROWN_EYES,
+				JOHN_ALREADY_HAS_BLUE_SHIRT,
+				JOHN_ALREADY_HAS_BROWN_TROUSERS));
+		builder.removeStatement(JOHN_ALREADY_HAS_BROWN_EYES.getStatementId());
+		Statement johnChangesBrownTrousersToBlueTrousers = JOHN_HAS_BLUE_TROUSERS
+				.withStatementId(JOHN_ALREADY_HAS_BROWN_TROUSERS.getStatementId());
 		builder.replaceStatement(johnChangesBrownTrousersToBlueTrousers);
 		// inconsistent subject
-		assertThrows(IllegalArgumentException.class, () -> builder
-				.replaceStatement(ritaAlreadyHasBrownHair.withStatementId(johnAlreadyHasBrownEyes.getStatementId())));
+		assertThrows(IllegalArgumentException.class, () -> builder.replaceStatement(
+				RITA_ALREADY_HAS_BROWN_HAIR.withStatementId(JOHN_ALREADY_HAS_BROWN_EYES.getStatementId())));
 		// unknown ID
 		assertThrows(IllegalArgumentException.class,
-				() -> builder.replaceStatement(johnAlreadyHasBrownHair.withStatementId("ID999")));
-		Statement johnChangesBrownHairToSilverHair = johnHasSilverHair
-				.withStatementId(johnAlreadyHasBrownHair.getStatementId());
+				() -> builder.replaceStatement(JOHN_ALREADY_HAS_BROWN_HAIR.withStatementId("ID999")));
+		Statement johnChangesBrownHairToSilverHair = JOHN_HAS_SILVER_HAIR
+				.withStatementId(JOHN_ALREADY_HAS_BROWN_HAIR.getStatementId());
 		builder.replaceStatement(johnChangesBrownHairToSilverHair); // simple case
-		builder.replaceStatement(johnAlreadyHasBlueShirt); // no change
-		builder.replaceStatement(johnAlreadyHasBrownEyes); // restore deleted
-		builder.replaceStatement(johnAlreadyHasBrownTrousers); // restore replaced
+		builder.replaceStatement(JOHN_ALREADY_HAS_BLUE_SHIRT); // no change
+		builder.replaceStatement(JOHN_ALREADY_HAS_BROWN_EYES); // restore deleted
+		builder.replaceStatement(JOHN_ALREADY_HAS_BROWN_TROUSERS); // restore replaced
 		StatementUpdate update = builder.build();
 		assertThat(update.getRemovedStatements(), is(empty()));
 		assertThat(update.getReplacedStatements().values(), containsInAnyOrder(johnChangesBrownHairToSilverHair));
@@ -230,11 +237,33 @@ public class StatementUpdateBuilderTest {
 
 	@Test
 	public void testBaseRemoval() {
-		StatementUpdateBuilder builder = StatementUpdateBuilder.forStatements(Arrays.asList(johnAlreadyHasBrownHair));
+		StatementUpdateBuilder builder = StatementUpdateBuilder
+				.forStatements(Arrays.asList(JOHN_ALREADY_HAS_BROWN_HAIR));
 		assertThrows(IllegalArgumentException.class, () -> builder.removeStatement("ID999")); // unknown ID
-		builder.removeStatement(johnAlreadyHasBrownHair.getStatementId()); // simple case
+		builder.removeStatement(JOHN_ALREADY_HAS_BROWN_HAIR.getStatementId()); // simple case
 		StatementUpdate update = builder.build();
-		assertThat(update.getRemovedStatements(), containsInAnyOrder(johnAlreadyHasBrownHair.getStatementId()));
+		assertThat(update.getRemovedStatements(), containsInAnyOrder(JOHN_ALREADY_HAS_BROWN_HAIR.getStatementId()));
+	}
+
+	@Test
+	public void testMerge() {
+		assertThrows(NullPointerException.class, () -> StatementUpdateBuilder.create().apply(null));
+		StatementUpdate update = StatementUpdateBuilder.create()
+				.addStatement(JOHN_HAS_BROWN_EYES) // prior addition
+				.replaceStatement(JOHN_ALREADY_HAS_SILVER_HAIR) // prior replacement
+				.removeStatement(JOHN_ALREADY_HAS_BLUE_SHIRT.getStatementId()) // prior removal
+				.apply(StatementUpdateBuilder.create()
+						.addStatement(JOHN_HAS_BROWN_TROUSERS) // another addition
+						.replaceStatement(JOHN_ALREADY_HAS_BROWN_HAIR) // another replacement
+						.removeStatement(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId()) // another removal
+						.build())
+				.build();
+		assertEquals(update.getAddedStatements(), Arrays.asList(JOHN_HAS_BROWN_EYES, JOHN_HAS_BROWN_TROUSERS));
+		assertThat(update.getReplacedStatements().values(),
+				containsInAnyOrder(JOHN_ALREADY_HAS_SILVER_HAIR, JOHN_ALREADY_HAS_BROWN_HAIR));
+		assertThat(update.getRemovedStatements(), containsInAnyOrder(
+				JOHN_ALREADY_HAS_BLUE_SHIRT.getStatementId(),
+				JOHN_ALREADY_HAS_BLUE_EYES.getStatementId()));
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilderTest.java
@@ -104,6 +104,14 @@ public class StatementUpdateBuilderTest {
 	}
 
 	@Test
+	public void testCreateWithSubject() {
+		StatementUpdateBuilder builder = StatementUpdateBuilder.create(JOHN);
+		assertThrows(IllegalArgumentException.class, () -> builder.add(RITA_HAS_BROWN_HAIR));
+		assertThrows(IllegalArgumentException.class, () -> builder.replace(RITA_ALREADY_HAS_BROWN_HAIR));
+		builder.add(JOHN_HAS_BLUE_EYES);
+	}
+
+	@Test
 	public void testForStatements() {
 		assertThrows(NullPointerException.class, () -> StatementUpdateBuilder.forStatements(null));
 		assertThrows(NullPointerException.class,
@@ -131,6 +139,14 @@ public class StatementUpdateBuilderTest {
 	}
 
 	@Test
+	public void testForStatementsWithSubject() {
+		assertThrows(IllegalArgumentException.class,
+				() -> StatementUpdateBuilder.forStatements(JOHN, Arrays.asList(RITA_ALREADY_HAS_BROWN_HAIR)));
+		StatementUpdateBuilder builder = StatementUpdateBuilder.forStatements(JOHN, Collections.emptyList());
+		assertThrows(IllegalArgumentException.class, () -> builder.add(RITA_HAS_BROWN_HAIR));
+	}
+
+	@Test
 	public void testForStatementGroups() {
 		assertThrows(NullPointerException.class, () -> StatementUpdateBuilder.forStatementGroups(null));
 		StatementGroup johnAlreadyHasBrownAndSilverHair = Datamodel.makeStatementGroup(
@@ -148,9 +164,19 @@ public class StatementUpdateBuilderTest {
 	}
 
 	@Test
+	public void testForStatementGroupsWithSubject() {
+		assertThrows(IllegalArgumentException.class, () -> StatementUpdateBuilder.forStatementGroups(JOHN,
+				Arrays.asList(Datamodel.makeStatementGroup(Arrays.asList(RITA_ALREADY_HAS_BROWN_HAIR)))));
+		StatementUpdateBuilder builder = StatementUpdateBuilder.forStatementGroups(JOHN, Collections.emptyList());
+		assertThrows(IllegalArgumentException.class, () -> builder.add(RITA_HAS_BROWN_HAIR));
+	}
+
+	@Test
 	public void testBlindAddition() {
 		StatementUpdateBuilder builder = StatementUpdateBuilder.create();
 		assertThrows(NullPointerException.class, () -> builder.add(null));
+		// placeholder ID
+		assertThrows(IllegalArgumentException.class, () -> builder.add(NOBODY_HAS_BROWN_HAIR));
 		builder.add(JOHN_HAS_BROWN_HAIR); // simple case
 		builder.add(JOHN_HAS_BROWN_HAIR); // duplicates allowed
 		builder.add(JOHN_ALREADY_HAS_BROWN_EYES); // strip ID
@@ -164,6 +190,8 @@ public class StatementUpdateBuilderTest {
 	public void testBlindReplacement() {
 		StatementUpdateBuilder builder = StatementUpdateBuilder.create();
 		assertThrows(NullPointerException.class, () -> builder.replace(null));
+		// placeholder ID
+		assertThrows(IllegalArgumentException.class, () -> builder.replace(NOBODY_ALREADY_HAS_BROWN_HAIR));
 		builder.remove(JOHN_ALREADY_HAS_BROWN_EYES.getStatementId());
 		builder.replace(JOHN_ALREADY_HAS_BROWN_HAIR); // simple case
 		builder.replace(JOHN_ALREADY_HAS_BROWN_EYES); // previously removed

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilderTest.java
@@ -98,9 +98,9 @@ public class StatementUpdateBuilderTest {
 	@Test
 	public void testCreate() {
 		StatementUpdate update = StatementUpdateBuilder.create().build();
-		assertThat(update.getAddedStatements(), is(empty()));
-		assertThat(update.getReplacedStatements(), is(anEmptyMap()));
-		assertThat(update.getRemovedStatements(), is(empty()));
+		assertThat(update.getAdded(), is(empty()));
+		assertThat(update.getReplaced(), is(anEmptyMap()));
+		assertThat(update.getRemoved(), is(empty()));
 	}
 
 	@Test
@@ -125,9 +125,9 @@ public class StatementUpdateBuilderTest {
 		StatementUpdate update = StatementUpdateBuilder
 				.forStatements(Arrays.asList(JOHN_ALREADY_HAS_BROWN_HAIR, JOHN_ALREADY_HAS_BROWN_EYES))
 				.build();
-		assertThat(update.getAddedStatements(), is(empty()));
-		assertThat(update.getReplacedStatements(), is(anEmptyMap()));
-		assertThat(update.getRemovedStatements(), is(empty()));
+		assertThat(update.getAdded(), is(empty()));
+		assertThat(update.getReplaced(), is(anEmptyMap()));
+		assertThat(update.getRemoved(), is(empty()));
 	}
 
 	@Test
@@ -142,55 +142,54 @@ public class StatementUpdateBuilderTest {
 		StatementUpdate update = StatementUpdateBuilder
 				.forStatementGroups(Arrays.asList(johnAlreadyHasBrownAndSilverHair))
 				.build();
-		assertThat(update.getAddedStatements(), is(empty()));
-		assertThat(update.getReplacedStatements(), is(anEmptyMap()));
-		assertThat(update.getRemovedStatements(), is(empty()));
+		assertThat(update.getAdded(), is(empty()));
+		assertThat(update.getReplaced(), is(anEmptyMap()));
+		assertThat(update.getRemoved(), is(empty()));
 	}
 
 	@Test
 	public void testBlindAddition() {
 		StatementUpdateBuilder builder = StatementUpdateBuilder.create();
-		assertThrows(NullPointerException.class, () -> builder.addStatement(null));
-		builder.addStatement(JOHN_HAS_BROWN_HAIR); // simple case
-		builder.addStatement(JOHN_HAS_BROWN_HAIR); // duplicates allowed
-		builder.addStatement(JOHN_ALREADY_HAS_BROWN_EYES); // strip ID
+		assertThrows(NullPointerException.class, () -> builder.add(null));
+		builder.add(JOHN_HAS_BROWN_HAIR); // simple case
+		builder.add(JOHN_HAS_BROWN_HAIR); // duplicates allowed
+		builder.add(JOHN_ALREADY_HAS_BROWN_EYES); // strip ID
 		// inconsistent subject
-		assertThrows(IllegalArgumentException.class, () -> builder.addStatement(RITA_HAS_BROWN_HAIR));
+		assertThrows(IllegalArgumentException.class, () -> builder.add(RITA_HAS_BROWN_HAIR));
 		StatementUpdate update = builder.build();
-		assertEquals(update.getAddedStatements(),
-				Arrays.asList(JOHN_HAS_BROWN_HAIR, JOHN_HAS_BROWN_HAIR, JOHN_HAS_BROWN_EYES));
+		assertEquals(update.getAdded(), Arrays.asList(JOHN_HAS_BROWN_HAIR, JOHN_HAS_BROWN_HAIR, JOHN_HAS_BROWN_EYES));
 	}
 
 	@Test
 	public void testBlindReplacement() {
 		StatementUpdateBuilder builder = StatementUpdateBuilder.create();
-		assertThrows(NullPointerException.class, () -> builder.replaceStatement(null));
-		builder.removeStatement(JOHN_ALREADY_HAS_BROWN_EYES.getStatementId());
-		builder.replaceStatement(JOHN_ALREADY_HAS_BROWN_HAIR); // simple case
-		builder.replaceStatement(JOHN_ALREADY_HAS_BROWN_EYES); // previously removed
-		builder.replaceStatement(JOHN_ALREADY_HAS_BROWN_HAIR); // replace twice
+		assertThrows(NullPointerException.class, () -> builder.replace(null));
+		builder.remove(JOHN_ALREADY_HAS_BROWN_EYES.getStatementId());
+		builder.replace(JOHN_ALREADY_HAS_BROWN_HAIR); // simple case
+		builder.replace(JOHN_ALREADY_HAS_BROWN_EYES); // previously removed
+		builder.replace(JOHN_ALREADY_HAS_BROWN_HAIR); // replace twice
 		// inconsistent subject
-		assertThrows(IllegalArgumentException.class, () -> builder.replaceStatement(RITA_ALREADY_HAS_BROWN_HAIR));
+		assertThrows(IllegalArgumentException.class, () -> builder.replace(RITA_ALREADY_HAS_BROWN_HAIR));
 		// no statement ID
-		assertThrows(IllegalArgumentException.class, () -> builder.replaceStatement(JOHN_HAS_SILVER_HAIR));
+		assertThrows(IllegalArgumentException.class, () -> builder.replace(JOHN_HAS_SILVER_HAIR));
 		StatementUpdate update = builder.build();
-		assertThat(update.getRemovedStatements(), is(empty()));
+		assertThat(update.getRemoved(), is(empty()));
 		assertThat(
-				update.getReplacedStatements().values(),
+				update.getReplaced().values(),
 				containsInAnyOrder(JOHN_ALREADY_HAS_BROWN_HAIR, JOHN_ALREADY_HAS_BROWN_EYES));
 	}
 
 	@Test
 	public void testBlindRemoval() {
 		StatementUpdateBuilder builder = StatementUpdateBuilder.create();
-		assertThrows(NullPointerException.class, () -> builder.removeStatement(null));
-		assertThrows(IllegalArgumentException.class, () -> builder.removeStatement(""));
-		builder.replaceStatement(JOHN_ALREADY_HAS_BROWN_EYES);
-		builder.removeStatement(JOHN_ALREADY_HAS_BROWN_HAIR.getStatementId()); // simple case
-		builder.removeStatement(JOHN_ALREADY_HAS_BROWN_EYES.getStatementId()); // previously replaced
+		assertThrows(NullPointerException.class, () -> builder.remove(null));
+		assertThrows(IllegalArgumentException.class, () -> builder.remove(""));
+		builder.replace(JOHN_ALREADY_HAS_BROWN_EYES);
+		builder.remove(JOHN_ALREADY_HAS_BROWN_HAIR.getStatementId()); // simple case
+		builder.remove(JOHN_ALREADY_HAS_BROWN_EYES.getStatementId()); // previously replaced
 		StatementUpdate update = builder.build();
-		assertThat(update.getReplacedStatements(), is(anEmptyMap()));
-		assertThat(update.getRemovedStatements(), containsInAnyOrder(
+		assertThat(update.getReplaced(), is(anEmptyMap()));
+		assertThat(update.getRemoved(), containsInAnyOrder(
 				JOHN_ALREADY_HAS_BROWN_HAIR.getStatementId(),
 				JOHN_ALREADY_HAS_BROWN_EYES.getStatementId()));
 	}
@@ -200,11 +199,11 @@ public class StatementUpdateBuilderTest {
 		StatementUpdateBuilder builder = StatementUpdateBuilder
 				.forStatements(Arrays.asList(JOHN_ALREADY_HAS_BROWN_HAIR));
 		// inconsistent subject
-		assertThrows(IllegalArgumentException.class, () -> builder.addStatement(RITA_HAS_BROWN_HAIR));
-		builder.addStatement(JOHN_HAS_BROWN_EYES); // simple case
-		builder.addStatement(JOHN_ALREADY_HAS_BROWN_HAIR); // duplicating existing statements is allowed
+		assertThrows(IllegalArgumentException.class, () -> builder.add(RITA_HAS_BROWN_HAIR));
+		builder.add(JOHN_HAS_BROWN_EYES); // simple case
+		builder.add(JOHN_ALREADY_HAS_BROWN_HAIR); // duplicating existing statements is allowed
 		StatementUpdate update = builder.build();
-		assertEquals(update.getAddedStatements(), Arrays.asList(JOHN_HAS_BROWN_EYES, JOHN_HAS_BROWN_HAIR));
+		assertEquals(update.getAdded(), Arrays.asList(JOHN_HAS_BROWN_EYES, JOHN_HAS_BROWN_HAIR));
 	}
 
 	@Test
@@ -214,54 +213,54 @@ public class StatementUpdateBuilderTest {
 				JOHN_ALREADY_HAS_BROWN_EYES,
 				JOHN_ALREADY_HAS_BLUE_SHIRT,
 				JOHN_ALREADY_HAS_BROWN_TROUSERS));
-		builder.removeStatement(JOHN_ALREADY_HAS_BROWN_EYES.getStatementId());
+		builder.remove(JOHN_ALREADY_HAS_BROWN_EYES.getStatementId());
 		Statement johnChangesBrownTrousersToBlueTrousers = JOHN_HAS_BLUE_TROUSERS
 				.withStatementId(JOHN_ALREADY_HAS_BROWN_TROUSERS.getStatementId());
-		builder.replaceStatement(johnChangesBrownTrousersToBlueTrousers);
+		builder.replace(johnChangesBrownTrousersToBlueTrousers);
 		// inconsistent subject
-		assertThrows(IllegalArgumentException.class, () -> builder.replaceStatement(
+		assertThrows(IllegalArgumentException.class, () -> builder.replace(
 				RITA_ALREADY_HAS_BROWN_HAIR.withStatementId(JOHN_ALREADY_HAS_BROWN_EYES.getStatementId())));
 		// unknown ID
 		assertThrows(IllegalArgumentException.class,
-				() -> builder.replaceStatement(JOHN_ALREADY_HAS_BROWN_HAIR.withStatementId("ID999")));
+				() -> builder.replace(JOHN_ALREADY_HAS_BROWN_HAIR.withStatementId("ID999")));
 		Statement johnChangesBrownHairToSilverHair = JOHN_HAS_SILVER_HAIR
 				.withStatementId(JOHN_ALREADY_HAS_BROWN_HAIR.getStatementId());
-		builder.replaceStatement(johnChangesBrownHairToSilverHair); // simple case
-		builder.replaceStatement(JOHN_ALREADY_HAS_BLUE_SHIRT); // no change
-		builder.replaceStatement(JOHN_ALREADY_HAS_BROWN_EYES); // restore deleted
-		builder.replaceStatement(JOHN_ALREADY_HAS_BROWN_TROUSERS); // restore replaced
+		builder.replace(johnChangesBrownHairToSilverHair); // simple case
+		builder.replace(JOHN_ALREADY_HAS_BLUE_SHIRT); // no change
+		builder.replace(JOHN_ALREADY_HAS_BROWN_EYES); // restore deleted
+		builder.replace(JOHN_ALREADY_HAS_BROWN_TROUSERS); // restore replaced
 		StatementUpdate update = builder.build();
-		assertThat(update.getRemovedStatements(), is(empty()));
-		assertThat(update.getReplacedStatements().values(), containsInAnyOrder(johnChangesBrownHairToSilverHair));
+		assertThat(update.getRemoved(), is(empty()));
+		assertThat(update.getReplaced().values(), containsInAnyOrder(johnChangesBrownHairToSilverHair));
 	}
 
 	@Test
 	public void testBaseRemoval() {
 		StatementUpdateBuilder builder = StatementUpdateBuilder
 				.forStatements(Arrays.asList(JOHN_ALREADY_HAS_BROWN_HAIR));
-		assertThrows(IllegalArgumentException.class, () -> builder.removeStatement("ID999")); // unknown ID
-		builder.removeStatement(JOHN_ALREADY_HAS_BROWN_HAIR.getStatementId()); // simple case
+		assertThrows(IllegalArgumentException.class, () -> builder.remove("ID999")); // unknown ID
+		builder.remove(JOHN_ALREADY_HAS_BROWN_HAIR.getStatementId()); // simple case
 		StatementUpdate update = builder.build();
-		assertThat(update.getRemovedStatements(), containsInAnyOrder(JOHN_ALREADY_HAS_BROWN_HAIR.getStatementId()));
+		assertThat(update.getRemoved(), containsInAnyOrder(JOHN_ALREADY_HAS_BROWN_HAIR.getStatementId()));
 	}
 
 	@Test
 	public void testMerge() {
-		assertThrows(NullPointerException.class, () -> StatementUpdateBuilder.create().apply(null));
+		assertThrows(NullPointerException.class, () -> StatementUpdateBuilder.create().append(null));
 		StatementUpdate update = StatementUpdateBuilder.create()
-				.addStatement(JOHN_HAS_BROWN_EYES) // prior addition
-				.replaceStatement(JOHN_ALREADY_HAS_SILVER_HAIR) // prior replacement
-				.removeStatement(JOHN_ALREADY_HAS_BLUE_SHIRT.getStatementId()) // prior removal
-				.apply(StatementUpdateBuilder.create()
-						.addStatement(JOHN_HAS_BROWN_TROUSERS) // another addition
-						.replaceStatement(JOHN_ALREADY_HAS_BROWN_HAIR) // another replacement
-						.removeStatement(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId()) // another removal
+				.add(JOHN_HAS_BROWN_EYES) // prior addition
+				.replace(JOHN_ALREADY_HAS_SILVER_HAIR) // prior replacement
+				.remove(JOHN_ALREADY_HAS_BLUE_SHIRT.getStatementId()) // prior removal
+				.append(StatementUpdateBuilder.create()
+						.add(JOHN_HAS_BROWN_TROUSERS) // another addition
+						.replace(JOHN_ALREADY_HAS_BROWN_HAIR) // another replacement
+						.remove(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId()) // another removal
 						.build())
 				.build();
-		assertEquals(update.getAddedStatements(), Arrays.asList(JOHN_HAS_BROWN_EYES, JOHN_HAS_BROWN_TROUSERS));
-		assertThat(update.getReplacedStatements().values(),
+		assertEquals(update.getAdded(), Arrays.asList(JOHN_HAS_BROWN_EYES, JOHN_HAS_BROWN_TROUSERS));
+		assertThat(update.getReplaced().values(),
 				containsInAnyOrder(JOHN_ALREADY_HAS_SILVER_HAIR, JOHN_ALREADY_HAS_BROWN_HAIR));
-		assertThat(update.getRemovedStatements(), containsInAnyOrder(
+		assertThat(update.getRemoved(), containsInAnyOrder(
 				JOHN_ALREADY_HAS_BLUE_SHIRT.getStatementId(),
 				JOHN_ALREADY_HAS_BLUE_EYES.getStatementId()));
 	}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/TermUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/TermUpdateBuilderTest.java
@@ -1,0 +1,123 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.helpers;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
+
+public class TermUpdateBuilderTest {
+
+	MonolingualTextValue en = Datamodel.makeMonolingualTextValue("hello", "en");
+	MonolingualTextValue en2 = Datamodel.makeMonolingualTextValue("hi", "en");
+	MonolingualTextValue sk = Datamodel.makeMonolingualTextValue("ahoj", "sk");
+	MonolingualTextValue cs = Datamodel.makeMonolingualTextValue("nazdar", "cs");
+	MonolingualTextValue de = Datamodel.makeMonolingualTextValue("Hallo", "de");
+	MonolingualTextValue de2 = Datamodel.makeMonolingualTextValue("Guten Tag", "de");
+	MonolingualTextValue fr = Datamodel.makeMonolingualTextValue("Bonjour", "fr");
+
+	@Test
+	public void testCreate() {
+		TermUpdate update = TermUpdateBuilder.create().build();
+		assertThat(update.getModifiedTerms(), is(anEmptyMap()));
+		assertThat(update.getRemovedTerms(), is(empty()));
+	}
+
+	@Test
+	public void testForTerms() {
+		assertThrows(NullPointerException.class, () -> TermUpdateBuilder.forTerms(null));
+		assertThrows(IllegalArgumentException.class, () -> TermUpdateBuilder.forTerms(Arrays.asList(sk, null)));
+		assertThrows(IllegalArgumentException.class, () -> TermUpdateBuilder.forTerms(Arrays.asList(sk, sk)));
+		TermUpdate update = TermUpdateBuilder.forTerms(Arrays.asList(sk, en)).build();
+		assertThat(update.getModifiedTerms(), is(anEmptyMap()));
+		assertThat(update.getRemovedTerms(), is(empty()));
+	}
+
+	@Test
+	public void testBlindAssignment() {
+		TermUpdateBuilder builder = TermUpdateBuilder.create();
+		assertThrows(NullPointerException.class, () -> builder.setTerm(null));
+		builder.removeTerm("sk");
+		builder.removeTerm("de");
+		builder.setTerm(en); // simple case
+		builder.setTerm(sk); // previously removed
+		TermUpdate update = builder.build();
+		assertThat(update.getRemovedTerms(), containsInAnyOrder("de"));
+		assertThat(update.getModifiedTerms().keySet(), containsInAnyOrder("sk", "en"));
+		assertEquals(en, update.getModifiedTerms().get("en"));
+		assertEquals(sk, update.getModifiedTerms().get("sk"));
+	}
+
+	@Test
+	public void testBlindRemoval() {
+		TermUpdateBuilder builder = TermUpdateBuilder.create();
+		assertThrows(NullPointerException.class, () -> builder.removeTerm(null));
+		builder.setTerm(en);
+		builder.setTerm(sk);
+		builder.removeTerm("de"); // simple case
+		builder.removeTerm("sk"); // previously assigned
+		TermUpdate update = builder.build();
+		assertThat(update.getRemovedTerms(), containsInAnyOrder("sk", "de"));
+		assertThat(update.getModifiedTerms().keySet(), containsInAnyOrder("en"));
+	}
+
+	@Test
+	public void testBaseAssignment() {
+		TermUpdateBuilder builder = TermUpdateBuilder.forTerms(Arrays.asList(sk, en, de, cs));
+		builder.removeTerm("sk");
+		builder.removeTerm("de");
+		builder.setTerm(fr); // new language key
+		builder.setTerm(en2); // new value
+		builder.setTerm(cs); // same value
+		builder.setTerm(sk); // same value for previously removed
+		builder.setTerm(de2); // new value for previously removed
+		TermUpdate update = builder.build();
+		assertThat(update.getRemovedTerms(), is(empty()));
+		assertThat(update.getModifiedTerms().keySet(), containsInAnyOrder("en", "de", "fr"));
+		assertEquals(fr, update.getModifiedTerms().get("fr"));
+		assertEquals(en2, update.getModifiedTerms().get("en"));
+		assertEquals(de2, update.getModifiedTerms().get("de"));
+	}
+
+	@Test
+	public void testBaseRemoval() {
+		TermUpdateBuilder builder = TermUpdateBuilder.forTerms(Arrays.asList(en, sk, cs));
+		builder.setTerm(en2);
+		builder.setTerm(de);
+		builder.removeTerm("sk"); // simple case
+		builder.removeTerm("fr"); // not found
+		builder.removeTerm("en"); // previously modified
+		builder.removeTerm("de"); // previously added
+		TermUpdate update = builder.build();
+		assertThat(update.getModifiedTerms(), anEmptyMap());
+		assertThat(update.getRemovedTerms(), containsInAnyOrder("en", "sk"));
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/TermUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/TermUpdateBuilderTest.java
@@ -53,7 +53,7 @@ public class TermUpdateBuilderTest {
 	@Test
 	public void testForTerms() {
 		assertThrows(NullPointerException.class, () -> TermUpdateBuilder.forTerms(null));
-		assertThrows(IllegalArgumentException.class, () -> TermUpdateBuilder.forTerms(Arrays.asList(sk, null)));
+		assertThrows(NullPointerException.class, () -> TermUpdateBuilder.forTerms(Arrays.asList(sk, null)));
 		assertThrows(IllegalArgumentException.class, () -> TermUpdateBuilder.forTerms(Arrays.asList(sk, sk)));
 		TermUpdate update = TermUpdateBuilder.forTerms(Arrays.asList(sk, en)).build();
 		assertThat(update.getModifiedTerms(), is(anEmptyMap()));

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/TermUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/TermUpdateBuilderTest.java
@@ -79,6 +79,7 @@ public class TermUpdateBuilderTest {
 	public void testBlindRemoval() {
 		TermUpdateBuilder builder = TermUpdateBuilder.create();
 		assertThrows(NullPointerException.class, () -> builder.removeTerm(null));
+		assertThrows(IllegalArgumentException.class, () -> builder.removeTerm(" "));
 		builder.setTerm(EN);
 		builder.setTerm(SK);
 		builder.removeTerm("de"); // simple case

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/TermedDocumentUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/TermedDocumentUpdateBuilderTest.java
@@ -1,0 +1,190 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.helpers;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
+import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.MediaInfoIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
+import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocumentUpdate;
+
+public class TermedDocumentUpdateBuilderTest {
+
+	private static final ItemIdValue Q1 = EntityUpdateBuilderTest.Q1;
+	private static final PropertyIdValue P1 = EntityUpdateBuilderTest.P1;
+	private static final MediaInfoIdValue M1 = EntityUpdateBuilderTest.M1;
+	private static final ItemDocument ITEM = EntityUpdateBuilderTest.ITEM;
+	private static final PropertyDocument PROPERTY = EntityUpdateBuilderTest.PROPERTY;
+	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateBuilderTest.JOHN_HAS_BROWN_HAIR;
+	private static final MonolingualTextValue EN = TermUpdateBuilderTest.EN;
+	private static final MonolingualTextValue EN2 = TermUpdateBuilderTest.EN2;
+	private static final MonolingualTextValue DE = TermUpdateBuilderTest.DE;
+	private static final MonolingualTextValue DE2 = TermUpdateBuilderTest.DE2;
+	private static final MonolingualTextValue SK = TermUpdateBuilderTest.SK;
+	private static final MonolingualTextValue CS = TermUpdateBuilderTest.CS;
+	private static final MonolingualTextValue FR = TermUpdateBuilderTest.FR;
+	private static final MonolingualTextValue ES = Datamodel.makeMonolingualTextValue("hola", "es");
+
+	@Test
+	public void testForEntityId() {
+		assertThrows(NullPointerException.class, () -> TermedDocumentUpdateBuilder.forEntityId(null));
+		assertThrows(IllegalArgumentException.class, () -> TermedDocumentUpdateBuilder.forEntityId(ItemIdValue.NULL));
+		assertThrows(IllegalArgumentException.class, () -> TermedDocumentUpdateBuilder.forEntityId(M1));
+		assertThat(TermedDocumentUpdateBuilder.forEntityId(Q1), is(instanceOf(ItemUpdateBuilder.class)));
+		assertThat(TermedDocumentUpdateBuilder.forEntityId(P1), is(instanceOf(PropertyUpdateBuilder.class)));
+	}
+
+	@Test
+	public void testForBaseRevision() {
+		assertThrows(NullPointerException.class, () -> TermedDocumentUpdateBuilder.forBaseRevision(null));
+		assertThrows(IllegalArgumentException.class,
+				() -> TermedDocumentUpdateBuilder.forBaseRevision(Datamodel.makeItemDocument(ItemIdValue.NULL)));
+		assertThat(TermedDocumentUpdateBuilder.forBaseRevision(ITEM), is(instanceOf(ItemUpdateBuilder.class)));
+		assertThat(TermedDocumentUpdateBuilder.forBaseRevision(PROPERTY), is(instanceOf(PropertyUpdateBuilder.class)));
+	}
+
+	@Test
+	public void testStatementUpdate() {
+		TermedStatementDocumentUpdate update = TermedDocumentUpdateBuilder.forEntityId(Q1)
+				.updateStatements(StatementUpdateBuilder.create().addStatement(JOHN_HAS_BROWN_HAIR).build())
+				.build();
+		assertThat(update.getStatements().getAddedStatements(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
+	}
+
+	@Test
+	public void testLabelUpdate() {
+		TermedStatementDocumentUpdate update = TermedDocumentUpdateBuilder.forEntityId(Q1)
+				.updateLabels(TermUpdateBuilder.create().removeTerm("en").build())
+				.build();
+		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("en"));
+	}
+
+	@Test
+	public void testBlindDescriptionUpdate() {
+		assertThrows(NullPointerException.class,
+				() -> TermedDocumentUpdateBuilder.forEntityId(Q1).updateDescriptions(null));
+		TermedStatementDocumentUpdate update = TermedDocumentUpdateBuilder.forEntityId(Q1)
+				.updateDescriptions(TermUpdateBuilder.create().removeTerm("en").build())
+				.updateDescriptions(TermUpdateBuilder.create().removeTerm("sk").build())
+				.build();
+		assertThat(update.getDescriptions().getRemovedTerms(), containsInAnyOrder("en", "sk"));
+	}
+
+	@Test
+	public void testBaseDescriptionUpdate() {
+		TermedStatementDocumentUpdate update = TermedDocumentUpdateBuilder
+				.forBaseRevision(ITEM
+						.withDescription(EN)
+						.withDescription(SK))
+				.updateDescriptions(TermUpdateBuilder.create()
+						.setTerm(SK) // ignored
+						.removeTerm("en") // checked
+						.build())
+				.build();
+		assertThat(update.getDescriptions().getModifiedTerms(), is(anEmptyMap()));
+		assertThat(update.getDescriptions().getRemovedTerms(), containsInAnyOrder("en"));
+	}
+
+	@Test
+	public void testBlindAliasChanges() {
+		TermedDocumentUpdateBuilder builder = TermedDocumentUpdateBuilder.forEntityId(Q1);
+		assertThrows(NullPointerException.class, () -> builder.setAliases(null, Collections.emptyList()));
+		assertThrows(IllegalArgumentException.class, () -> builder.setAliases(" ", Collections.emptyList()));
+		assertThrows(NullPointerException.class, () -> builder.setAliases("en", null));
+		assertThrows(NullPointerException.class, () -> builder.setAliases("en", Arrays.asList("hello", null)));
+		assertThrows(IllegalArgumentException.class, () -> builder.setAliases("en", Arrays.asList("hello", "hello")));
+		TermedStatementDocumentUpdate update = builder
+				.setAliases("sk", Arrays.asList(SK.getText())) // single value
+				.setAliases("en", Arrays.asList(EN.getText(), EN2.getText())) // multiple values
+				.setAliases("cs", Collections.emptyList()) // remove aliases
+				.setAliases("de", Arrays.asList(DE.getText()))
+				.setAliases("de", Arrays.asList(DE2.getText())) // overwrite previous value
+				.build();
+		assertThat(update.getAliases().keySet(), containsInAnyOrder("de", "en", "cs", "sk"));
+		assertEquals(Arrays.asList(SK), update.getAliases().get("sk"));
+		assertEquals(Arrays.asList(EN, EN2), update.getAliases().get("en"));
+		assertThat(update.getAliases().get("cs"), is(empty()));
+		assertEquals(Arrays.asList(DE2), update.getAliases().get("de"));
+	}
+
+	@Test
+	public void testBaseAliasChanges() {
+		TermedDocumentUpdateBuilder builder = TermedDocumentUpdateBuilder.forBaseRevision(ITEM
+				.withAliases("en", Arrays.asList(EN))
+				.withAliases("de", Arrays.asList(DE))
+				.withAliases("cs", Arrays.asList(CS))
+				.withAliases("fr", Arrays.asList(FR))
+				.withAliases("es", Arrays.asList(ES)));
+		TermedStatementDocumentUpdate update = builder
+				.setAliases("sk", Arrays.asList(SK.getText())) // add alias
+				.setAliases("cs", Collections.emptyList()) // remove alias
+				.setAliases("de", Arrays.asList(DE2.getText())) // modify alias
+				.setAliases("pl", Collections.emptyList()) // remove non-existent
+				.setAliases("es", Arrays.asList(ES.getText())) // same value
+				.setAliases("en", Arrays.asList(EN2.getText()))
+				.setAliases("en", Arrays.asList(EN.getText())) // revert modification
+				.setAliases("fr", Collections.emptyList())
+				.setAliases("fr", Arrays.asList(FR.getText())) // revert removal
+				.setAliases("el", Arrays.asList("?"))
+				.setAliases("el", Collections.emptyList()) // revert addition
+				.build();
+		assertThat(update.getAliases().keySet(), containsInAnyOrder("de", "cs", "sk"));
+		assertEquals(Arrays.asList(DE2), update.getAliases().get("de"));
+		assertThat(update.getAliases().get("cs"), is(empty()));
+		assertEquals(Arrays.asList(SK), update.getAliases().get("sk"));
+	}
+
+	@Test
+	public void testMerge() {
+		assertThrows(NullPointerException.class, () -> TermedDocumentUpdateBuilder.forEntityId(Q1).apply(null));
+		TermedDocumentUpdateBuilder builder = TermedDocumentUpdateBuilder.forEntityId(Q1)
+				.updateLabels(TermUpdateBuilder.create().removeTerm("pl").build())
+				.updateDescriptions(TermUpdateBuilder.create().removeTerm("fr").build())
+				.setAliases("en", Arrays.asList(EN.getText()));
+		builder.apply(TermedDocumentUpdateBuilder.forEntityId(Q1)
+				.updateLabels(TermUpdateBuilder.create().removeTerm("sk").build())
+				.updateDescriptions(TermUpdateBuilder.create().removeTerm("es").build())
+				.setAliases("de", Arrays.asList(DE.getText()))
+				.build());
+		TermedStatementDocumentUpdate update = builder.build();
+		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("sk", "pl"));
+		assertThat(update.getDescriptions().getRemovedTerms(), containsInAnyOrder("es", "fr"));
+		assertThat(update.getAliases().keySet(), containsInAnyOrder("en", "de"));
+		assertEquals(Arrays.asList(EN), update.getAliases().get("en"));
+		assertEquals(Arrays.asList(DE), update.getAliases().get("de"));
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/TermedDocumentUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/TermedDocumentUpdateBuilderTest.java
@@ -127,12 +127,12 @@ public class TermedDocumentUpdateBuilderTest {
 	@Test
 	public void testBlindAliasChanges() {
 		TermedDocumentUpdateBuilder builder = TermedDocumentUpdateBuilder.forEntityId(Q1);
-		assertThrows(NullPointerException.class, () -> builder.updateAliases(null, AliasUpdate.NULL));
-		assertThrows(IllegalArgumentException.class, () -> builder.updateAliases(" ", AliasUpdate.NULL));
+		assertThrows(NullPointerException.class, () -> builder.updateAliases(null, AliasUpdate.EMPTY));
+		assertThrows(IllegalArgumentException.class, () -> builder.updateAliases(" ", AliasUpdate.EMPTY));
 		assertThrows(NullPointerException.class, () -> builder.updateAliases("en", null));
 		TermedStatementDocumentUpdate update = builder
 				.updateAliases("sk", AliasUpdateBuilder.create().add(SK).build()) // simple case
-				.updateAliases("cs", AliasUpdate.NULL) // empty update
+				.updateAliases("cs", AliasUpdate.EMPTY) // empty update
 				.updateAliases("de", AliasUpdateBuilder.create().add(DE).build())
 				.updateAliases("de", AliasUpdateBuilder.create().add(DE2).build()) // merge changes
 				.build();

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/TermedDocumentUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/TermedDocumentUpdateBuilderTest.java
@@ -69,6 +69,12 @@ public class TermedDocumentUpdateBuilderTest {
 	}
 
 	@Test
+	public void testForBaseRevisionId() {
+		assertEquals(123, TermedDocumentUpdateBuilder.forBaseRevisionId(Q1, 123).getBaseRevisionId());
+		assertEquals(123, TermedDocumentUpdateBuilder.forBaseRevisionId(P1, 123).getBaseRevisionId());
+	}
+
+	@Test
 	public void testForBaseRevision() {
 		assertThrows(NullPointerException.class, () -> TermedDocumentUpdateBuilder.forBaseRevision(null));
 		assertThrows(IllegalArgumentException.class,

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/TermedDocumentUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/TermedDocumentUpdateBuilderTest.java
@@ -57,6 +57,7 @@ public class TermedDocumentUpdateBuilderTest {
 	private static final MonolingualTextValue CS = TermUpdateBuilderTest.CS;
 	private static final MonolingualTextValue FR = TermUpdateBuilderTest.FR;
 	private static final MonolingualTextValue ES = Datamodel.makeMonolingualTextValue("hola", "es");
+	private static final MonolingualTextValue EL = Datamodel.makeMonolingualTextValue("yassou", "el");
 
 	@Test
 	public void testForEntityId() {
@@ -79,17 +80,17 @@ public class TermedDocumentUpdateBuilderTest {
 	@Test
 	public void testStatementUpdate() {
 		TermedStatementDocumentUpdate update = TermedDocumentUpdateBuilder.forEntityId(Q1)
-				.updateStatements(StatementUpdateBuilder.create().addStatement(JOHN_HAS_BROWN_HAIR).build())
+				.updateStatements(StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())
 				.build();
-		assertThat(update.getStatements().getAddedStatements(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
+		assertThat(update.getStatements().getAdded(), containsInAnyOrder(JOHN_HAS_BROWN_HAIR));
 	}
 
 	@Test
 	public void testLabelUpdate() {
 		TermedStatementDocumentUpdate update = TermedDocumentUpdateBuilder.forEntityId(Q1)
-				.updateLabels(TermUpdateBuilder.create().removeTerm("en").build())
+				.updateLabels(TermUpdateBuilder.create().remove("en").build())
 				.build();
-		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("en"));
+		assertThat(update.getLabels().getRemoved(), containsInAnyOrder("en"));
 	}
 
 	@Test
@@ -97,10 +98,10 @@ public class TermedDocumentUpdateBuilderTest {
 		assertThrows(NullPointerException.class,
 				() -> TermedDocumentUpdateBuilder.forEntityId(Q1).updateDescriptions(null));
 		TermedStatementDocumentUpdate update = TermedDocumentUpdateBuilder.forEntityId(Q1)
-				.updateDescriptions(TermUpdateBuilder.create().removeTerm("en").build())
-				.updateDescriptions(TermUpdateBuilder.create().removeTerm("sk").build())
+				.updateDescriptions(TermUpdateBuilder.create().remove("en").build())
+				.updateDescriptions(TermUpdateBuilder.create().remove("sk").build())
 				.build();
-		assertThat(update.getDescriptions().getRemovedTerms(), containsInAnyOrder("en", "sk"));
+		assertThat(update.getDescriptions().getRemoved(), containsInAnyOrder("en", "sk"));
 	}
 
 	@Test
@@ -110,28 +111,28 @@ public class TermedDocumentUpdateBuilderTest {
 						.withDescription(EN)
 						.withDescription(SK))
 				.updateDescriptions(TermUpdateBuilder.create()
-						.setTerm(SK) // ignored
-						.removeTerm("en") // checked
+						.put(SK) // ignored
+						.remove("en") // checked
 						.build())
 				.build();
-		assertThat(update.getDescriptions().getModifiedTerms(), is(anEmptyMap()));
-		assertThat(update.getDescriptions().getRemovedTerms(), containsInAnyOrder("en"));
+		assertThat(update.getDescriptions().getModified(), is(anEmptyMap()));
+		assertThat(update.getDescriptions().getRemoved(), containsInAnyOrder("en"));
 	}
 
 	@Test
 	public void testBlindAliasChanges() {
 		TermedDocumentUpdateBuilder builder = TermedDocumentUpdateBuilder.forEntityId(Q1);
-		assertThrows(NullPointerException.class, () -> builder.setAliases(null, Collections.emptyList()));
-		assertThrows(IllegalArgumentException.class, () -> builder.setAliases(" ", Collections.emptyList()));
-		assertThrows(NullPointerException.class, () -> builder.setAliases("en", null));
-		assertThrows(NullPointerException.class, () -> builder.setAliases("en", Arrays.asList("hello", null)));
-		assertThrows(IllegalArgumentException.class, () -> builder.setAliases("en", Arrays.asList("hello", "hello")));
+		assertThrows(NullPointerException.class, () -> builder.putAliases(null, Collections.emptyList()));
+		assertThrows(IllegalArgumentException.class, () -> builder.putAliases(" ", Collections.emptyList()));
+		assertThrows(NullPointerException.class, () -> builder.putAliases("en", null));
+		assertThrows(NullPointerException.class, () -> builder.putAliases("en", Arrays.asList(EN, null)));
+		assertThrows(IllegalArgumentException.class, () -> builder.putAliases("en", Arrays.asList(EN, EN)));
 		TermedStatementDocumentUpdate update = builder
-				.setAliases("sk", Arrays.asList(SK.getText())) // single value
-				.setAliases("en", Arrays.asList(EN.getText(), EN2.getText())) // multiple values
-				.setAliases("cs", Collections.emptyList()) // remove aliases
-				.setAliases("de", Arrays.asList(DE.getText()))
-				.setAliases("de", Arrays.asList(DE2.getText())) // overwrite previous value
+				.putAliases("sk", Arrays.asList(SK)) // single value
+				.putAliases("en", Arrays.asList(EN, EN2)) // multiple values
+				.putAliases("cs", Collections.emptyList()) // remove aliases
+				.putAliases("de", Arrays.asList(DE))
+				.putAliases("de", Arrays.asList(DE2)) // overwrite previous value
 				.build();
 		assertThat(update.getAliases().keySet(), containsInAnyOrder("de", "en", "cs", "sk"));
 		assertEquals(Arrays.asList(SK), update.getAliases().get("sk"));
@@ -149,17 +150,17 @@ public class TermedDocumentUpdateBuilderTest {
 				.withAliases("fr", Arrays.asList(FR))
 				.withAliases("es", Arrays.asList(ES)));
 		TermedStatementDocumentUpdate update = builder
-				.setAliases("sk", Arrays.asList(SK.getText())) // add alias
-				.setAliases("cs", Collections.emptyList()) // remove alias
-				.setAliases("de", Arrays.asList(DE2.getText())) // modify alias
-				.setAliases("pl", Collections.emptyList()) // remove non-existent
-				.setAliases("es", Arrays.asList(ES.getText())) // same value
-				.setAliases("en", Arrays.asList(EN2.getText()))
-				.setAliases("en", Arrays.asList(EN.getText())) // revert modification
-				.setAliases("fr", Collections.emptyList())
-				.setAliases("fr", Arrays.asList(FR.getText())) // revert removal
-				.setAliases("el", Arrays.asList("?"))
-				.setAliases("el", Collections.emptyList()) // revert addition
+				.putAliases("sk", Arrays.asList(SK)) // add alias
+				.putAliases("cs", Collections.emptyList()) // remove alias
+				.putAliases("de", Arrays.asList(DE2)) // modify alias
+				.putAliases("pl", Collections.emptyList()) // remove non-existent
+				.putAliases("es", Arrays.asList(ES)) // same value
+				.putAliases("en", Arrays.asList(EN2))
+				.putAliases("en", Arrays.asList(EN)) // revert modification
+				.putAliases("fr", Collections.emptyList())
+				.putAliases("fr", Arrays.asList(FR)) // revert removal
+				.putAliases("el", Arrays.asList(EL))
+				.putAliases("el", Collections.emptyList()) // revert addition
 				.build();
 		assertThat(update.getAliases().keySet(), containsInAnyOrder("de", "cs", "sk"));
 		assertEquals(Arrays.asList(DE2), update.getAliases().get("de"));
@@ -168,20 +169,36 @@ public class TermedDocumentUpdateBuilderTest {
 	}
 
 	@Test
+	public void testStringAliases() {
+		TermedDocumentUpdateBuilder builder = TermedDocumentUpdateBuilder.forEntityId(Q1);
+		assertThrows(NullPointerException.class, () -> builder.putAliasesAsStrings(null, Collections.emptyList()));
+		assertThrows(IllegalArgumentException.class, () -> builder.putAliasesAsStrings(" ", Collections.emptyList()));
+		assertThrows(NullPointerException.class, () -> builder.putAliasesAsStrings("en", null));
+		assertThrows(NullPointerException.class, () -> builder.putAliasesAsStrings("en", Arrays.asList("hello", null)));
+		TermedStatementDocumentUpdate update = builder
+				.putAliasesAsStrings("en", Arrays.asList(EN.getText(), EN2.getText()))
+				.putAliasesAsStrings("cs", Collections.emptyList())
+				.build();
+		assertThat(update.getAliases().keySet(), containsInAnyOrder("en", "cs"));
+		assertEquals(Arrays.asList(EN, EN2), update.getAliases().get("en"));
+		assertThat(update.getAliases().get("cs"), is(empty()));
+	}
+
+	@Test
 	public void testMerge() {
-		assertThrows(NullPointerException.class, () -> TermedDocumentUpdateBuilder.forEntityId(Q1).apply(null));
+		assertThrows(NullPointerException.class, () -> TermedDocumentUpdateBuilder.forEntityId(Q1).append(null));
 		TermedDocumentUpdateBuilder builder = TermedDocumentUpdateBuilder.forEntityId(Q1)
-				.updateLabels(TermUpdateBuilder.create().removeTerm("pl").build())
-				.updateDescriptions(TermUpdateBuilder.create().removeTerm("fr").build())
-				.setAliases("en", Arrays.asList(EN.getText()));
-		builder.apply(TermedDocumentUpdateBuilder.forEntityId(Q1)
-				.updateLabels(TermUpdateBuilder.create().removeTerm("sk").build())
-				.updateDescriptions(TermUpdateBuilder.create().removeTerm("es").build())
-				.setAliases("de", Arrays.asList(DE.getText()))
+				.updateLabels(TermUpdateBuilder.create().remove("pl").build())
+				.updateDescriptions(TermUpdateBuilder.create().remove("fr").build())
+				.putAliasesAsStrings("en", Arrays.asList(EN.getText()));
+		builder.append(TermedDocumentUpdateBuilder.forEntityId(Q1)
+				.updateLabels(TermUpdateBuilder.create().remove("sk").build())
+				.updateDescriptions(TermUpdateBuilder.create().remove("es").build())
+				.putAliasesAsStrings("de", Arrays.asList(DE.getText()))
 				.build());
 		TermedStatementDocumentUpdate update = builder.build();
-		assertThat(update.getLabels().getRemovedTerms(), containsInAnyOrder("sk", "pl"));
-		assertThat(update.getDescriptions().getRemovedTerms(), containsInAnyOrder("es", "fr"));
+		assertThat(update.getLabels().getRemoved(), containsInAnyOrder("sk", "pl"));
+		assertThat(update.getDescriptions().getRemoved(), containsInAnyOrder("es", "fr"));
 		assertThat(update.getAliases().keySet(), containsInAnyOrder("en", "de"));
 		assertEquals(Arrays.asList(EN), update.getAliases().get("en"));
 		assertEquals(Arrays.asList(DE), update.getAliases().get("de"));

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/TermedDocumentUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/TermedDocumentUpdateBuilderTest.java
@@ -24,7 +24,6 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.empty;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -32,6 +31,7 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoIdValue;
@@ -57,7 +57,6 @@ public class TermedDocumentUpdateBuilderTest {
 	private static final MonolingualTextValue CS = TermUpdateBuilderTest.CS;
 	private static final MonolingualTextValue FR = TermUpdateBuilderTest.FR;
 	private static final MonolingualTextValue ES = Datamodel.makeMonolingualTextValue("hola", "es");
-	private static final MonolingualTextValue EL = Datamodel.makeMonolingualTextValue("yassou", "el");
 
 	@Test
 	public void testForEntityId() {
@@ -128,23 +127,18 @@ public class TermedDocumentUpdateBuilderTest {
 	@Test
 	public void testBlindAliasChanges() {
 		TermedDocumentUpdateBuilder builder = TermedDocumentUpdateBuilder.forEntityId(Q1);
-		assertThrows(NullPointerException.class, () -> builder.putAliases(null, Collections.emptyList()));
-		assertThrows(IllegalArgumentException.class, () -> builder.putAliases(" ", Collections.emptyList()));
-		assertThrows(NullPointerException.class, () -> builder.putAliases("en", null));
-		assertThrows(NullPointerException.class, () -> builder.putAliases("en", Arrays.asList(EN, null)));
-		assertThrows(IllegalArgumentException.class, () -> builder.putAliases("en", Arrays.asList(EN, EN)));
+		assertThrows(NullPointerException.class, () -> builder.updateAliases(null, AliasUpdate.NULL));
+		assertThrows(IllegalArgumentException.class, () -> builder.updateAliases(" ", AliasUpdate.NULL));
+		assertThrows(NullPointerException.class, () -> builder.updateAliases("en", null));
 		TermedStatementDocumentUpdate update = builder
-				.putAliases("sk", Arrays.asList(SK)) // single value
-				.putAliases("en", Arrays.asList(EN, EN2)) // multiple values
-				.putAliases("cs", Collections.emptyList()) // remove aliases
-				.putAliases("de", Arrays.asList(DE))
-				.putAliases("de", Arrays.asList(DE2)) // overwrite previous value
+				.updateAliases("sk", AliasUpdateBuilder.create().add(SK).build()) // simple case
+				.updateAliases("cs", AliasUpdate.NULL) // empty update
+				.updateAliases("de", AliasUpdateBuilder.create().add(DE).build())
+				.updateAliases("de", AliasUpdateBuilder.create().add(DE2).build()) // merge changes
 				.build();
-		assertThat(update.getAliases().keySet(), containsInAnyOrder("de", "en", "cs", "sk"));
-		assertEquals(Arrays.asList(SK), update.getAliases().get("sk"));
-		assertEquals(Arrays.asList(EN, EN2), update.getAliases().get("en"));
-		assertThat(update.getAliases().get("cs"), is(empty()));
-		assertEquals(Arrays.asList(DE2), update.getAliases().get("de"));
+		assertThat(update.getAliases().keySet(), containsInAnyOrder("de", "sk"));
+		assertEquals(AliasUpdateBuilder.create().add(SK).build(), update.getAliases().get("sk"));
+		assertEquals(AliasUpdateBuilder.create().add(DE).add(DE2).build(), update.getAliases().get("de"));
 	}
 
 	@Test
@@ -156,38 +150,20 @@ public class TermedDocumentUpdateBuilderTest {
 				.withAliases("fr", Arrays.asList(FR))
 				.withAliases("es", Arrays.asList(ES)));
 		TermedStatementDocumentUpdate update = builder
-				.putAliases("sk", Arrays.asList(SK)) // add alias
-				.putAliases("cs", Collections.emptyList()) // remove alias
-				.putAliases("de", Arrays.asList(DE2)) // modify alias
-				.putAliases("pl", Collections.emptyList()) // remove non-existent
-				.putAliases("es", Arrays.asList(ES)) // same value
-				.putAliases("en", Arrays.asList(EN2))
-				.putAliases("en", Arrays.asList(EN)) // revert modification
-				.putAliases("fr", Collections.emptyList())
-				.putAliases("fr", Arrays.asList(FR)) // revert removal
-				.putAliases("el", Arrays.asList(EL))
-				.putAliases("el", Collections.emptyList()) // revert addition
+				// extend existing alias list
+				.updateAliases("en", AliasUpdateBuilder.create().add(EN2).build())
+				// new language
+				.updateAliases("sk", AliasUpdateBuilder.create().add(SK).build())
+				// clear non-existent language
+				.updateAliases("pl", Datamodel.makeAliasUpdate(Collections.emptyList()))
+				// same value
+				.updateAliases("es", Datamodel.makeAliasUpdate(Arrays.asList(ES)))
+				// redundant change
+				.updateAliases("fr", AliasUpdateBuilder.create().add(FR).build())
 				.build();
-		assertThat(update.getAliases().keySet(), containsInAnyOrder("de", "cs", "sk"));
-		assertEquals(Arrays.asList(DE2), update.getAliases().get("de"));
-		assertThat(update.getAliases().get("cs"), is(empty()));
-		assertEquals(Arrays.asList(SK), update.getAliases().get("sk"));
-	}
-
-	@Test
-	public void testStringAliases() {
-		TermedDocumentUpdateBuilder builder = TermedDocumentUpdateBuilder.forEntityId(Q1);
-		assertThrows(NullPointerException.class, () -> builder.putAliasesAsStrings(null, Collections.emptyList()));
-		assertThrows(IllegalArgumentException.class, () -> builder.putAliasesAsStrings(" ", Collections.emptyList()));
-		assertThrows(NullPointerException.class, () -> builder.putAliasesAsStrings("en", null));
-		assertThrows(NullPointerException.class, () -> builder.putAliasesAsStrings("en", Arrays.asList("hello", null)));
-		TermedStatementDocumentUpdate update = builder
-				.putAliasesAsStrings("en", Arrays.asList(EN.getText(), EN2.getText()))
-				.putAliasesAsStrings("cs", Collections.emptyList())
-				.build();
-		assertThat(update.getAliases().keySet(), containsInAnyOrder("en", "cs"));
-		assertEquals(Arrays.asList(EN, EN2), update.getAliases().get("en"));
-		assertThat(update.getAliases().get("cs"), is(empty()));
+		assertThat(update.getAliases().keySet(), containsInAnyOrder("sk", "en"));
+		assertEquals(AliasUpdateBuilder.create().add(SK).build(), update.getAliases().get("sk"));
+		assertEquals(AliasUpdateBuilder.create().add(EN2).build(), update.getAliases().get("en"));
 	}
 
 	@Test
@@ -196,18 +172,19 @@ public class TermedDocumentUpdateBuilderTest {
 		TermedDocumentUpdateBuilder builder = TermedDocumentUpdateBuilder.forEntityId(Q1)
 				.updateLabels(TermUpdateBuilder.create().remove("pl").build())
 				.updateDescriptions(TermUpdateBuilder.create().remove("fr").build())
-				.putAliasesAsStrings("en", Arrays.asList(EN.getText()));
+				.updateAliases("en", AliasUpdateBuilder.create().add(EN).build());
 		builder.append(TermedDocumentUpdateBuilder.forEntityId(Q1)
 				.updateLabels(TermUpdateBuilder.create().remove("sk").build())
 				.updateDescriptions(TermUpdateBuilder.create().remove("es").build())
-				.putAliasesAsStrings("de", Arrays.asList(DE.getText()))
+				.updateAliases("en", AliasUpdateBuilder.create().add(EN2).build())
+				.updateAliases("de", AliasUpdateBuilder.create().add(DE).build())
 				.build());
 		TermedStatementDocumentUpdate update = builder.build();
 		assertThat(update.getLabels().getRemoved(), containsInAnyOrder("sk", "pl"));
 		assertThat(update.getDescriptions().getRemoved(), containsInAnyOrder("es", "fr"));
 		assertThat(update.getAliases().keySet(), containsInAnyOrder("en", "de"));
-		assertEquals(Arrays.asList(EN), update.getAliases().get("en"));
-		assertEquals(Arrays.asList(DE), update.getAliases().get("de"));
+		assertEquals(AliasUpdateBuilder.create().add(EN).add(EN2).build(), update.getAliases().get("en"));
+		assertEquals(AliasUpdateBuilder.create().add(DE).build(), update.getAliases().get("de"));
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/AliasUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/AliasUpdateImplTest.java
@@ -27,6 +27,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.producesJson;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,6 +36,7 @@ import java.util.List;
 
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.helpers.AliasUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
@@ -169,6 +171,18 @@ public class AliasUpdateImplTest {
 		AliasUpdate update2b = new AliasUpdateImpl(null, Arrays.asList(EN), Arrays.asList(EN2));
 		assertEquals(update1a.hashCode(), update1b.hashCode());
 		assertEquals(update2a.hashCode(), update2b.hashCode());
+	}
+
+	@Test
+	public void testJson() {
+		assertThat(AliasUpdateBuilder.create().build(), producesJson("null"));
+		assertThat(AliasUpdateBuilder.create().recreate(Collections.emptyList()).build(), producesJson("[]"));
+		assertThat(AliasUpdateBuilder.create().recreate(Arrays.asList(EN, EN2)).build(),
+				producesJson("[{'language':'en','value':'hello'},{'language':'en','value':'hi'}]"));
+		assertThat(AliasUpdateBuilder.create().add(EN).build(),
+				producesJson("[{'add':'','language':'en','value':'hello'}]"));
+		assertThat(AliasUpdateBuilder.create().remove(EN).build(),
+				producesJson("[{'language':'en','remove':'','value':'hello'}]"));
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/AliasUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/AliasUpdateImplTest.java
@@ -1,0 +1,174 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.implementation;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+
+public class AliasUpdateImplTest {
+
+	private static final MonolingualTextValue EN = Datamodel.makeMonolingualTextValue("hello", "en");
+	private static final MonolingualTextValue EN2 = Datamodel.makeMonolingualTextValue("hi", "en");
+	private static final MonolingualTextValue EN3 = Datamodel.makeMonolingualTextValue("hey", "en");
+	private static final MonolingualTextValue EN4 = Datamodel.makeMonolingualTextValue("howdy", "en");
+	private static final MonolingualTextValue SK = Datamodel.makeMonolingualTextValue("ahoj", "sk");
+
+	@Test
+	public void testFields() {
+		AliasUpdate empty = new AliasUpdateImpl(null, Collections.emptyList(), Collections.emptyList());
+		assertFalse(empty.getLanguageCode().isPresent());
+		assertFalse(empty.getRecreated().isPresent());
+		assertThat(empty.getAdded(), is(Matchers.empty()));
+		assertThat(empty.getRemoved(), is(Matchers.empty()));
+		AliasUpdate cleared = new AliasUpdateImpl(Collections.emptyList(), Collections.emptyList(),
+				Collections.emptyList());
+		assertFalse(cleared.getLanguageCode().isPresent());
+		assertThat(cleared.getRecreated().get(), is(Matchers.empty()));
+		assertThat(cleared.getAdded(), is(Matchers.empty()));
+		assertThat(cleared.getRemoved(), is(Matchers.empty()));
+		AliasUpdate recreated = new AliasUpdateImpl(Arrays.asList(EN, EN2), Collections.emptyList(),
+				Collections.emptyList());
+		assertEquals("en", recreated.getLanguageCode().get());
+		assertEquals(Arrays.asList(EN, EN2), recreated.getRecreated().get());
+		assertThat(recreated.getAdded(), is(Matchers.empty()));
+		assertThat(recreated.getRemoved(), is(Matchers.empty()));
+		AliasUpdate incremental = new AliasUpdateImpl(null, Arrays.asList(EN, EN2), Arrays.asList(EN3));
+		assertEquals("en", incremental.getLanguageCode().get());
+		assertFalse(incremental.getRecreated().isPresent());
+		assertThat(incremental.getAdded(), contains(EN, EN2));
+		assertThat(incremental.getRemoved(), containsInAnyOrder(EN3));
+	}
+
+	@Test
+	public void testValidation() {
+		assertThrows(NullPointerException.class, () -> new AliasUpdateImpl(null, null, Collections.emptyList()));
+		assertThrows(NullPointerException.class, () -> new AliasUpdateImpl(null, Collections.emptyList(), null));
+		assertThrows(NullPointerException.class,
+				() -> new AliasUpdateImpl(Arrays.asList(EN, null), Collections.emptyList(), Collections.emptyList()));
+		assertThrows(NullPointerException.class,
+				() -> new AliasUpdateImpl(null, Arrays.asList(EN, null), Collections.emptyList()));
+		assertThrows(NullPointerException.class,
+				() -> new AliasUpdateImpl(null, Collections.emptyList(), Arrays.asList(EN, null)));
+		assertThrows(IllegalArgumentException.class,
+				() -> new AliasUpdateImpl(Collections.emptyList(), Arrays.asList(EN), Collections.emptyList()));
+		assertThrows(IllegalArgumentException.class,
+				() -> new AliasUpdateImpl(Collections.emptyList(), Collections.emptyList(), Arrays.asList(EN)));
+		assertThrows(IllegalArgumentException.class,
+				() -> new AliasUpdateImpl(Arrays.asList(EN, SK), Collections.emptyList(), Collections.emptyList()));
+		assertThrows(IllegalArgumentException.class,
+				() -> new AliasUpdateImpl(null, Arrays.asList(EN, SK), Collections.emptyList()));
+		assertThrows(IllegalArgumentException.class,
+				() -> new AliasUpdateImpl(null, Collections.emptyList(), Arrays.asList(EN, SK)));
+		assertThrows(IllegalArgumentException.class,
+				() -> new AliasUpdateImpl(null, Arrays.asList(EN), Arrays.asList(SK)));
+		assertThrows(IllegalArgumentException.class,
+				() -> new AliasUpdateImpl(Arrays.asList(EN, EN), Collections.emptyList(), Collections.emptyList()));
+		assertThrows(IllegalArgumentException.class,
+				() -> new AliasUpdateImpl(null, Arrays.asList(EN, EN), Collections.emptyList()));
+		assertThrows(IllegalArgumentException.class,
+				() -> new AliasUpdateImpl(null, Collections.emptyList(), Arrays.asList(EN, EN)));
+		assertThrows(IllegalArgumentException.class,
+				() -> new AliasUpdateImpl(null, Arrays.asList(EN), Arrays.asList(EN)));
+	}
+
+	@Test
+	public void testImmutability() {
+		List<MonolingualTextValue> recreated = new ArrayList<>();
+		List<MonolingualTextValue> added = new ArrayList<>();
+		List<MonolingualTextValue> removed = new ArrayList<>();
+		recreated.add(EN);
+		added.add(EN);
+		removed.add(EN2);
+		AliasUpdate update1 = new AliasUpdateImpl(recreated, Collections.emptyList(), Collections.emptyList());
+		assertThrows(UnsupportedOperationException.class, () -> update1.getRecreated().get().add(EN4));
+		assertThrows(UnsupportedOperationException.class, () -> update1.getAdded().add(EN4));
+		assertThrows(UnsupportedOperationException.class, () -> update1.getRemoved().add(EN4));
+		AliasUpdate update2 = new AliasUpdateImpl(null, added, removed);
+		assertThrows(UnsupportedOperationException.class, () -> update2.getAdded().add(EN4));
+		assertThrows(UnsupportedOperationException.class, () -> update2.getRemoved().add(EN4));
+		recreated.add(EN2);
+		added.add(EN3);
+		removed.add(EN4);
+		assertEquals(1, update1.getRecreated().get().size());
+		assertEquals(1, update2.getAdded().size());
+		assertEquals(1, update2.getRemoved().size());
+	}
+
+	@Test
+	public void testEmpty() {
+		assertTrue(new AliasUpdateImpl(null, Collections.emptyList(), Collections.emptyList()).isEmpty());
+		assertFalse(new AliasUpdateImpl(null, Arrays.asList(EN), Collections.emptyList()).isEmpty());
+		assertFalse(new AliasUpdateImpl(null, Collections.emptyList(), Arrays.asList(EN)).isEmpty());
+		assertFalse(new AliasUpdateImpl(Arrays.asList(EN), Collections.emptyList(), Collections.emptyList()).isEmpty());
+		assertFalse(new AliasUpdateImpl(Collections.emptyList(), Collections.emptyList(), Collections.emptyList())
+				.isEmpty());
+	}
+
+	@Test
+	@SuppressWarnings("unlikely-arg-type")
+	public void testEquality() {
+		List<MonolingualTextValue> recreated = Arrays.asList(EN);
+		List<MonolingualTextValue> added = Arrays.asList(EN2);
+		List<MonolingualTextValue> removed = Arrays.asList(EN3);
+		AliasUpdate update1 = new AliasUpdateImpl(recreated, Collections.emptyList(), Collections.emptyList());
+		AliasUpdate update2 = new AliasUpdateImpl(null, added, removed);
+		assertFalse(update1.equals(null));
+		assertFalse(update2.equals(null));
+		assertFalse(update1.equals(this));
+		assertFalse(update2.equals(this));
+		assertTrue(update1.equals(update1));
+		assertTrue(update2.equals(update2));
+		assertFalse(update1.equals(update2));
+		assertTrue(update1.equals(new AliasUpdateImpl(recreated, Collections.emptyList(), Collections.emptyList())));
+		assertTrue(update2.equals(new AliasUpdateImpl(null, added, removed)));
+		assertFalse(update1.equals(
+				new AliasUpdateImpl(Arrays.asList(EN2), Collections.emptyList(), Collections.emptyList())));
+		assertFalse(update2.equals(new AliasUpdateImpl(null, Arrays.asList(EN4), removed)));
+		assertFalse(update2.equals(new AliasUpdateImpl(null, added, Arrays.asList(EN4))));
+	}
+
+	@Test
+	public void testHashCode() {
+		AliasUpdate update1a = new AliasUpdateImpl(Arrays.asList(EN), Collections.emptyList(), Collections.emptyList());
+		AliasUpdate update1b = new AliasUpdateImpl(Arrays.asList(EN), Collections.emptyList(), Collections.emptyList());
+		AliasUpdate update2a = new AliasUpdateImpl(null, Arrays.asList(EN), Arrays.asList(EN2));
+		AliasUpdate update2b = new AliasUpdateImpl(null, Arrays.asList(EN), Arrays.asList(EN2));
+		assertEquals(update1a.hashCode(), update1b.hashCode());
+		assertEquals(update2a.hashCode(), update2b.hashCode());
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/EntityUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/EntityUpdateImplTest.java
@@ -40,7 +40,7 @@ public class EntityUpdateImplTest {
 
 	private static EntityUpdate create(PropertyIdValue entityId, long revisionId) {
 		return new PropertyUpdateImpl(entityId, revisionId,
-				TermUpdate.NULL, TermUpdate.NULL, Collections.emptyMap(), StatementUpdate.NULL);
+				TermUpdate.EMPTY, TermUpdate.EMPTY, Collections.emptyMap(), StatementUpdate.EMPTY);
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/EntityUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/EntityUpdateImplTest.java
@@ -1,0 +1,100 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.implementation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.helpers.PropertyUpdateBuilder;
+import org.wikidata.wdtk.datamodel.helpers.StatementUpdateBuilder;
+import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;
+import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.EntityUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
+
+public class EntityUpdateImplTest {
+
+	private static final PropertyIdValue P1 = Datamodel.makeWikidataPropertyIdValue("P1");
+	private static final PropertyIdValue P2 = Datamodel.makeWikidataPropertyIdValue("P2");
+	private static final PropertyDocument PROPERTY = Datamodel.makePropertyDocument(
+			P1, Datamodel.makeDatatypeIdValue(DatatypeIdValue.DT_ITEM));
+	private static final TermUpdate NO_TERMS = TermUpdateBuilder.create().build();
+	private static final StatementUpdate NO_STATEMENTS = StatementUpdateBuilder.create().build();
+	private static final Map<String, List<MonolingualTextValue>> NO_ALIASES = Collections.emptyMap();
+
+	@Test
+	public void testFields() {
+		EntityUpdate update = new PropertyUpdateImpl(P1, PROPERTY, NO_TERMS, NO_TERMS, NO_ALIASES, NO_STATEMENTS);
+		assertEquals(P1, update.getEntityId());
+		assertEquals(PROPERTY, update.getBaseRevision());
+		update = new PropertyUpdateImpl(P1, null, NO_TERMS, NO_TERMS, NO_ALIASES, NO_STATEMENTS);
+		assertNull(update.getBaseRevision());
+	}
+
+	@Test
+	public void testValidation() {
+		assertThrows(NullPointerException.class, () -> new PropertyUpdateImpl(
+				null, PROPERTY, NO_TERMS, NO_TERMS, NO_ALIASES, NO_STATEMENTS));
+		assertThrows(NullPointerException.class, () -> new PropertyUpdateImpl(
+				null, null, NO_TERMS, NO_TERMS, NO_ALIASES, NO_STATEMENTS));
+		assertThrows(IllegalArgumentException.class, () -> new PropertyUpdateImpl(
+				P2, PROPERTY, NO_TERMS, NO_TERMS, NO_ALIASES, NO_STATEMENTS));
+		assertThrows(IllegalArgumentException.class, () -> new PropertyUpdateImpl(
+				PropertyIdValue.NULL, null, NO_TERMS, NO_TERMS, NO_ALIASES, NO_STATEMENTS));
+		assertThrows(IllegalArgumentException.class, () -> new PropertyUpdateImpl(
+				PropertyIdValue.NULL, PROPERTY.withEntityId(PropertyIdValue.NULL),
+				NO_TERMS, NO_TERMS, NO_ALIASES, NO_STATEMENTS));
+	}
+
+	@Test
+	public void testEquality() {
+		EntityUpdate update1 = PropertyUpdateBuilder.forEntityId(P1).build();
+		EntityUpdate update2 = PropertyUpdateBuilder.forBaseRevision(PROPERTY).build();
+		assertEquals(update1, update1);
+		assertEquals(update2, update2);
+		assertEquals(update1, PropertyUpdateBuilder.forEntityId(P1).build());
+		assertEquals(update2, PropertyUpdateBuilder.forBaseRevision(PROPERTY).build());
+		assertNotEquals(update1, null);
+		assertNotEquals(update1, this);
+		assertNotEquals(update1, update2);
+		assertNotEquals(update1, PropertyUpdateBuilder.forEntityId(P2).build());
+		assertNotEquals(update2, PropertyUpdateBuilder.forBaseRevision(PROPERTY.withRevisionId(1234)).build());
+	}
+
+	@Test
+	public void testHashCode() {
+		assertEquals(
+				PropertyUpdateBuilder.forBaseRevision(PROPERTY).build().hashCode(),
+				PropertyUpdateBuilder.forBaseRevision(PROPERTY).build().hashCode());
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/EntityUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/EntityUpdateImplTest.java
@@ -20,21 +20,15 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Collections;
-import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
-import org.wikidata.wdtk.datamodel.helpers.PropertyUpdateBuilder;
-import org.wikidata.wdtk.datamodel.helpers.StatementUpdateBuilder;
-import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;
-import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
-import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.EntityUpdate;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
@@ -43,47 +37,39 @@ public class EntityUpdateImplTest {
 
 	private static final PropertyIdValue P1 = Datamodel.makeWikidataPropertyIdValue("P1");
 	private static final PropertyIdValue P2 = Datamodel.makeWikidataPropertyIdValue("P2");
-	private static final PropertyDocument PROPERTY = Datamodel.makePropertyDocument(
-			P1, Datamodel.makeDatatypeIdValue(DatatypeIdValue.DT_ITEM));
-	private static final TermUpdate NO_TERMS = TermUpdateBuilder.create().build();
-	private static final StatementUpdate NO_STATEMENTS = StatementUpdateBuilder.create().build();
-	private static final Map<String, AliasUpdate> NO_ALIASES = Collections.emptyMap();
+
+	private static EntityUpdate create(PropertyIdValue entityId, long revisionId) {
+		return new PropertyUpdateImpl(entityId, revisionId,
+				TermUpdate.NULL, TermUpdate.NULL, Collections.emptyMap(), StatementUpdate.NULL);
+	}
 
 	@Test
 	public void testFields() {
-		EntityUpdate update = new PropertyUpdateImpl(P1, 123, NO_TERMS, NO_TERMS, NO_ALIASES, NO_STATEMENTS);
+		EntityUpdate update = create(P1, 123);
 		assertEquals(P1, update.getEntityId());
 		assertEquals(123, update.getBaseRevisionId());
-		update = new PropertyUpdateImpl(P1, 0, NO_TERMS, NO_TERMS, NO_ALIASES, NO_STATEMENTS);
+		update = create(P1, 0);
 		assertEquals(0, update.getBaseRevisionId());
 	}
 
 	@Test
 	public void testValidation() {
-		assertThrows(NullPointerException.class, () -> new PropertyUpdateImpl(
-				null, 0, NO_TERMS, NO_TERMS, NO_ALIASES, NO_STATEMENTS));
-		assertThrows(IllegalArgumentException.class, () -> new PropertyUpdateImpl(
-				PropertyIdValue.NULL, 0, NO_TERMS, NO_TERMS, NO_ALIASES, NO_STATEMENTS));
+		assertThrows(NullPointerException.class, () -> create(null, 0));
+		assertThrows(IllegalArgumentException.class, () -> create(PropertyIdValue.NULL, 0));
 	}
 
 	@Test
 	public void testEquality() {
-		EntityUpdate update1 = PropertyUpdateBuilder.forEntityId(P1).build();
-		EntityUpdate update2 = PropertyUpdateBuilder.forBaseRevision(PROPERTY).build();
-		assertEquals(update1, update1);
-		assertEquals(update1, update2);
-		assertEquals(update1, PropertyUpdateBuilder.forEntityId(P1).build());
-		assertNotEquals(update1, null);
-		assertNotEquals(update1, this);
-		assertNotEquals(update1, PropertyUpdateBuilder.forEntityId(P2).build());
-		assertNotEquals(update2, PropertyUpdateBuilder.forBaseRevision(PROPERTY.withRevisionId(1234)).build());
+		EntityUpdate update = create(P1, 123);
+		assertTrue(update.equals(update));
+		assertTrue(update.equals(create(P1, 123)));
+		assertFalse(update.equals(create(P2, 123)));
+		assertFalse(update.equals(create(P1, 777)));
 	}
 
 	@Test
 	public void testHashCode() {
-		assertEquals(
-				PropertyUpdateBuilder.forBaseRevision(PROPERTY).build().hashCode(),
-				PropertyUpdateBuilder.forBaseRevision(PROPERTY).build().hashCode());
+		assertEquals(create(P1, 123).hashCode(), create(P1, 123).hashCode());
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/EntityUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/EntityUpdateImplTest.java
@@ -21,7 +21,6 @@ package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
@@ -53,26 +52,19 @@ public class EntityUpdateImplTest {
 
 	@Test
 	public void testFields() {
-		EntityUpdate update = new PropertyUpdateImpl(P1, PROPERTY, NO_TERMS, NO_TERMS, NO_ALIASES, NO_STATEMENTS);
+		EntityUpdate update = new PropertyUpdateImpl(P1, 123, NO_TERMS, NO_TERMS, NO_ALIASES, NO_STATEMENTS);
 		assertEquals(P1, update.getEntityId());
-		assertEquals(PROPERTY, update.getBaseRevision());
-		update = new PropertyUpdateImpl(P1, null, NO_TERMS, NO_TERMS, NO_ALIASES, NO_STATEMENTS);
-		assertNull(update.getBaseRevision());
+		assertEquals(123, update.getBaseRevisionId());
+		update = new PropertyUpdateImpl(P1, 0, NO_TERMS, NO_TERMS, NO_ALIASES, NO_STATEMENTS);
+		assertEquals(0, update.getBaseRevisionId());
 	}
 
 	@Test
 	public void testValidation() {
 		assertThrows(NullPointerException.class, () -> new PropertyUpdateImpl(
-				null, PROPERTY, NO_TERMS, NO_TERMS, NO_ALIASES, NO_STATEMENTS));
-		assertThrows(NullPointerException.class, () -> new PropertyUpdateImpl(
-				null, null, NO_TERMS, NO_TERMS, NO_ALIASES, NO_STATEMENTS));
+				null, 0, NO_TERMS, NO_TERMS, NO_ALIASES, NO_STATEMENTS));
 		assertThrows(IllegalArgumentException.class, () -> new PropertyUpdateImpl(
-				P2, PROPERTY, NO_TERMS, NO_TERMS, NO_ALIASES, NO_STATEMENTS));
-		assertThrows(IllegalArgumentException.class, () -> new PropertyUpdateImpl(
-				PropertyIdValue.NULL, null, NO_TERMS, NO_TERMS, NO_ALIASES, NO_STATEMENTS));
-		assertThrows(IllegalArgumentException.class, () -> new PropertyUpdateImpl(
-				PropertyIdValue.NULL, PROPERTY.withEntityId(PropertyIdValue.NULL),
-				NO_TERMS, NO_TERMS, NO_ALIASES, NO_STATEMENTS));
+				PropertyIdValue.NULL, 0, NO_TERMS, NO_TERMS, NO_ALIASES, NO_STATEMENTS));
 	}
 
 	@Test
@@ -80,12 +72,10 @@ public class EntityUpdateImplTest {
 		EntityUpdate update1 = PropertyUpdateBuilder.forEntityId(P1).build();
 		EntityUpdate update2 = PropertyUpdateBuilder.forBaseRevision(PROPERTY).build();
 		assertEquals(update1, update1);
-		assertEquals(update2, update2);
+		assertEquals(update1, update2);
 		assertEquals(update1, PropertyUpdateBuilder.forEntityId(P1).build());
-		assertEquals(update2, PropertyUpdateBuilder.forBaseRevision(PROPERTY).build());
 		assertNotEquals(update1, null);
 		assertNotEquals(update1, this);
-		assertNotEquals(update1, update2);
 		assertNotEquals(update1, PropertyUpdateBuilder.forEntityId(P2).build());
 		assertNotEquals(update2, PropertyUpdateBuilder.forBaseRevision(PROPERTY.withRevisionId(1234)).build());
 	}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/EntityUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/EntityUpdateImplTest.java
@@ -24,7 +24,6 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
@@ -32,9 +31,9 @@ import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.PropertyUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.StatementUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;
+import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.EntityUpdate;
-import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
@@ -48,7 +47,7 @@ public class EntityUpdateImplTest {
 			P1, Datamodel.makeDatatypeIdValue(DatatypeIdValue.DT_ITEM));
 	private static final TermUpdate NO_TERMS = TermUpdateBuilder.create().build();
 	private static final StatementUpdate NO_STATEMENTS = StatementUpdateBuilder.create().build();
-	private static final Map<String, List<MonolingualTextValue>> NO_ALIASES = Collections.emptyMap();
+	private static final Map<String, AliasUpdate> NO_ALIASES = Collections.emptyMap();
 
 	@Test
 	public void testFields() {

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/FormDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/FormDocumentImplTest.java
@@ -34,6 +34,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.Claim;
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
@@ -161,6 +162,13 @@ public class FormDocumentImplTest {
 		assertTrue(statements.hasNext());
 		assertEquals(s, statements.next());
 		assertFalse(statements.hasNext());
+	}
+
+	@Test
+	public void testWithEntityId() {
+		assertEquals(FormIdValue.NULL, fd1.withEntityId(FormIdValue.NULL).getEntityId());
+		FormIdValue id = Datamodel.makeWikidataFormIdValue("L123-F45");
+		assertEquals(id, fd1.withEntityId(id).getEntityId());
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/FormIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/FormIdValueImplTest.java
@@ -21,6 +21,7 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -129,4 +130,10 @@ public class FormIdValueImplTest {
 	public void testToJavaWithoutNumericalID() throws IOException {
 		assertEquals(form1, mapper.readValue(JSON_FORM_ID_VALUE_WITHOUT_TYPE, ValueImpl.class));
 	}
+
+	@Test
+	public void testIsPlaceholder() {
+		assertFalse(form1.isPlaceholder());
+	}
+
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/FormUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/FormUpdateImplTest.java
@@ -46,7 +46,7 @@ import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 public class FormUpdateImplTest {
 
 	private static final FormIdValue F1 = Datamodel.makeWikidataFormIdValue("L1-F1");
-	private static final StatementUpdate STATEMENTS = LabeledDocumentUpdateImplTest.STATEMENTS;
+	private static final StatementUpdate STATEMENTS = StatementDocumentUpdateImplTest.STATEMENTS;
 	private static final TermUpdate REPRESENTATIONS = TermUpdateBuilder.create().remove("en").build();
 	private static final ItemIdValue FEATURE1 = Datamodel.makeWikidataItemIdValue("Q1");
 	private static final ItemIdValue FEATURE2 = Datamodel.makeWikidataItemIdValue("Q2");

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/FormUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/FormUpdateImplTest.java
@@ -27,6 +27,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.producesJson;
+import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.toJson;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,6 +38,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.helpers.FormUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;
 import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.FormUpdate;
@@ -121,6 +124,19 @@ public class FormUpdateImplTest {
 		FormUpdate update2 = new FormUpdateImpl(F1, 123, TermUpdateBuilder.create().remove("en").build(),
 				Arrays.asList(Datamodel.makeWikidataItemIdValue("Q1")), STATEMENTS);
 		assertEquals(update1.hashCode(), update2.hashCode());
+	}
+
+	@Test
+	public void testJson() {
+		assertThat(new FormUpdateImpl(F1, 123, TermUpdate.EMPTY, null, StatementUpdate.EMPTY), producesJson("{}"));
+		assertThat(FormUpdateBuilder.forEntityId(F1).updateRepresentations(REPRESENTATIONS).build(),
+				producesJson("{'representations':" + toJson(REPRESENTATIONS) + "}"));
+		assertThat(FormUpdateBuilder.forEntityId(F1).setGrammaticalFeatures(FEATURES).build(),
+				producesJson("{'grammaticalFeatures':['Q1']}"));
+		assertThat(FormUpdateBuilder.forEntityId(F1).setGrammaticalFeatures(Collections.emptyList()).build(),
+				producesJson("{'grammaticalFeatures':[]}"));
+		assertThat(FormUpdateBuilder.forEntityId(F1).updateStatements(STATEMENTS).build(),
+				producesJson("{'claims':" + toJson(STATEMENTS) + "}"));
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/FormUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/FormUpdateImplTest.java
@@ -1,0 +1,126 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.implementation;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;
+import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.FormUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
+
+public class FormUpdateImplTest {
+
+	private static final FormIdValue F1 = Datamodel.makeWikidataFormIdValue("L1-F1");
+	private static final StatementUpdate STATEMENTS = LabeledDocumentUpdateImplTest.STATEMENTS;
+	private static final TermUpdate REPRESENTATIONS = TermUpdateBuilder.create().remove("en").build();
+	private static final ItemIdValue FEATURE1 = Datamodel.makeWikidataItemIdValue("Q1");
+	private static final ItemIdValue FEATURE2 = Datamodel.makeWikidataItemIdValue("Q2");
+	private static final List<ItemIdValue> FEATURES = Arrays.asList(FEATURE1);
+
+	@Test
+	public void testFields() {
+		FormUpdate update = new FormUpdateImpl(F1, 123, REPRESENTATIONS, FEATURES, STATEMENTS);
+		assertEquals(F1, update.getEntityId());
+		assertEquals(123, update.getBaseRevisionId());
+		assertSame(REPRESENTATIONS, update.getRepresentations());
+		assertEquals(new HashSet<>(FEATURES), update.getGrammaticalFeatures().get());
+		assertSame(STATEMENTS, update.getStatements());
+		update = new FormUpdateImpl(F1, 123, REPRESENTATIONS, null, STATEMENTS);
+		assertFalse(update.getGrammaticalFeatures().isPresent());
+		update = new FormUpdateImpl(F1, 123, REPRESENTATIONS, Collections.emptyList(), STATEMENTS);
+		assertThat(update.getGrammaticalFeatures().get(), is(empty()));
+	}
+
+	@Test
+	public void testValidation() {
+		assertThrows(NullPointerException.class,
+				() -> new FormUpdateImpl(F1, 0, null, null, StatementUpdate.EMPTY));
+		assertThrows(NullPointerException.class, () -> new FormUpdateImpl(
+				F1, 0, TermUpdate.EMPTY, Arrays.asList(FEATURE1, null), StatementUpdate.EMPTY));
+		assertThrows(IllegalArgumentException.class, () -> new FormUpdateImpl(
+				F1, 0, TermUpdate.EMPTY, Arrays.asList(ItemIdValue.NULL), StatementUpdate.EMPTY));
+		assertThrows(IllegalArgumentException.class, () -> new FormUpdateImpl(
+				F1, 0, TermUpdate.EMPTY, Arrays.asList(FEATURE1, FEATURE1), StatementUpdate.EMPTY));
+	}
+
+	@Test
+	public void testImmutability() {
+		List<ItemIdValue> features = new ArrayList<>();
+		features.add(FEATURE1);
+		FormUpdate update = new FormUpdateImpl(F1, 123, REPRESENTATIONS, features, STATEMENTS);
+		assertThrows(UnsupportedOperationException.class, () -> update.getGrammaticalFeatures().get().add(FEATURE2));
+		features.add(FEATURE2);
+		assertEquals(1, update.getGrammaticalFeatures().get().size());
+	}
+
+	@Test
+	public void testEmpty() {
+		assertFalse(new FormUpdateImpl(F1, 0, REPRESENTATIONS, null, StatementUpdate.EMPTY).isEmpty());
+		assertFalse(
+				new FormUpdateImpl(F1, 0, TermUpdate.EMPTY, Collections.emptyList(), StatementUpdate.EMPTY).isEmpty());
+		assertFalse(new FormUpdateImpl(F1, 0, TermUpdate.EMPTY, FEATURES, StatementUpdate.EMPTY).isEmpty());
+		assertFalse(new FormUpdateImpl(F1, 0, TermUpdate.EMPTY, null, STATEMENTS).isEmpty());
+		assertTrue(new FormUpdateImpl(F1, 0, TermUpdate.EMPTY, null, StatementUpdate.EMPTY).isEmpty());
+	}
+
+	@Test
+	@SuppressWarnings("unlikely-arg-type")
+	public void testEquality() {
+		FormUpdate update = new FormUpdateImpl(F1, 0, REPRESENTATIONS, FEATURES, STATEMENTS);
+		assertFalse(update.equals(null));
+		assertFalse(update.equals(this));
+		assertTrue(update.equals(update));
+		assertTrue(update.equals(new FormUpdateImpl(F1, 0, TermUpdateBuilder.create().remove("en").build(),
+				Arrays.asList(Datamodel.makeWikidataItemIdValue("Q1")), STATEMENTS)));
+		assertFalse(update.equals(new FormUpdateImpl(F1, 123, REPRESENTATIONS, FEATURES, StatementUpdate.EMPTY)));
+		assertFalse(update.equals(new FormUpdateImpl(F1, 123, TermUpdate.EMPTY, FEATURES, STATEMENTS)));
+		assertFalse(update.equals(new FormUpdateImpl(F1, 123, REPRESENTATIONS, null, STATEMENTS)));
+		assertFalse(update.equals(new FormUpdateImpl(F1, 123, REPRESENTATIONS, Collections.emptyList(), STATEMENTS)));
+		assertFalse(new FormUpdateImpl(F1, 123, REPRESENTATIONS, null, STATEMENTS).equals(
+				new FormUpdateImpl(F1, 123, REPRESENTATIONS, Collections.emptyList(), STATEMENTS)));
+	}
+
+	@Test
+	public void testHashCode() {
+		FormUpdate update1 = new FormUpdateImpl(F1, 123, REPRESENTATIONS, FEATURES, STATEMENTS);
+		FormUpdate update2 = new FormUpdateImpl(F1, 123, TermUpdateBuilder.create().remove("en").build(),
+				Arrays.asList(Datamodel.makeWikidataItemIdValue("Q1")), STATEMENTS);
+		assertEquals(update1.hashCode(), update2.hashCode());
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImplTest.java
@@ -34,6 +34,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.Claim;
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
@@ -242,7 +243,14 @@ public class ItemDocumentImplTest {
 		assertEquals(s, statements.next());
 		assertFalse(statements.hasNext());
 	}
-	
+
+	@Test
+	public void testWithEntityId() {
+		assertEquals(ItemIdValue.NULL, ir1.withEntityId(ItemIdValue.NULL).getEntityId());
+		ItemIdValue id = Datamodel.makeWikidataItemIdValue("Q123");
+		assertEquals(id, ir1.withEntityId(id).getEntityId());
+	}
+
 	@Test
 	public void testWithRevisionId() {
 		assertEquals(1235L, ir1.withRevisionId(1235L).getRevisionId());

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemIdValueImplTest.java
@@ -21,6 +21,7 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -150,6 +151,11 @@ public class ItemIdValueImplTest {
 	@Test
 	public void testToJavaUnsupportedWithoutId() throws IOException {
 		assertThrows(JsonMappingException.class, () -> mapper.readValue(JSON_ITEM_ID_VALUE_UNSUPPORTED_NO_ID, ValueImpl.class));
+	}
+
+	@Test
+	public void testIsPlaceholder() {
+		assertFalse(item1.isPlaceholder());
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemUpdateImplTest.java
@@ -26,6 +26,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.producesJson;
+import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.toJson;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -34,6 +36,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.helpers.ItemUpdateBuilder;
 import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ItemUpdate;
@@ -47,6 +50,7 @@ public class ItemUpdateImplTest {
 	private static final StatementUpdate STATEMENTS = StatementDocumentUpdateImplTest.STATEMENTS;
 	private static final TermUpdate LABELS = LabeledDocumentUpdateImplTest.LABELS;
 	private static final TermUpdate DESCRIPTIONS = TermedDocumentUpdateImplTest.DESCRIPTIONS;
+	private static final AliasUpdate ALIAS = TermedDocumentUpdateImplTest.ALIAS;
 	private static final Map<String, AliasUpdate> ALIASES = TermedDocumentUpdateImplTest.ALIASES;
 	private static final SiteLink SITELINK1 = Datamodel.makeSiteLink("Something", "enwiki");
 	private static final List<SiteLink> SITELINKS = Arrays.asList(SITELINK1);
@@ -130,6 +134,26 @@ public class ItemUpdateImplTest {
 		ItemUpdate update2 = new ItemUpdateImpl(
 				Q1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, REMOVED_SITELINKS);
 		assertEquals(update1.hashCode(), update2.hashCode());
+	}
+
+	@Test
+	public void testJson() {
+		assertThat(
+				new ItemUpdateImpl(Q1, 123, TermUpdate.EMPTY, TermUpdate.EMPTY, Collections.emptyMap(),
+						StatementUpdate.EMPTY, Collections.emptyList(), Collections.emptyList()),
+				producesJson("{}"));
+		assertThat(ItemUpdateBuilder.forEntityId(Q1).updateLabels(LABELS).build(),
+				producesJson("{'labels':" + toJson(LABELS) + "}"));
+		assertThat(ItemUpdateBuilder.forEntityId(Q1).updateDescriptions(DESCRIPTIONS).build(),
+				producesJson("{'descriptions':" + toJson(LABELS) + "}"));
+		assertThat(ItemUpdateBuilder.forEntityId(Q1).updateAliases("en", ALIAS).build(),
+				producesJson("{'aliases':{'en':" + toJson(ALIAS) + "}}"));
+		assertThat(ItemUpdateBuilder.forEntityId(Q1).updateStatements(STATEMENTS).build(),
+				producesJson("{'claims':" + toJson(STATEMENTS) + "}"));
+		assertThat(ItemUpdateBuilder.forEntityId(Q1).putSiteLink(SITELINK1).build(),
+				producesJson("{'sitelinks':{'enwiki':" + toJson(SITELINK1) + "}}"));
+		assertThat(ItemUpdateBuilder.forEntityId(Q1).removeSiteLink("enwiki").build(),
+				producesJson("{'sitelinks':{'enwiki':{'remove':'','site':'enwiki'}}}"));
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemUpdateImplTest.java
@@ -1,0 +1,135 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.implementation;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.ItemUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
+import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
+
+public class ItemUpdateImplTest {
+
+	private static final ItemIdValue JOHN = LabeledDocumentUpdateImplTest.JOHN;
+	private static final StatementUpdate STATEMENTS = LabeledDocumentUpdateImplTest.STATEMENTS;
+	private static final TermUpdate LABELS = LabeledDocumentUpdateImplTest.LABELS;
+	private static final TermUpdate DESCRIPTIONS = TermedDocumentUpdateImplTest.DESCRIPTIONS;
+	private static final Map<String, AliasUpdate> ALIASES = TermedDocumentUpdateImplTest.ALIASES;
+	private static final SiteLink SITELINK1 = Datamodel.makeSiteLink("Something", "enwiki");
+	private static final List<SiteLink> SITELINKS = Arrays.asList(SITELINK1);
+	private static final List<String> REMOVED_SITELINKS = Arrays.asList("skwiki");
+
+	@Test
+	public void testFields() {
+		ItemUpdate update = new ItemUpdateImpl(
+				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, REMOVED_SITELINKS);
+		assertEquals(JOHN, update.getEntityId());
+		assertEquals(123, update.getBaseRevisionId());
+		assertSame(LABELS, update.getLabels());
+		assertSame(DESCRIPTIONS, update.getDescriptions());
+		assertEquals(ALIASES, update.getAliases());
+		assertSame(STATEMENTS, update.getStatements());
+		assertThat(update.getModifiedSiteLinks().keySet(), containsInAnyOrder("enwiki"));
+		assertEquals(SITELINK1, update.getModifiedSiteLinks().get("enwiki"));
+		assertThat(update.getRemovedSiteLinks(), containsInAnyOrder("skwiki"));
+	}
+
+	@Test
+	public void testValidation() {
+		assertThrows(NullPointerException.class, () -> new ItemUpdateImpl(
+				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, null, REMOVED_SITELINKS));
+		assertThrows(NullPointerException.class, () -> new ItemUpdateImpl(
+				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, null));
+		assertThrows(NullPointerException.class, () -> new ItemUpdateImpl(
+				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS,
+				Arrays.asList(SITELINK1, null), REMOVED_SITELINKS));
+		assertThrows(NullPointerException.class, () -> new ItemUpdateImpl(
+				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, Arrays.asList("skwiki", null)));
+		assertThrows(IllegalArgumentException.class, () -> new ItemUpdateImpl(
+				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, Arrays.asList("skwiki", " ")));
+		assertThrows(IllegalArgumentException.class, () -> new ItemUpdateImpl(
+				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS,
+				Arrays.asList(SITELINK1, SITELINK1), REMOVED_SITELINKS));
+		assertThrows(IllegalArgumentException.class, () -> new ItemUpdateImpl(
+				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, Arrays.asList("skwiki", "skwiki")));
+		assertThrows(IllegalArgumentException.class, () -> new ItemUpdateImpl(
+				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, Arrays.asList("enwiki")));
+	}
+
+	@Test
+	public void testEmpty() {
+		ItemUpdate empty = new ItemUpdateImpl(JOHN, 123, TermUpdate.EMPTY, TermUpdate.EMPTY,
+				Collections.emptyMap(), StatementUpdate.EMPTY, Collections.emptyList(), Collections.emptyList());
+		assertTrue(empty.isEmpty());
+		ItemUpdate nonempty1 = new ItemUpdateImpl(JOHN, 123, TermUpdate.EMPTY, DESCRIPTIONS,
+				Collections.emptyMap(), StatementUpdate.EMPTY, Collections.emptyList(), Collections.emptyList());
+		ItemUpdate nonempty2 = new ItemUpdateImpl(JOHN, 123, TermUpdate.EMPTY, TermUpdate.EMPTY,
+				Collections.emptyMap(), StatementUpdate.EMPTY, SITELINKS, Collections.emptyList());
+		ItemUpdate nonempty3 = new ItemUpdateImpl(JOHN, 123, TermUpdate.EMPTY, TermUpdate.EMPTY,
+				Collections.emptyMap(), StatementUpdate.EMPTY, Collections.emptyList(), REMOVED_SITELINKS);
+		assertFalse(nonempty1.isEmpty());
+		assertFalse(nonempty2.isEmpty());
+		assertFalse(nonempty3.isEmpty());
+	}
+
+	@Test
+	@SuppressWarnings("unlikely-arg-type")
+	public void testEquality() {
+		ItemUpdate update = new ItemUpdateImpl(
+				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, REMOVED_SITELINKS);
+		assertFalse(update.equals(null));
+		assertFalse(update.equals(this));
+		assertTrue(update.equals(update));
+		assertTrue(update.equals(new ItemUpdateImpl(
+				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, REMOVED_SITELINKS)));
+		assertFalse(update.equals(new ItemUpdateImpl(
+				JOHN, 123, LABELS, TermUpdate.EMPTY, ALIASES, STATEMENTS, SITELINKS, REMOVED_SITELINKS)));
+		assertFalse(update.equals(new ItemUpdateImpl(
+				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, Collections.emptyList(), REMOVED_SITELINKS)));
+		assertFalse(update.equals(new ItemUpdateImpl(
+				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, Collections.emptyList())));
+	}
+
+	@Test
+	public void testHashCode() {
+		ItemUpdate update1 = new ItemUpdateImpl(
+				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, REMOVED_SITELINKS);
+		ItemUpdate update2 = new ItemUpdateImpl(
+				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, REMOVED_SITELINKS);
+		assertEquals(update1.hashCode(), update2.hashCode());
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemUpdateImplTest.java
@@ -43,8 +43,8 @@ import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 
 public class ItemUpdateImplTest {
 
-	private static final ItemIdValue JOHN = LabeledDocumentUpdateImplTest.JOHN;
-	private static final StatementUpdate STATEMENTS = LabeledDocumentUpdateImplTest.STATEMENTS;
+	private static final ItemIdValue Q1 = LabeledDocumentUpdateImplTest.JOHN;
+	private static final StatementUpdate STATEMENTS = StatementDocumentUpdateImplTest.STATEMENTS;
 	private static final TermUpdate LABELS = LabeledDocumentUpdateImplTest.LABELS;
 	private static final TermUpdate DESCRIPTIONS = TermedDocumentUpdateImplTest.DESCRIPTIONS;
 	private static final Map<String, AliasUpdate> ALIASES = TermedDocumentUpdateImplTest.ALIASES;
@@ -55,8 +55,8 @@ public class ItemUpdateImplTest {
 	@Test
 	public void testFields() {
 		ItemUpdate update = new ItemUpdateImpl(
-				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, REMOVED_SITELINKS);
-		assertEquals(JOHN, update.getEntityId());
+				Q1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, REMOVED_SITELINKS);
+		assertEquals(Q1, update.getEntityId());
 		assertEquals(123, update.getBaseRevisionId());
 		assertSame(LABELS, update.getLabels());
 		assertSame(DESCRIPTIONS, update.getDescriptions());
@@ -70,35 +70,35 @@ public class ItemUpdateImplTest {
 	@Test
 	public void testValidation() {
 		assertThrows(NullPointerException.class, () -> new ItemUpdateImpl(
-				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, null, REMOVED_SITELINKS));
+				Q1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, null, REMOVED_SITELINKS));
 		assertThrows(NullPointerException.class, () -> new ItemUpdateImpl(
-				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, null));
+				Q1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, null));
 		assertThrows(NullPointerException.class, () -> new ItemUpdateImpl(
-				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS,
+				Q1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS,
 				Arrays.asList(SITELINK1, null), REMOVED_SITELINKS));
 		assertThrows(NullPointerException.class, () -> new ItemUpdateImpl(
-				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, Arrays.asList("skwiki", null)));
+				Q1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, Arrays.asList("skwiki", null)));
 		assertThrows(IllegalArgumentException.class, () -> new ItemUpdateImpl(
-				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, Arrays.asList("skwiki", " ")));
+				Q1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, Arrays.asList("skwiki", " ")));
 		assertThrows(IllegalArgumentException.class, () -> new ItemUpdateImpl(
-				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS,
+				Q1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS,
 				Arrays.asList(SITELINK1, SITELINK1), REMOVED_SITELINKS));
 		assertThrows(IllegalArgumentException.class, () -> new ItemUpdateImpl(
-				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, Arrays.asList("skwiki", "skwiki")));
+				Q1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, Arrays.asList("skwiki", "skwiki")));
 		assertThrows(IllegalArgumentException.class, () -> new ItemUpdateImpl(
-				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, Arrays.asList("enwiki")));
+				Q1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, Arrays.asList("enwiki")));
 	}
 
 	@Test
 	public void testEmpty() {
-		ItemUpdate empty = new ItemUpdateImpl(JOHN, 123, TermUpdate.EMPTY, TermUpdate.EMPTY,
+		ItemUpdate empty = new ItemUpdateImpl(Q1, 123, TermUpdate.EMPTY, TermUpdate.EMPTY,
 				Collections.emptyMap(), StatementUpdate.EMPTY, Collections.emptyList(), Collections.emptyList());
 		assertTrue(empty.isEmpty());
-		ItemUpdate nonempty1 = new ItemUpdateImpl(JOHN, 123, TermUpdate.EMPTY, DESCRIPTIONS,
+		ItemUpdate nonempty1 = new ItemUpdateImpl(Q1, 123, TermUpdate.EMPTY, DESCRIPTIONS,
 				Collections.emptyMap(), StatementUpdate.EMPTY, Collections.emptyList(), Collections.emptyList());
-		ItemUpdate nonempty2 = new ItemUpdateImpl(JOHN, 123, TermUpdate.EMPTY, TermUpdate.EMPTY,
+		ItemUpdate nonempty2 = new ItemUpdateImpl(Q1, 123, TermUpdate.EMPTY, TermUpdate.EMPTY,
 				Collections.emptyMap(), StatementUpdate.EMPTY, SITELINKS, Collections.emptyList());
-		ItemUpdate nonempty3 = new ItemUpdateImpl(JOHN, 123, TermUpdate.EMPTY, TermUpdate.EMPTY,
+		ItemUpdate nonempty3 = new ItemUpdateImpl(Q1, 123, TermUpdate.EMPTY, TermUpdate.EMPTY,
 				Collections.emptyMap(), StatementUpdate.EMPTY, Collections.emptyList(), REMOVED_SITELINKS);
 		assertFalse(nonempty1.isEmpty());
 		assertFalse(nonempty2.isEmpty());
@@ -109,26 +109,26 @@ public class ItemUpdateImplTest {
 	@SuppressWarnings("unlikely-arg-type")
 	public void testEquality() {
 		ItemUpdate update = new ItemUpdateImpl(
-				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, REMOVED_SITELINKS);
+				Q1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, REMOVED_SITELINKS);
 		assertFalse(update.equals(null));
 		assertFalse(update.equals(this));
 		assertTrue(update.equals(update));
 		assertTrue(update.equals(new ItemUpdateImpl(
-				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, REMOVED_SITELINKS)));
+				Q1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, REMOVED_SITELINKS)));
 		assertFalse(update.equals(new ItemUpdateImpl(
-				JOHN, 123, LABELS, TermUpdate.EMPTY, ALIASES, STATEMENTS, SITELINKS, REMOVED_SITELINKS)));
+				Q1, 123, LABELS, TermUpdate.EMPTY, ALIASES, STATEMENTS, SITELINKS, REMOVED_SITELINKS)));
 		assertFalse(update.equals(new ItemUpdateImpl(
-				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, Collections.emptyList(), REMOVED_SITELINKS)));
+				Q1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, Collections.emptyList(), REMOVED_SITELINKS)));
 		assertFalse(update.equals(new ItemUpdateImpl(
-				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, Collections.emptyList())));
+				Q1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, Collections.emptyList())));
 	}
 
 	@Test
 	public void testHashCode() {
 		ItemUpdate update1 = new ItemUpdateImpl(
-				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, REMOVED_SITELINKS);
+				Q1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, REMOVED_SITELINKS);
 		ItemUpdate update2 = new ItemUpdateImpl(
-				JOHN, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, REMOVED_SITELINKS);
+				Q1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS, SITELINKS, REMOVED_SITELINKS);
 		assertEquals(update1.hashCode(), update2.hashCode());
 	}
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/JsonTestUtils.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/JsonTestUtils.java
@@ -1,0 +1,105 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.implementation;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import java.util.TreeMap;
+
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+
+class JsonTestUtils {
+
+	private static final ObjectMapper mapper = new ObjectMapper();
+
+	static {
+		/*
+		 * Support for Optional properties.
+		 */
+		mapper.registerModule(new Jdk8Module());
+		/*
+		 * Sort fields by name to produce mostly canonical JSON.
+		 * https://cowtowncoder.medium.com/
+		 * jackson-tips-sorting-json-using-jsonnode-ce4476e37aee
+		 */
+		mapper.setNodeFactory(new JsonNodeFactory() {
+
+			private static final long serialVersionUID = 1L;
+
+			@Override
+			public ObjectNode objectNode() {
+				return new ObjectNode(this, new TreeMap<String, JsonNode>());
+			}
+
+		});
+	}
+
+	static String toJson(Object value) {
+		try {
+			String json = mapper.writeValueAsString(value);
+			/*
+			 * Canonical form.
+			 */
+			JsonNode tree = mapper.readTree(json);
+			return mapper.writeValueAsString(tree);
+		} catch (IOException ex) {
+			return fail("JSON serialization failed.", ex);
+		}
+	}
+
+	private static class JsonMatcher<T> extends BaseMatcher<T> {
+
+		private final String expected;
+
+		JsonMatcher(String expected) {
+			this.expected = expected.replace('\'', '"');
+		}
+
+		@Override
+		public boolean matches(Object actual) {
+			return toJson(actual).equals(expected);
+		}
+
+		@Override
+		public void describeTo(Description description) {
+			description.appendText(expected);
+		}
+
+		@Override
+		public void describeMismatch(Object item, Description description) {
+			description.appendText("was ").appendText(toJson(item));
+		}
+
+	}
+
+	static <T> Matcher<T> producesJson(String json) {
+		return new JsonMatcher<>(json);
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LabeledDocumentUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LabeledDocumentUpdateImplTest.java
@@ -44,8 +44,8 @@ public class LabeledDocumentUpdateImplTest {
 	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateImplTest.JOHN_HAS_BROWN_HAIR;
 	private static final Collection<SiteLink> NO_SITELINKS = Collections.emptyList();
 	private static final Collection<String> NO_REMOVED_SITELINKS = Collections.emptyList();
-	private static final StatementUpdate STATEMENTS = StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build();
-	private static final TermUpdate LABELS = TermUpdateBuilder.create().remove("en").build();
+	static final StatementUpdate STATEMENTS = StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build();
+	static final TermUpdate LABELS = TermUpdateBuilder.create().remove("en").build();
 
 	private static LabeledStatementDocumentUpdate create(
 			ItemIdValue entityId, long revisionId, StatementUpdate statements, TermUpdate labels) {

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LabeledDocumentUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LabeledDocumentUpdateImplTest.java
@@ -1,0 +1,94 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.implementation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.helpers.StatementUpdateBuilder;
+import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;
+import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.LabeledStatementDocumentUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
+import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
+
+public class LabeledDocumentUpdateImplTest {
+
+	private static final ItemIdValue JOHN = StatementUpdateImplTest.JOHN;
+	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateImplTest.JOHN_HAS_BROWN_HAIR;
+	private static final Collection<SiteLink> NO_SITELINKS = Collections.emptyList();
+	private static final Collection<String> NO_REMOVED_SITELINKS = Collections.emptyList();
+	private static final StatementUpdate STATEMENTS = StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build();
+	private static final TermUpdate LABELS = TermUpdateBuilder.create().remove("en").build();
+
+	private static LabeledStatementDocumentUpdate create(
+			ItemIdValue entityId, long revisionId, StatementUpdate statements, TermUpdate labels) {
+		return new ItemUpdateImpl(entityId, revisionId, labels, TermUpdate.EMPTY, Collections.emptyMap(),
+				statements, NO_SITELINKS, NO_REMOVED_SITELINKS);
+	}
+
+	@Test
+	public void testFields() {
+		LabeledStatementDocumentUpdate update = create(JOHN, 123, STATEMENTS, LABELS);
+		assertEquals(JOHN, update.getEntityId());
+		assertEquals(123, update.getBaseRevisionId());
+		assertSame(STATEMENTS, update.getStatements());
+		assertSame(LABELS, update.getLabels());
+	}
+
+	@Test
+	public void testValidation() {
+		assertThrows(NullPointerException.class, () -> create(JOHN, 0, StatementUpdate.EMPTY, null));
+	}
+
+	@Test
+	public void testEmpty() {
+		assertFalse(create(JOHN, 0, STATEMENTS, TermUpdate.EMPTY).isEmpty());
+		assertFalse(create(JOHN, 0, StatementUpdate.EMPTY, LABELS).isEmpty());
+		assertTrue(create(JOHN, 0, StatementUpdate.EMPTY, TermUpdate.EMPTY).isEmpty());
+	}
+
+	@Test
+	public void testEquality() {
+		LabeledStatementDocumentUpdate update = create(JOHN, 0, STATEMENTS, LABELS);
+		assertTrue(update.equals(update));
+		assertTrue(update.equals(create(JOHN, 0, STATEMENTS, TermUpdateBuilder.create().remove("en").build())));
+		assertFalse(update.equals(create(JOHN, 123, StatementUpdate.EMPTY, LABELS)));
+		assertFalse(update.equals(create(JOHN, 123, STATEMENTS, TermUpdate.EMPTY)));
+	}
+
+	@Test
+	public void testHashCode() {
+		LabeledStatementDocumentUpdate update1 = create(JOHN, 123, STATEMENTS, LABELS);
+		LabeledStatementDocumentUpdate update2 = create(JOHN, 123, STATEMENTS,
+				TermUpdateBuilder.create().remove("en").build());
+		assertEquals(update1.hashCode(), update2.hashCode());
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LabeledDocumentUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LabeledDocumentUpdateImplTest.java
@@ -44,7 +44,7 @@ public class LabeledDocumentUpdateImplTest {
 	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateImplTest.JOHN_HAS_BROWN_HAIR;
 	private static final Collection<SiteLink> NO_SITELINKS = Collections.emptyList();
 	private static final Collection<String> NO_REMOVED_SITELINKS = Collections.emptyList();
-	static final StatementUpdate STATEMENTS = StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build();
+	private static final StatementUpdate STATEMENTS = StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build();
 	static final TermUpdate LABELS = TermUpdateBuilder.create().remove("en").build();
 
 	private static LabeledStatementDocumentUpdate create(

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LabeledDocumentUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LabeledDocumentUpdateImplTest.java
@@ -40,7 +40,7 @@ import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 
 public class LabeledDocumentUpdateImplTest {
 
-	private static final ItemIdValue JOHN = StatementUpdateImplTest.JOHN;
+	static final ItemIdValue JOHN = StatementUpdateImplTest.JOHN;
 	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateImplTest.JOHN_HAS_BROWN_HAIR;
 	private static final Collection<SiteLink> NO_SITELINKS = Collections.emptyList();
 	private static final Collection<String> NO_REMOVED_SITELINKS = Collections.emptyList();

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeDocumentImplTest.java
@@ -223,6 +223,13 @@ public class LexemeDocumentImplTest {
 	}
 
 	@Test
+	public void testWithEntityId() {
+		assertEquals(LexemeIdValue.NULL, ld1.withEntityId(LexemeIdValue.NULL).getEntityId());
+		LexemeIdValue id = Datamodel.makeWikidataLexemeIdValue("L123");
+		assertEquals(id, ld1.withEntityId(id).getEntityId());
+	}
+
+	@Test
 	public void testWithRevisionId() {
 		assertEquals(1235L, ld1.withRevisionId(1235L).getRevisionId());
 		assertEquals(ld1, ld1.withRevisionId(1325L).withRevisionId(ld1.getRevisionId()));

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeIdValueImplTest.java
@@ -21,6 +21,7 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -119,6 +120,11 @@ public class LexemeIdValueImplTest {
 	@Test
 	public void testToJavaWithoutNumericalID() throws IOException {
 		assertEquals(lexeme1, mapper.readValue(JSON_LEXEME_ID_VALUE_WITHOUT_NUMERICAL_ID, ValueImpl.class));
+	}
+
+	@Test
+	public void testIsPlaceholder() {
+		assertFalse(lexeme1.isPlaceholder());
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeUpdateImplTest.java
@@ -28,6 +28,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.producesJson;
+import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.toJson;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -37,6 +39,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.FormUpdateBuilder;
+import org.wikidata.wdtk.datamodel.helpers.LexemeUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.SenseUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;
 import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
@@ -302,6 +305,34 @@ public class LexemeUpdateImplTest {
 		LexemeUpdate update2 = new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
 				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES, ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS);
 		assertEquals(update1.hashCode(), update2.hashCode());
+	}
+
+	@Test
+	public void testJson() {
+		assertThat(
+				new LexemeUpdateImpl(L1, 123, null, null, TermUpdate.EMPTY, StatementUpdate.EMPTY,
+						Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
+						Collections.emptyList(), Collections.emptyList(), Collections.emptyList()),
+				producesJson("{}"));
+		assertThat(LexemeUpdateBuilder.forEntityId(L1).setLanguage(Q1).build(), producesJson("{'language':'Q1'}"));
+		assertThat(LexemeUpdateBuilder.forEntityId(L1).setLexicalCategory(Q2).build(),
+				producesJson("{'lexicalCategory':'Q2'}"));
+		assertThat(LexemeUpdateBuilder.forEntityId(L1).updateLemmas(LEMMAS).build(),
+				producesJson("{'lemmas':" + toJson(LEMMAS) + "}"));
+		assertThat(LexemeUpdateBuilder.forEntityId(L1).updateStatements(STATEMENTS).build(),
+				producesJson("{'claims':" + toJson(STATEMENTS) + "}"));
+		assertThat(LexemeUpdateBuilder.forEntityId(L1).addSense(ADDED_SENSE).build(),
+				producesJson("{'senses':[{'add':''," + toJson(ADDED_SENSE).substring(1) + "]}"));
+		assertThat(LexemeUpdateBuilder.forEntityId(L1).updateSense(UPDATED_SENSE).build(),
+				producesJson("{'senses':[" + toJson(UPDATED_SENSE) + "]}"));
+		assertThat(LexemeUpdateBuilder.forEntityId(L1).removeSense(S2).build(),
+				producesJson("{'senses':[{'id':'L1-S2','remove':''}]}"));
+		assertThat(LexemeUpdateBuilder.forEntityId(L1).addForm(ADDED_FORM).build(),
+				producesJson("{'forms':[{'add':''," + toJson(ADDED_FORM).substring(1) + "]}"));
+		assertThat(LexemeUpdateBuilder.forEntityId(L1).updateForm(UPDATED_FORM).build(),
+				producesJson("{'forms':[" + toJson(UPDATED_FORM) + "]}"));
+		assertThat(LexemeUpdateBuilder.forEntityId(L1).removeForm(F2).build(),
+				producesJson("{'forms':[{'id':'L1-F2','remove':''}]}"));
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeUpdateImplTest.java
@@ -1,0 +1,307 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.implementation;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.helpers.FormUpdateBuilder;
+import org.wikidata.wdtk.datamodel.helpers.SenseUpdateBuilder;
+import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;
+import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
+import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.FormUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.LexemeIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.LexemeUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.SenseDocument;
+import org.wikidata.wdtk.datamodel.interfaces.SenseIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.SenseUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
+
+public class LexemeUpdateImplTest {
+
+	private static final LexemeIdValue L1 = Datamodel.makeWikidataLexemeIdValue("L1");
+	private static final StatementUpdate STATEMENTS = StatementDocumentUpdateImplTest.STATEMENTS;
+	private static final TermUpdate LEMMAS = TermUpdateBuilder.create().remove("en").build();
+	private static final ItemIdValue Q1 = Datamodel.makeWikidataItemIdValue("Q1");
+	private static final ItemIdValue Q2 = Datamodel.makeWikidataItemIdValue("Q2");
+	private static final SenseIdValue S1 = Datamodel.makeWikidataSenseIdValue("L1-S1");
+	private static final SenseIdValue S2 = Datamodel.makeWikidataSenseIdValue("L1-S2");
+	private static final SenseIdValue S3 = Datamodel.makeWikidataSenseIdValue("L1-S3");
+	private static final SenseDocument ADDED_SENSE = Datamodel.makeSenseDocument(
+			SenseIdValue.NULL, Collections.emptyList(), Collections.emptyList());
+	private static final List<SenseDocument> ADDED_SENSES = Arrays.asList(ADDED_SENSE);
+	private static final SenseUpdate UPDATED_SENSE = SenseUpdateBuilder.forEntityId(S1)
+			.updateStatements(STATEMENTS)
+			.build();
+	private static final List<SenseUpdate> UPDATED_SENSES = Arrays.asList(UPDATED_SENSE);
+	private static final List<SenseIdValue> REMOVED_SENSES = Arrays.asList(S2);
+	private static final FormIdValue F1 = Datamodel.makeWikidataFormIdValue("L1-F1");
+	private static final FormIdValue F2 = Datamodel.makeWikidataFormIdValue("L1-F2");
+	private static final FormIdValue F3 = Datamodel.makeWikidataFormIdValue("L1-F3");
+	private static final FormDocument ADDED_FORM = Datamodel.makeFormDocument(
+			FormIdValue.NULL, Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+	private static final List<FormDocument> ADDED_FORMS = Arrays.asList(ADDED_FORM);
+	private static final FormUpdate UPDATED_FORM = FormUpdateBuilder.forEntityId(F1)
+			.updateStatements(STATEMENTS)
+			.build();
+	private static final List<FormUpdate> UPDATED_FORMS = Arrays.asList(UPDATED_FORM);
+	private static final List<FormIdValue> REMOVED_FORMS = Arrays.asList(F2);
+
+	@Test
+	public void testFields() {
+		LexemeUpdate update = new LexemeUpdateImpl(L1, 123, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES, ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS);
+		assertEquals(L1, update.getEntityId());
+		assertEquals(123, update.getBaseRevisionId());
+		assertEquals(Q1, update.getLanguage().get());
+		assertEquals(Q2, update.getLexicalCategory().get());
+		assertSame(LEMMAS, update.getLemmas());
+		assertSame(STATEMENTS, update.getStatements());
+		assertEquals(ADDED_SENSES, update.getAddedSenses());
+		assertThat(update.getUpdatedSenses().keySet(), containsInAnyOrder(S1));
+		assertEquals(UPDATED_SENSE, update.getUpdatedSenses().get(S1));
+		assertThat(update.getRemovedSenses(), containsInAnyOrder(S2));
+		assertEquals(ADDED_FORMS, update.getAddedForms());
+		assertThat(update.getUpdatedForms().keySet(), containsInAnyOrder(F1));
+		assertEquals(UPDATED_FORM, update.getUpdatedForms().get(F1));
+		assertThat(update.getRemovedForms(), containsInAnyOrder(F2));
+		update = new LexemeUpdateImpl(L1, 123, null, null, LEMMAS, STATEMENTS,
+				ADDED_SENSES, Arrays.asList(SenseUpdateBuilder.forEntityId(S1).build()), REMOVED_SENSES,
+				ADDED_FORMS, Arrays.asList(FormUpdateBuilder.forEntityId(F1).build()), REMOVED_FORMS);
+		assertFalse(update.getLanguage().isPresent());
+		assertFalse(update.getLexicalCategory().isPresent());
+		assertThat(update.getUpdatedSenses(), is(anEmptyMap()));
+		assertThat(update.getUpdatedForms(), is(anEmptyMap()));
+	}
+
+	@Test
+	public void testValidation() {
+		// null parameter
+		assertThrows(NullPointerException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, null, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES, ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS));
+		assertThrows(NullPointerException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, null,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES, ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS));
+		assertThrows(NullPointerException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				null, UPDATED_SENSES, REMOVED_SENSES, ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS));
+		assertThrows(NullPointerException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, null, REMOVED_SENSES, ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS));
+		assertThrows(NullPointerException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, null, ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS));
+		assertThrows(NullPointerException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES, null, UPDATED_FORMS, REMOVED_FORMS));
+		assertThrows(NullPointerException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES, ADDED_FORMS, null, REMOVED_FORMS));
+		assertThrows(NullPointerException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES, ADDED_FORMS, UPDATED_FORMS, null));
+		// null item
+		assertThrows(NullPointerException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				Arrays.asList(ADDED_SENSE, null), UPDATED_SENSES, REMOVED_SENSES,
+				ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS));
+		assertThrows(NullPointerException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, Arrays.asList(UPDATED_SENSE, null), REMOVED_SENSES,
+				ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS));
+		assertThrows(NullPointerException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, Arrays.asList(S2, null),
+				ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS));
+		assertThrows(NullPointerException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES,
+				Arrays.asList(ADDED_FORM, null), UPDATED_FORMS, REMOVED_FORMS));
+		assertThrows(NullPointerException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES,
+				ADDED_FORMS, Arrays.asList(UPDATED_FORM, null), REMOVED_FORMS));
+		assertThrows(NullPointerException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES,
+				ADDED_FORMS, UPDATED_FORMS, Arrays.asList(F2, null)));
+		// placeholder ID
+		assertThrows(IllegalArgumentException.class, () -> new LexemeUpdateImpl(L1, 0, ItemIdValue.NULL, Q2, LEMMAS,
+				STATEMENTS, ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES, ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS));
+		assertThrows(IllegalArgumentException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, ItemIdValue.NULL, LEMMAS,
+				STATEMENTS, ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES, ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS));
+		assertThrows(IllegalArgumentException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, Arrays.asList(S2, SenseIdValue.NULL),
+				ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS));
+		assertThrows(IllegalArgumentException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES,
+				ADDED_FORMS, UPDATED_FORMS, Arrays.asList(F2, FormIdValue.NULL)));
+		// expected placeholder ID
+		assertThrows(IllegalArgumentException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				Arrays.asList(ADDED_SENSE.withEntityId(S3)), UPDATED_SENSES, REMOVED_SENSES,
+				ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS));
+		assertThrows(IllegalArgumentException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES,
+				Arrays.asList(ADDED_FORM.withEntityId(F3)), UPDATED_FORMS, REMOVED_FORMS));
+		// unique IDs
+		assertThrows(IllegalArgumentException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, Arrays.asList(UPDATED_SENSE, UPDATED_SENSE), REMOVED_SENSES,
+				ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS));
+		assertThrows(IllegalArgumentException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, Arrays.asList(S2, S2),
+				ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS));
+		assertThrows(IllegalArgumentException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, Arrays.asList(S1),
+				ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS));
+		assertThrows(IllegalArgumentException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES,
+				ADDED_FORMS, Arrays.asList(UPDATED_FORM, UPDATED_FORM), REMOVED_FORMS));
+		assertThrows(IllegalArgumentException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES,
+				ADDED_FORMS, UPDATED_FORMS, Arrays.asList(F2, F2)));
+		assertThrows(IllegalArgumentException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES,
+				ADDED_FORMS, UPDATED_FORMS, Arrays.asList(F1)));
+	}
+
+	@Test
+	public void testImmutability() {
+		List<SenseDocument> addedSenses = new ArrayList<>(ADDED_SENSES);
+		List<SenseUpdate> updatedSenses = new ArrayList<>(UPDATED_SENSES);
+		List<SenseIdValue> removedSenses = new ArrayList<>(REMOVED_SENSES);
+		List<FormDocument> addedForms = new ArrayList<>(ADDED_FORMS);
+		List<FormUpdate> updatedForms = new ArrayList<>(UPDATED_FORMS);
+		List<FormIdValue> removedForms = new ArrayList<>(REMOVED_FORMS);
+		LexemeUpdate update = new LexemeUpdateImpl(L1, 123, Q1, Q2, LEMMAS, STATEMENTS,
+				addedSenses, updatedSenses, removedSenses, addedForms, updatedForms, removedForms);
+		assertThrows(UnsupportedOperationException.class, () -> update.getAddedSenses().clear());
+		assertThrows(UnsupportedOperationException.class, () -> update.getUpdatedSenses().clear());
+		assertThrows(UnsupportedOperationException.class, () -> update.getRemovedSenses().clear());
+		assertThrows(UnsupportedOperationException.class, () -> update.getAddedForms().clear());
+		assertThrows(UnsupportedOperationException.class, () -> update.getUpdatedForms().clear());
+		assertThrows(UnsupportedOperationException.class, () -> update.getRemovedForms().clear());
+		addedSenses.clear();
+		updatedSenses.clear();
+		removedSenses.clear();
+		addedForms.clear();
+		updatedForms.clear();
+		removedForms.clear();
+		assertEquals(1, update.getAddedSenses().size());
+		assertEquals(1, update.getUpdatedSenses().size());
+		assertEquals(1, update.getRemovedSenses().size());
+		assertEquals(1, update.getAddedForms().size());
+		assertEquals(1, update.getUpdatedForms().size());
+		assertEquals(1, update.getRemovedForms().size());
+	}
+
+	@Test
+	public void testEmpty() {
+		LexemeUpdate update = new LexemeUpdateImpl(L1, 0, null, null, TermUpdate.EMPTY, StatementUpdate.EMPTY,
+				Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
+				Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+		assertTrue(update.isEmpty());
+		update = new LexemeUpdateImpl(L1, 0, Q1, null, TermUpdate.EMPTY, StatementUpdate.EMPTY,
+				Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
+				Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+		assertFalse(update.isEmpty());
+		update = new LexemeUpdateImpl(L1, 0, null, Q2, TermUpdate.EMPTY, StatementUpdate.EMPTY,
+				Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
+				Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+		assertFalse(update.isEmpty());
+		update = new LexemeUpdateImpl(L1, 0, null, null, LEMMAS, StatementUpdate.EMPTY,
+				Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
+				Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+		assertFalse(update.isEmpty());
+		update = new LexemeUpdateImpl(L1, 0, null, null, TermUpdate.EMPTY, STATEMENTS,
+				Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
+				Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+		assertFalse(update.isEmpty());
+		update = new LexemeUpdateImpl(L1, 0, null, null, TermUpdate.EMPTY, StatementUpdate.EMPTY,
+				ADDED_SENSES, Collections.emptyList(), Collections.emptyList(),
+				Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+		assertFalse(update.isEmpty());
+		update = new LexemeUpdateImpl(L1, 0, null, null, TermUpdate.EMPTY, StatementUpdate.EMPTY,
+				Collections.emptyList(), UPDATED_SENSES, Collections.emptyList(),
+				Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+		assertFalse(update.isEmpty());
+		update = new LexemeUpdateImpl(L1, 0, null, null, TermUpdate.EMPTY, StatementUpdate.EMPTY,
+				Collections.emptyList(), Collections.emptyList(), REMOVED_SENSES,
+				Collections.emptyList(), Collections.emptyList(), Collections.emptyList());
+		assertFalse(update.isEmpty());
+		update = new LexemeUpdateImpl(L1, 0, null, null, TermUpdate.EMPTY, StatementUpdate.EMPTY,
+				Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
+				ADDED_FORMS, Collections.emptyList(), Collections.emptyList());
+		assertFalse(update.isEmpty());
+		update = new LexemeUpdateImpl(L1, 0, null, null, TermUpdate.EMPTY, StatementUpdate.EMPTY,
+				Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
+				Collections.emptyList(), UPDATED_FORMS, Collections.emptyList());
+		assertFalse(update.isEmpty());
+		update = new LexemeUpdateImpl(L1, 0, null, null, TermUpdate.EMPTY, StatementUpdate.EMPTY,
+				Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
+				Collections.emptyList(), Collections.emptyList(), REMOVED_FORMS);
+		assertFalse(update.isEmpty());
+	}
+
+	@Test
+	@SuppressWarnings("unlikely-arg-type")
+	public void testEquality() {
+		LexemeUpdate update = new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES, ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS);
+		assertFalse(update.equals(null));
+		assertFalse(update.equals(this));
+		assertTrue(update.equals(update));
+		assertTrue(update.equals(new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES, ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS)));
+		assertFalse(update.equals(new LexemeUpdateImpl(L1, 0, null, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES, ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS)));
+		assertFalse(update.equals(new LexemeUpdateImpl(L1, 0, Q1, null, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES, ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS)));
+		assertFalse(update.equals(new LexemeUpdateImpl(L1, 0, Q1, Q2, TermUpdate.EMPTY, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES, ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS)));
+		assertFalse(update.equals(new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, StatementUpdate.EMPTY,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES, ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS)));
+		assertFalse(update.equals(new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				Collections.emptyList(), UPDATED_SENSES, REMOVED_SENSES, ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS)));
+		assertFalse(update.equals(new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, Collections.emptyList(), REMOVED_SENSES, ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS)));
+		assertFalse(update.equals(new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, Collections.emptyList(), ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS)));
+		assertFalse(update.equals(new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES, Collections.emptyList(), UPDATED_FORMS, REMOVED_FORMS)));
+		assertFalse(update.equals(new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES, ADDED_FORMS, Collections.emptyList(), REMOVED_FORMS)));
+		assertFalse(update.equals(new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES, ADDED_FORMS, UPDATED_FORMS, Collections.emptyList())));
+	}
+
+	@Test
+	public void testHashCode() {
+		LexemeUpdate update1 = new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES, ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS);
+		LexemeUpdate update2 = new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES, ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS);
+		assertEquals(update1.hashCode(), update2.hashCode());
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeUpdateImplTest.java
@@ -70,7 +70,11 @@ public class LexemeUpdateImplTest {
 	private static final SenseUpdate UPDATED_SENSE = SenseUpdateBuilder.forEntityId(S1)
 			.updateStatements(STATEMENTS)
 			.build();
+	private static final SenseUpdate UPDATED_SENSE_REVISION = SenseUpdateBuilder.forBaseRevisionId(S1, 123)
+			.append(UPDATED_SENSE)
+			.build();
 	private static final List<SenseUpdate> UPDATED_SENSES = Arrays.asList(UPDATED_SENSE);
+	private static final List<SenseUpdate> UPDATED_SENSE_REVISIONS = Arrays.asList(UPDATED_SENSE_REVISION);
 	private static final List<SenseIdValue> REMOVED_SENSES = Arrays.asList(S2);
 	private static final FormIdValue F1 = Datamodel.makeWikidataFormIdValue("L1-F1");
 	private static final FormIdValue F2 = Datamodel.makeWikidataFormIdValue("L1-F2");
@@ -81,13 +85,18 @@ public class LexemeUpdateImplTest {
 	private static final FormUpdate UPDATED_FORM = FormUpdateBuilder.forEntityId(F1)
 			.updateStatements(STATEMENTS)
 			.build();
+	private static final FormUpdate UPDATED_FORM_REVISION = FormUpdateBuilder.forBaseRevisionId(F1, 123)
+			.append(UPDATED_FORM)
+			.build();
 	private static final List<FormUpdate> UPDATED_FORMS = Arrays.asList(UPDATED_FORM);
+	private static final List<FormUpdate> UPDATED_FORM_REVISIONS = Arrays.asList(UPDATED_FORM_REVISION);
 	private static final List<FormIdValue> REMOVED_FORMS = Arrays.asList(F2);
 
 	@Test
 	public void testFields() {
 		LexemeUpdate update = new LexemeUpdateImpl(L1, 123, Q1, Q2, LEMMAS, STATEMENTS,
-				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES, ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS);
+				ADDED_SENSES, UPDATED_SENSE_REVISIONS, REMOVED_SENSES,
+				ADDED_FORMS, UPDATED_FORM_REVISIONS, REMOVED_FORMS);
 		assertEquals(L1, update.getEntityId());
 		assertEquals(123, update.getBaseRevisionId());
 		assertEquals(Q1, update.getLanguage().get());
@@ -96,15 +105,15 @@ public class LexemeUpdateImplTest {
 		assertSame(STATEMENTS, update.getStatements());
 		assertEquals(ADDED_SENSES, update.getAddedSenses());
 		assertThat(update.getUpdatedSenses().keySet(), containsInAnyOrder(S1));
-		assertEquals(UPDATED_SENSE, update.getUpdatedSenses().get(S1));
+		assertEquals(UPDATED_SENSE_REVISION, update.getUpdatedSenses().get(S1));
 		assertThat(update.getRemovedSenses(), containsInAnyOrder(S2));
 		assertEquals(ADDED_FORMS, update.getAddedForms());
 		assertThat(update.getUpdatedForms().keySet(), containsInAnyOrder(F1));
-		assertEquals(UPDATED_FORM, update.getUpdatedForms().get(F1));
+		assertEquals(UPDATED_FORM_REVISION, update.getUpdatedForms().get(F1));
 		assertThat(update.getRemovedForms(), containsInAnyOrder(F2));
 		update = new LexemeUpdateImpl(L1, 123, null, null, LEMMAS, STATEMENTS,
-				ADDED_SENSES, Arrays.asList(SenseUpdateBuilder.forEntityId(S1).build()), REMOVED_SENSES,
-				ADDED_FORMS, Arrays.asList(FormUpdateBuilder.forEntityId(F1).build()), REMOVED_FORMS);
+				ADDED_SENSES, Arrays.asList(SenseUpdateBuilder.forBaseRevisionId(S1, 123).build()), REMOVED_SENSES,
+				ADDED_FORMS, Arrays.asList(FormUpdateBuilder.forBaseRevisionId(F1, 123).build()), REMOVED_FORMS);
 		assertFalse(update.getLanguage().isPresent());
 		assertFalse(update.getLexicalCategory().isPresent());
 		assertThat(update.getUpdatedSenses(), is(anEmptyMap()));
@@ -186,15 +195,22 @@ public class LexemeUpdateImplTest {
 		assertThrows(IllegalArgumentException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
 				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES,
 				ADDED_FORMS, UPDATED_FORMS, Arrays.asList(F1)));
+		// consistent revision
+		assertThrows(IllegalArgumentException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSE_REVISIONS, REMOVED_SENSES,
+				ADDED_FORMS, UPDATED_FORMS, REMOVED_FORMS));
+		assertThrows(IllegalArgumentException.class, () -> new LexemeUpdateImpl(L1, 0, Q1, Q2, LEMMAS, STATEMENTS,
+				ADDED_SENSES, UPDATED_SENSES, REMOVED_SENSES,
+				ADDED_FORMS, UPDATED_FORM_REVISIONS, REMOVED_FORMS));
 	}
 
 	@Test
 	public void testImmutability() {
 		List<SenseDocument> addedSenses = new ArrayList<>(ADDED_SENSES);
-		List<SenseUpdate> updatedSenses = new ArrayList<>(UPDATED_SENSES);
+		List<SenseUpdate> updatedSenses = new ArrayList<>(UPDATED_SENSE_REVISIONS);
 		List<SenseIdValue> removedSenses = new ArrayList<>(REMOVED_SENSES);
 		List<FormDocument> addedForms = new ArrayList<>(ADDED_FORMS);
-		List<FormUpdate> updatedForms = new ArrayList<>(UPDATED_FORMS);
+		List<FormUpdate> updatedForms = new ArrayList<>(UPDATED_FORM_REVISIONS);
 		List<FormIdValue> removedForms = new ArrayList<>(REMOVED_FORMS);
 		LexemeUpdate update = new LexemeUpdateImpl(L1, 123, Q1, Q2, LEMMAS, STATEMENTS,
 				addedSenses, updatedSenses, removedSenses, addedForms, updatedForms, removedForms);

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoDocumentImplTest.java
@@ -34,6 +34,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.Claim;
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
@@ -164,7 +165,14 @@ public class MediaInfoDocumentImplTest {
 		assertEquals(s, statements.next());
 		assertFalse(statements.hasNext());
 	}
-	
+
+	@Test
+	public void testWithEntityId() {
+		assertEquals(MediaInfoIdValue.NULL, mi1.withEntityId(MediaInfoIdValue.NULL).getEntityId());
+		MediaInfoIdValue id = Datamodel.makeWikimediaCommonsMediaInfoIdValue("M123");
+		assertEquals(id, mi1.withEntityId(id).getEntityId());
+	}
+
 	@Test
 	public void testWithRevisionId() {
 		assertEquals(1235L, mi1.withRevisionId(1235L).getRevisionId());

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoIdValueImplTest.java
@@ -21,6 +21,7 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -119,6 +120,11 @@ public class MediaInfoIdValueImplTest {
 	@Test
 	public void testToJavaWithoutNumericalID() throws IOException {
 		assertEquals(mediaInfo1, mapper.readValue(JSON_MEDIA_INFO_ID_VALUE_WITHOUT_NUMERICAL_ID, ValueImpl.class));
+	}
+
+	@Test
+	public void testIsPlaceholder() {
+		assertFalse(mediaInfo1.isPlaceholder());
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoUpdateImplTest.java
@@ -19,13 +19,17 @@
  */
 package org.wikidata.wdtk.datamodel.implementation;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.producesJson;
+import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.toJson;
 
 import org.junit.jupiter.api.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.helpers.MediaInfoUpdateBuilder;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
@@ -68,6 +72,15 @@ public class MediaInfoUpdateImplTest {
 		assertEquals(
 				new MediaInfoUpdateImpl(M1, 123, LABELS, STATEMENTS).hashCode(),
 				new MediaInfoUpdateImpl(M1, 123, LABELS, STATEMENTS).hashCode());
+	}
+
+	@Test
+	public void testJson() {
+		assertThat(new MediaInfoUpdateImpl(M1, 123, TermUpdate.EMPTY, StatementUpdate.EMPTY), producesJson("{}"));
+		assertThat(MediaInfoUpdateBuilder.forEntityId(M1).updateLabels(LABELS).build(),
+				producesJson("{'labels':" + toJson(LABELS) + "}"));
+		assertThat(MediaInfoUpdateBuilder.forEntityId(M1).updateStatements(STATEMENTS).build(),
+				producesJson("{'claims':" + toJson(STATEMENTS) + "}"));
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoUpdateImplTest.java
@@ -34,7 +34,7 @@ import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 public class MediaInfoUpdateImplTest {
 
 	private static final MediaInfoIdValue M1 = Datamodel.makeWikimediaCommonsMediaInfoIdValue("M1");
-	private static final StatementUpdate STATEMENTS = LabeledDocumentUpdateImplTest.STATEMENTS;
+	private static final StatementUpdate STATEMENTS = StatementDocumentUpdateImplTest.STATEMENTS;
 	private static final TermUpdate LABELS = LabeledDocumentUpdateImplTest.LABELS;
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoUpdateImplTest.java
@@ -1,0 +1,72 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.implementation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.interfaces.MediaInfoIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.MediaInfoUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
+
+public class MediaInfoUpdateImplTest {
+
+	private static final MediaInfoIdValue M1 = Datamodel.makeWikimediaCommonsMediaInfoIdValue("M1");
+	private static final StatementUpdate STATEMENTS = LabeledDocumentUpdateImplTest.STATEMENTS;
+	private static final TermUpdate LABELS = LabeledDocumentUpdateImplTest.LABELS;
+
+	@Test
+	public void testFields() {
+		MediaInfoUpdate update = new MediaInfoUpdateImpl(M1, 123, LABELS, STATEMENTS);
+		assertEquals(M1, update.getEntityId());
+		assertEquals(123, update.getBaseRevisionId());
+		assertSame(STATEMENTS, update.getStatements());
+		assertSame(LABELS, update.getLabels());
+	}
+
+	@Test
+	public void testEmpty() {
+		assertTrue(new MediaInfoUpdateImpl(M1, 123, TermUpdate.EMPTY, StatementUpdate.EMPTY).isEmpty());
+		assertFalse(new MediaInfoUpdateImpl(M1, 123, LABELS, StatementUpdate.EMPTY).isEmpty());
+	}
+
+	@Test
+	public void testEquality() {
+		MediaInfoUpdate update = new MediaInfoUpdateImpl(M1, 123, LABELS, STATEMENTS);
+		assertFalse(update.equals(null));
+		assertFalse(update.equals(this));
+		assertTrue(update.equals(update));
+		assertTrue(update.equals(new MediaInfoUpdateImpl(M1, 123, LABELS, STATEMENTS)));
+		assertFalse(update.equals(new MediaInfoUpdateImpl(M1, 123, TermUpdate.EMPTY, STATEMENTS)));
+	}
+
+	@Test
+	public void testHashCode() {
+		assertEquals(
+				new MediaInfoUpdateImpl(M1, 123, LABELS, STATEMENTS).hashCode(),
+				new MediaInfoUpdateImpl(M1, 123, LABELS, STATEMENTS).hashCode());
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImplTest.java
@@ -203,7 +203,14 @@ public class PropertyDocumentImplTest {
 		assertThrows(IllegalArgumentException.class, () -> new PropertyDocumentImpl(pid, labelList, descriptions2, aliasList,
 				statementGroups, datatypeId, 1234));
 	}
-	
+
+	@Test
+	public void testWithEntityId() {
+		assertEquals(PropertyIdValue.NULL, pd1.withEntityId(PropertyIdValue.NULL).getEntityId());
+		PropertyIdValue id = Datamodel.makeWikidataPropertyIdValue("P123");
+		assertEquals(id, pd1.withEntityId(id).getEntityId());
+	}
+
 	@Test
 	public void testWithRevisionId() {
 		assertEquals(1235L, pd1.withRevisionId(1235L).getRevisionId());

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyIdValueImplTest.java
@@ -21,6 +21,7 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -106,4 +107,10 @@ public class PropertyIdValueImplTest {
 	public void testToJavaWithoutNumericalID() throws IOException {
 		assertEquals(prop1, mapper.readValue(JSON_PROPERTY_ID_VALUE_WITHOUT_NUMERICAL_ID, ValueImpl.class));
 	}
+
+	@Test
+	public void testIsPlaceholder() {
+		assertFalse(prop1.isPlaceholder());
+	}
+
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyUpdateImplTest.java
@@ -19,16 +19,20 @@
  */
 package org.wikidata.wdtk.datamodel.implementation;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.producesJson;
+import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.toJson;
 
 import java.util.Collections;
 import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.helpers.PropertyUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.StatementUpdateBuilder;
 import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
@@ -42,6 +46,7 @@ public class PropertyUpdateImplTest {
 	private static final StatementUpdate STATEMENTS = StatementUpdateBuilder.create().remove("ID123").build();
 	private static final TermUpdate LABELS = LabeledDocumentUpdateImplTest.LABELS;
 	private static final TermUpdate DESCRIPTIONS = TermedDocumentUpdateImplTest.DESCRIPTIONS;
+	private static final AliasUpdate ALIAS = TermedDocumentUpdateImplTest.ALIAS;
 	private static final Map<String, AliasUpdate> ALIASES = TermedDocumentUpdateImplTest.ALIASES;
 
 	@Test
@@ -81,6 +86,22 @@ public class PropertyUpdateImplTest {
 		assertEquals(
 				new PropertyUpdateImpl(P1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS).hashCode(),
 				new PropertyUpdateImpl(P1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS).hashCode());
+	}
+
+	@Test
+	public void testJson() {
+		assertThat(
+				new PropertyUpdateImpl(
+						P1, 123, TermUpdate.EMPTY, TermUpdate.EMPTY, Collections.emptyMap(), StatementUpdate.EMPTY),
+				producesJson("{}"));
+		assertThat(PropertyUpdateBuilder.forEntityId(P1).updateLabels(LABELS).build(),
+				producesJson("{'labels':" + toJson(LABELS) + "}"));
+		assertThat(PropertyUpdateBuilder.forEntityId(P1).updateDescriptions(DESCRIPTIONS).build(),
+				producesJson("{'descriptions':" + toJson(LABELS) + "}"));
+		assertThat(PropertyUpdateBuilder.forEntityId(P1).updateAliases("en", ALIAS).build(),
+				producesJson("{'aliases':{'en':" + toJson(ALIAS) + "}}"));
+		assertThat(PropertyUpdateBuilder.forEntityId(P1).updateStatements(STATEMENTS).build(),
+				producesJson("{'claims':" + toJson(STATEMENTS) + "}"));
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyUpdateImplTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.helpers.StatementUpdateBuilder;
 import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyUpdate;
@@ -38,7 +39,7 @@ import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 public class PropertyUpdateImplTest {
 
 	private static final PropertyIdValue P1 = Datamodel.makeWikidataPropertyIdValue("P1");
-	private static final StatementUpdate STATEMENTS = LabeledDocumentUpdateImplTest.STATEMENTS;
+	private static final StatementUpdate STATEMENTS = StatementUpdateBuilder.create().remove("ID123").build();
 	private static final TermUpdate LABELS = LabeledDocumentUpdateImplTest.LABELS;
 	private static final TermUpdate DESCRIPTIONS = TermedDocumentUpdateImplTest.DESCRIPTIONS;
 	private static final Map<String, AliasUpdate> ALIASES = TermedDocumentUpdateImplTest.ALIASES;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyUpdateImplTest.java
@@ -24,50 +24,62 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Collections;
+import java.util.Map;
+
 import org.junit.jupiter.api.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
-import org.wikidata.wdtk.datamodel.interfaces.MediaInfoIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.MediaInfoUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 
-public class MediaInfoUpdateImplTest {
+public class PropertyUpdateImplTest {
 
-	private static final MediaInfoIdValue M1 = Datamodel.makeWikimediaCommonsMediaInfoIdValue("M1");
+	private static final PropertyIdValue P1 = Datamodel.makeWikidataPropertyIdValue("P1");
 	private static final StatementUpdate STATEMENTS = LabeledDocumentUpdateImplTest.STATEMENTS;
 	private static final TermUpdate LABELS = LabeledDocumentUpdateImplTest.LABELS;
+	private static final TermUpdate DESCRIPTIONS = TermedDocumentUpdateImplTest.DESCRIPTIONS;
+	private static final Map<String, AliasUpdate> ALIASES = TermedDocumentUpdateImplTest.ALIASES;
 
 	@Test
 	public void testFields() {
-		MediaInfoUpdate update = new MediaInfoUpdateImpl(M1, 123, LABELS, STATEMENTS);
-		assertEquals(M1, update.getEntityId());
+		PropertyUpdate update = new PropertyUpdateImpl(P1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS);
+		assertEquals(P1, update.getEntityId());
 		assertEquals(123, update.getBaseRevisionId());
 		assertSame(LABELS, update.getLabels());
+		assertSame(DESCRIPTIONS, update.getDescriptions());
+		assertEquals(ALIASES, update.getAliases());
 		assertSame(STATEMENTS, update.getStatements());
 	}
 
 	@Test
 	public void testEmpty() {
-		assertTrue(new MediaInfoUpdateImpl(M1, 123, TermUpdate.EMPTY, StatementUpdate.EMPTY).isEmpty());
-		assertFalse(new MediaInfoUpdateImpl(M1, 123, LABELS, StatementUpdate.EMPTY).isEmpty());
+		PropertyUpdate empty = new PropertyUpdateImpl(P1, 123, TermUpdate.EMPTY, TermUpdate.EMPTY,
+				Collections.emptyMap(), StatementUpdate.EMPTY);
+		assertTrue(empty.isEmpty());
+		PropertyUpdate nonempty = new PropertyUpdateImpl(P1, 123, TermUpdate.EMPTY, DESCRIPTIONS,
+				Collections.emptyMap(), StatementUpdate.EMPTY);
+		assertFalse(nonempty.isEmpty());
 	}
 
 	@Test
 	@SuppressWarnings("unlikely-arg-type")
 	public void testEquality() {
-		MediaInfoUpdate update = new MediaInfoUpdateImpl(M1, 123, LABELS, STATEMENTS);
+		PropertyUpdate update = new PropertyUpdateImpl(P1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS);
 		assertFalse(update.equals(null));
 		assertFalse(update.equals(this));
 		assertTrue(update.equals(update));
-		assertTrue(update.equals(new MediaInfoUpdateImpl(M1, 123, LABELS, STATEMENTS)));
-		assertFalse(update.equals(new MediaInfoUpdateImpl(M1, 123, TermUpdate.EMPTY, STATEMENTS)));
+		assertTrue(update.equals(new PropertyUpdateImpl(P1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS)));
+		assertFalse(update.equals(new PropertyUpdateImpl(P1, 123, LABELS, TermUpdate.EMPTY, ALIASES, STATEMENTS)));
 	}
 
 	@Test
 	public void testHashCode() {
 		assertEquals(
-				new MediaInfoUpdateImpl(M1, 123, LABELS, STATEMENTS).hashCode(),
-				new MediaInfoUpdateImpl(M1, 123, LABELS, STATEMENTS).hashCode());
+				new PropertyUpdateImpl(P1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS).hashCode(),
+				new PropertyUpdateImpl(P1, 123, LABELS, DESCRIPTIONS, ALIASES, STATEMENTS).hashCode());
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SenseDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SenseDocumentImplTest.java
@@ -33,6 +33,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.Claim;
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
@@ -146,6 +147,13 @@ public class SenseDocumentImplTest {
 		assertTrue(statements.hasNext());
 		assertEquals(s, statements.next());
 		assertFalse(statements.hasNext());
+	}
+
+	@Test
+	public void testWithEntityId() {
+		assertEquals(SenseIdValue.NULL, sd1.withEntityId(SenseIdValue.NULL).getEntityId());
+		SenseIdValue id = Datamodel.makeWikidataSenseIdValue("L123-S45");
+		assertEquals(id, sd1.withEntityId(id).getEntityId());
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SenseIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SenseIdValueImplTest.java
@@ -21,6 +21,7 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -129,4 +130,10 @@ public class SenseIdValueImplTest {
 	public void testToJavaWithoutNumericalID() throws IOException {
 		assertEquals(sense1, mapper.readValue(JSON_SENSE_ID_VALUE_WITHOUT_TYPE, ValueImpl.class));
 	}
+
+	@Test
+	public void testIsPlaceholder() {
+		assertFalse(sense1.isPlaceholder());
+	}
+
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SenseUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SenseUpdateImplTest.java
@@ -36,7 +36,7 @@ import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 public class SenseUpdateImplTest {
 
 	private static final SenseIdValue S1 = Datamodel.makeWikidataSenseIdValue("L1-S1");
-	private static final StatementUpdate STATEMENTS = LabeledDocumentUpdateImplTest.STATEMENTS;
+	private static final StatementUpdate STATEMENTS = StatementDocumentUpdateImplTest.STATEMENTS;
 	private static final TermUpdate GLOSSES = TermUpdateBuilder.create().remove("en").build();
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SenseUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SenseUpdateImplTest.java
@@ -19,14 +19,18 @@
  */
 package org.wikidata.wdtk.datamodel.implementation;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.producesJson;
+import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.toJson;
 
 import org.junit.jupiter.api.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.helpers.SenseUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;
 import org.wikidata.wdtk.datamodel.interfaces.SenseIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.SenseUpdate;
@@ -78,6 +82,15 @@ public class SenseUpdateImplTest {
 		SenseUpdate update1 = new SenseUpdateImpl(S1, 123, GLOSSES, STATEMENTS);
 		SenseUpdate update2 = new SenseUpdateImpl(S1, 123, TermUpdateBuilder.create().remove("en").build(), STATEMENTS);
 		assertEquals(update1.hashCode(), update2.hashCode());
+	}
+
+	@Test
+	public void testJson() {
+		assertThat(new SenseUpdateImpl(S1, 123, TermUpdate.EMPTY, StatementUpdate.EMPTY), producesJson("{}"));
+		assertThat(SenseUpdateBuilder.forEntityId(S1).updateGlosses(GLOSSES).build(),
+				producesJson("{'glosses':" + toJson(GLOSSES) + "}"));
+		assertThat(SenseUpdateBuilder.forEntityId(S1).updateStatements(STATEMENTS).build(),
+				producesJson("{'claims':" + toJson(STATEMENTS) + "}"));
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SenseUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SenseUpdateImplTest.java
@@ -1,0 +1,82 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.implementation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;
+import org.wikidata.wdtk.datamodel.interfaces.SenseIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.SenseUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
+
+public class SenseUpdateImplTest {
+
+	private static final SenseIdValue S1 = Datamodel.makeWikidataSenseIdValue("L1-S1");
+	private static final StatementUpdate STATEMENTS = LabeledDocumentUpdateImplTest.STATEMENTS;
+	private static final TermUpdate GLOSSES = TermUpdateBuilder.create().remove("en").build();
+
+	@Test
+	public void testFields() {
+		SenseUpdate update = new SenseUpdateImpl(S1, 123, GLOSSES, STATEMENTS);
+		assertEquals(S1, update.getEntityId());
+		assertEquals(123, update.getBaseRevisionId());
+		assertSame(GLOSSES, update.getGlosses());
+		assertSame(STATEMENTS, update.getStatements());
+	}
+
+	@Test
+	public void testValidation() {
+		assertThrows(NullPointerException.class, () -> new SenseUpdateImpl(S1, 0, null, StatementUpdate.EMPTY));
+	}
+
+	@Test
+	public void testEmpty() {
+		assertFalse(new SenseUpdateImpl(S1, 0, TermUpdate.EMPTY, STATEMENTS).isEmpty());
+		assertFalse(new SenseUpdateImpl(S1, 0, GLOSSES, StatementUpdate.EMPTY).isEmpty());
+		assertTrue(new SenseUpdateImpl(S1, 0, TermUpdate.EMPTY, StatementUpdate.EMPTY).isEmpty());
+	}
+
+	@Test
+	public void testEquality() {
+		SenseUpdate update = new SenseUpdateImpl(S1, 0, GLOSSES, STATEMENTS);
+		assertFalse(update.equals(null));
+		assertFalse(update.equals(this));
+		assertTrue(update.equals(update));
+		assertTrue(update.equals(
+				new SenseUpdateImpl(S1, 0, TermUpdateBuilder.create().remove("en").build(), STATEMENTS)));
+		assertFalse(update.equals(new SenseUpdateImpl(S1, 123, GLOSSES, StatementUpdate.EMPTY)));
+		assertFalse(update.equals(new SenseUpdateImpl(S1, 123, TermUpdate.EMPTY, STATEMENTS)));
+	}
+
+	@Test
+	public void testHashCode() {
+		SenseUpdate update1 = new SenseUpdateImpl(S1, 123, GLOSSES, STATEMENTS);
+		SenseUpdate update2 = new SenseUpdateImpl(S1, 123, TermUpdateBuilder.create().remove("en").build(), STATEMENTS);
+		assertEquals(update1.hashCode(), update2.hashCode());
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SenseUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SenseUpdateImplTest.java
@@ -61,6 +61,7 @@ public class SenseUpdateImplTest {
 	}
 
 	@Test
+	@SuppressWarnings("unlikely-arg-type")
 	public void testEquality() {
 		SenseUpdate update = new SenseUpdateImpl(S1, 0, GLOSSES, STATEMENTS);
 		assertFalse(update.equals(null));

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementDocumentUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementDocumentUpdateImplTest.java
@@ -1,0 +1,94 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.implementation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.helpers.StatementUpdateBuilder;
+import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
+import org.wikidata.wdtk.datamodel.interfaces.StatementDocumentUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
+
+public class StatementDocumentUpdateImplTest {
+
+	private static final ItemIdValue JOHN = StatementUpdateImplTest.JOHN;
+	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateImplTest.JOHN_HAS_BROWN_HAIR;
+	private static final Collection<SiteLink> NO_SITELINKS = Collections.emptyList();
+	private static final Collection<String> NO_REMOVED_SITELINKS = Collections.emptyList();
+
+	private static StatementDocumentUpdate create(ItemIdValue entityId, long revisionId, StatementUpdate statements) {
+		return new ItemUpdateImpl(entityId, revisionId, TermUpdate.NULL, TermUpdate.NULL, Collections.emptyMap(),
+				statements, NO_SITELINKS, NO_REMOVED_SITELINKS);
+	}
+
+	@Test
+	public void testFields() {
+		StatementUpdate statements = StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build();
+		StatementDocumentUpdate update = create(JOHN, 123, statements);
+		assertEquals(JOHN, update.getEntityId());
+		assertEquals(123, update.getBaseRevisionId());
+		assertSame(statements, update.getStatements());
+	}
+
+	@Test
+	public void testValidation() {
+		assertThrows(NullPointerException.class, () -> create(JOHN, 0, null));
+	}
+
+	@Test
+	public void testEmpty() {
+		StatementUpdate statements = StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build();
+		assertFalse(create(JOHN, 0, statements).isEmpty());
+		assertTrue(create(JOHN, 0, StatementUpdate.NULL).isEmpty());
+	}
+
+	@Test
+	public void testEquality() {
+		StatementDocumentUpdate update = create(JOHN, 0,
+				StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build());
+		assertTrue(update.equals(update));
+		assertTrue(update.equals(create(JOHN, 0,
+				StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())));
+		assertFalse(update.equals(create(JOHN, 123,
+				StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())));
+		assertFalse(update.equals(create(JOHN, 0, StatementUpdate.NULL)));
+	}
+
+	@Test
+	public void testHashCode() {
+		StatementDocumentUpdate update1 = create(JOHN, 123,
+				StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build());
+		StatementDocumentUpdate update2 = create(JOHN, 123,
+				StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build());
+		assertEquals(update1.hashCode(), update2.hashCode());
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementDocumentUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementDocumentUpdateImplTest.java
@@ -45,7 +45,7 @@ public class StatementDocumentUpdateImplTest {
 	private static final Collection<String> NO_REMOVED_SITELINKS = Collections.emptyList();
 
 	private static StatementDocumentUpdate create(ItemIdValue entityId, long revisionId, StatementUpdate statements) {
-		return new ItemUpdateImpl(entityId, revisionId, TermUpdate.NULL, TermUpdate.NULL, Collections.emptyMap(),
+		return new ItemUpdateImpl(entityId, revisionId, TermUpdate.EMPTY, TermUpdate.EMPTY, Collections.emptyMap(),
 				statements, NO_SITELINKS, NO_REMOVED_SITELINKS);
 	}
 
@@ -67,7 +67,7 @@ public class StatementDocumentUpdateImplTest {
 	public void testEmpty() {
 		StatementUpdate statements = StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build();
 		assertFalse(create(JOHN, 0, statements).isEmpty());
-		assertTrue(create(JOHN, 0, StatementUpdate.NULL).isEmpty());
+		assertTrue(create(JOHN, 0, StatementUpdate.EMPTY).isEmpty());
 	}
 
 	@Test
@@ -79,7 +79,7 @@ public class StatementDocumentUpdateImplTest {
 				StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())));
 		assertFalse(update.equals(create(JOHN, 123,
 				StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())));
-		assertFalse(update.equals(create(JOHN, 0, StatementUpdate.NULL)));
+		assertFalse(update.equals(create(JOHN, 0, StatementUpdate.EMPTY)));
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementDocumentUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementDocumentUpdateImplTest.java
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.Test;
 import org.wikidata.wdtk.datamodel.helpers.StatementUpdateBuilder;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
-import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementDocumentUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
@@ -40,7 +39,7 @@ import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 public class StatementDocumentUpdateImplTest {
 
 	private static final ItemIdValue JOHN = StatementUpdateImplTest.JOHN;
-	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateImplTest.JOHN_HAS_BROWN_HAIR;
+	static final StatementUpdate STATEMENTS = StatementUpdateBuilder.create().remove("ID123").build();
 	private static final Collection<SiteLink> NO_SITELINKS = Collections.emptyList();
 	private static final Collection<String> NO_REMOVED_SITELINKS = Collections.emptyList();
 
@@ -51,43 +50,41 @@ public class StatementDocumentUpdateImplTest {
 
 	@Test
 	public void testFields() {
-		StatementUpdate statements = StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build();
-		StatementDocumentUpdate update = create(JOHN, 123, statements);
+		StatementDocumentUpdate update = create(JOHN, 123, STATEMENTS);
 		assertEquals(JOHN, update.getEntityId());
 		assertEquals(123, update.getBaseRevisionId());
-		assertSame(statements, update.getStatements());
+		assertSame(STATEMENTS, update.getStatements());
 	}
 
 	@Test
 	public void testValidation() {
 		assertThrows(NullPointerException.class, () -> create(JOHN, 0, null));
+		assertThrows(IllegalArgumentException.class, () -> create(JOHN, 0,
+				StatementUpdateBuilder.create().add(StatementUpdateImplTest.RITA_HAS_BROWN_HAIR).build()));
+		assertThrows(IllegalArgumentException.class,
+				() -> create(JOHN, 0, StatementUpdateBuilder.create()
+						.replace(StatementUpdateImplTest.RITA_HAS_BROWN_HAIR.withStatementId("ID99")).build()));
 	}
 
 	@Test
 	public void testEmpty() {
-		StatementUpdate statements = StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build();
-		assertFalse(create(JOHN, 0, statements).isEmpty());
+		assertFalse(create(JOHN, 0, STATEMENTS).isEmpty());
 		assertTrue(create(JOHN, 0, StatementUpdate.EMPTY).isEmpty());
 	}
 
 	@Test
 	public void testEquality() {
-		StatementDocumentUpdate update = create(JOHN, 0,
-				StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build());
+		StatementDocumentUpdate update = create(JOHN, 0, STATEMENTS);
 		assertTrue(update.equals(update));
-		assertTrue(update.equals(create(JOHN, 0,
-				StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())));
-		assertFalse(update.equals(create(JOHN, 123,
-				StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build())));
+		assertTrue(update.equals(create(JOHN, 0, StatementUpdateBuilder.create().remove("ID123").build())));
+		assertFalse(update.equals(create(JOHN, 123, STATEMENTS)));
 		assertFalse(update.equals(create(JOHN, 0, StatementUpdate.EMPTY)));
 	}
 
 	@Test
 	public void testHashCode() {
-		StatementDocumentUpdate update1 = create(JOHN, 123,
-				StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build());
-		StatementDocumentUpdate update2 = create(JOHN, 123,
-				StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build());
+		StatementDocumentUpdate update1 = create(JOHN, 123, STATEMENTS);
+		StatementDocumentUpdate update2 = create(JOHN, 123, StatementUpdateBuilder.create().remove("ID123").build());
 		assertEquals(update1.hashCode(), update2.hashCode());
 	}
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementUpdateImplTest.java
@@ -62,7 +62,7 @@ public class StatementUpdateImplTest {
 			.forSubjectAndProperty(JOHN, HAIR)
 			.withValue(BROWN)
 			.build();
-	private static final Statement RITA_HAS_BROWN_HAIR = StatementBuilder
+	static final Statement RITA_HAS_BROWN_HAIR = StatementBuilder
 			.forSubjectAndProperty(RITA, HAIR)
 			.withValue(BROWN)
 			.build();

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementUpdateImplTest.java
@@ -25,6 +25,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.producesJson;
+import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.toJson;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,6 +37,7 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.StatementBuilder;
+import org.wikidata.wdtk.datamodel.helpers.StatementUpdateBuilder;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
@@ -182,6 +185,17 @@ public class StatementUpdateImplTest {
 				Arrays.asList(JOHN_ALREADY_HAS_BLUE_EYES),
 				Arrays.asList(JOHN_ALREADY_HAS_SILVER_HAIR.getStatementId()));
 		assertEquals(update1.hashCode(), update2.hashCode());
+	}
+
+	@Test
+	public void testJson() {
+		assertThat(StatementUpdateBuilder.create().build(), producesJson("[]"));
+		assertThat(StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build(),
+				producesJson("[" + toJson(JOHN_HAS_BROWN_HAIR) + "]"));
+		assertThat(StatementUpdateBuilder.create().replace(JOHN_ALREADY_HAS_BLUE_EYES).build(),
+				producesJson("[" + toJson(JOHN_ALREADY_HAS_BLUE_EYES) + "]"));
+		assertThat(StatementUpdateBuilder.create().remove("ID123").build(),
+				producesJson("[{'id':'ID123','remove':''}]"));
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementUpdateImplTest.java
@@ -1,0 +1,187 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.implementation;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.helpers.StatementBuilder;
+import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
+import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.StringValue;
+
+public class StatementUpdateImplTest {
+
+	private static final Collection<Statement> NO_STATEMENTS = Collections.emptyList();
+	private static final Collection<String> NO_IDS = Collections.emptyList();
+	private static final EntityIdValue JOHN = Datamodel.makeWikidataItemIdValue("Q1");
+	private static final EntityIdValue RITA = Datamodel.makeWikidataItemIdValue("Q2");
+	private static final PropertyIdValue HAIR = Datamodel.makeWikidataPropertyIdValue("P1");
+	private static final PropertyIdValue EYES = Datamodel.makeWikidataPropertyIdValue("P2");
+	private static final StringValue BROWN = Datamodel.makeStringValue("brown");
+	private static final StringValue SILVER = Datamodel.makeStringValue("silver");
+	private static final StringValue BLUE = Datamodel.makeStringValue("blue");
+	private static final Statement NOBODY_HAS_BROWN_HAIR = StatementBuilder
+			.forSubjectAndProperty(ItemIdValue.NULL, HAIR)
+			.withValue(BROWN)
+			.build();
+	private static final Statement NOBODY_ALREADY_HAS_BROWN_HAIR = NOBODY_HAS_BROWN_HAIR.withStatementId("ID1");
+	private static final Statement JOHN_HAS_BROWN_HAIR = StatementBuilder
+			.forSubjectAndProperty(JOHN, HAIR)
+			.withValue(BROWN)
+			.build();
+	private static final Statement RITA_HAS_BROWN_HAIR = StatementBuilder
+			.forSubjectAndProperty(RITA, HAIR)
+			.withValue(BROWN)
+			.build();
+	private static final Statement JOHN_HAS_SILVER_HAIR = StatementBuilder
+			.forSubjectAndProperty(JOHN, HAIR)
+			.withValue(SILVER)
+			.build();
+	private static final Statement JOHN_ALREADY_HAS_SILVER_HAIR = JOHN_HAS_SILVER_HAIR.withStatementId("ID5");
+	private static final Statement JOHN_HAS_BLUE_EYES = StatementBuilder
+			.forSubjectAndProperty(JOHN, EYES)
+			.withValue(BLUE)
+			.build();
+	private static final Statement JOHN_ALREADY_HAS_BLUE_EYES = JOHN_HAS_BLUE_EYES.withStatementId("ID8");
+
+	@Test
+	public void testFields() {
+		StatementUpdate update = new StatementUpdateImpl(
+				Arrays.asList(JOHN_HAS_BROWN_HAIR),
+				Arrays.asList(JOHN_ALREADY_HAS_BLUE_EYES),
+				Arrays.asList(JOHN_ALREADY_HAS_SILVER_HAIR.getStatementId()));
+		assertEquals(Arrays.asList(JOHN_HAS_BROWN_HAIR), update.getAdded());
+		assertThat(update.getReplaced().keySet(), containsInAnyOrder(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId()));
+		assertEquals(JOHN_ALREADY_HAS_BLUE_EYES, update.getReplaced().get(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId()));
+		assertThat(update.getRemoved(), containsInAnyOrder(JOHN_ALREADY_HAS_SILVER_HAIR.getStatementId()));
+	}
+
+	@Test
+	public void testValidation() {
+		new StatementUpdateImpl(NO_STATEMENTS, NO_STATEMENTS, NO_IDS);
+		assertThrows(NullPointerException.class, () -> new StatementUpdateImpl(null, NO_STATEMENTS, NO_IDS));
+		assertThrows(NullPointerException.class, () -> new StatementUpdateImpl(NO_STATEMENTS, null, NO_IDS));
+		assertThrows(NullPointerException.class, () -> new StatementUpdateImpl(NO_STATEMENTS, NO_STATEMENTS, null));
+		assertThrows(NullPointerException.class, () -> new StatementUpdateImpl(
+				Arrays.asList(JOHN_HAS_BROWN_HAIR, null), NO_STATEMENTS, NO_IDS));
+		assertThrows(NullPointerException.class, () -> new StatementUpdateImpl(
+				NO_STATEMENTS, Arrays.asList(JOHN_ALREADY_HAS_BLUE_EYES, null), NO_IDS));
+		assertThrows(NullPointerException.class, () -> new StatementUpdateImpl(
+				NO_STATEMENTS, NO_STATEMENTS, Arrays.asList(JOHN_ALREADY_HAS_SILVER_HAIR.getStatementId(), null)));
+		assertThrows(IllegalArgumentException.class, () -> new StatementUpdateImpl(
+				Arrays.asList(JOHN_ALREADY_HAS_BLUE_EYES), NO_STATEMENTS, NO_IDS));
+		assertThrows(IllegalArgumentException.class, () -> new StatementUpdateImpl(
+				NO_STATEMENTS, Arrays.asList(JOHN_HAS_BLUE_EYES), NO_IDS));
+		assertThrows(IllegalArgumentException.class, () -> new StatementUpdateImpl(
+				NO_STATEMENTS, NO_STATEMENTS, Arrays.asList(" ")));
+		assertThrows(IllegalArgumentException.class, () -> new StatementUpdateImpl(
+				NO_STATEMENTS, Arrays.asList(JOHN_ALREADY_HAS_BLUE_EYES, JOHN_ALREADY_HAS_BLUE_EYES), NO_IDS));
+		assertThrows(IllegalArgumentException.class,
+				() -> new StatementUpdateImpl(NO_STATEMENTS, NO_STATEMENTS, Arrays.asList(
+						JOHN_ALREADY_HAS_BLUE_EYES.getStatementId(), JOHN_ALREADY_HAS_BLUE_EYES.getStatementId())));
+		assertThrows(IllegalArgumentException.class, () -> new StatementUpdateImpl(NO_STATEMENTS,
+				Arrays.asList(JOHN_ALREADY_HAS_BLUE_EYES), Arrays.asList(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId())));
+		assertThrows(IllegalArgumentException.class, () -> new StatementUpdateImpl(
+				Arrays.asList(RITA_HAS_BROWN_HAIR), Arrays.asList(JOHN_ALREADY_HAS_BLUE_EYES), NO_IDS));
+		assertThrows(IllegalArgumentException.class, () -> new StatementUpdateImpl(
+				Arrays.asList(NOBODY_HAS_BROWN_HAIR), NO_STATEMENTS, NO_IDS));
+		assertThrows(IllegalArgumentException.class, () -> new StatementUpdateImpl(
+				NO_STATEMENTS, Arrays.asList(NOBODY_ALREADY_HAS_BROWN_HAIR), NO_IDS));
+	}
+
+	@Test
+	public void testImmutability() {
+		List<Statement> added = new ArrayList<>();
+		List<Statement> replaced = new ArrayList<>();
+		List<String> removed = new ArrayList<>();
+		added.add(JOHN_HAS_BROWN_HAIR);
+		replaced.add(JOHN_ALREADY_HAS_BLUE_EYES);
+		removed.add(JOHN_ALREADY_HAS_SILVER_HAIR.getStatementId());
+		StatementUpdate update = new StatementUpdateImpl(added, replaced, removed);
+		assertThrows(UnsupportedOperationException.class, () -> update.getAdded().add(JOHN_HAS_SILVER_HAIR));
+		assertThrows(UnsupportedOperationException.class, () -> update.getReplaced()
+				.put(JOHN_ALREADY_HAS_SILVER_HAIR.getStatementId(), JOHN_ALREADY_HAS_SILVER_HAIR));
+		assertThrows(UnsupportedOperationException.class,
+				() -> update.getRemoved().add(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId()));
+		added.add(JOHN_HAS_SILVER_HAIR);
+		replaced.add(JOHN_ALREADY_HAS_SILVER_HAIR);
+		removed.add(JOHN_ALREADY_HAS_BLUE_EYES.getStatementId());
+		assertEquals(1, update.getAdded().size());
+		assertEquals(1, update.getReplaced().size());
+		assertEquals(1, update.getRemoved().size());
+	}
+
+	@Test
+	public void testEmpty() {
+		List<Statement> added = Arrays.asList(JOHN_HAS_BROWN_HAIR);
+		List<Statement> replaced = Arrays.asList(JOHN_ALREADY_HAS_BLUE_EYES);
+		List<String> removed = Arrays.asList(JOHN_ALREADY_HAS_SILVER_HAIR.getStatementId());
+		assertTrue(new StatementUpdateImpl(NO_STATEMENTS, NO_STATEMENTS, NO_IDS).isEmpty());
+		assertFalse(new StatementUpdateImpl(added, NO_STATEMENTS, NO_IDS).isEmpty());
+		assertFalse(new StatementUpdateImpl(NO_STATEMENTS, replaced, NO_IDS).isEmpty());
+		assertFalse(new StatementUpdateImpl(NO_STATEMENTS, NO_STATEMENTS, removed).isEmpty());
+	}
+
+	@Test
+	@SuppressWarnings("unlikely-arg-type")
+	public void testEquality() {
+		List<Statement> added = Arrays.asList(JOHN_HAS_BROWN_HAIR);
+		List<Statement> replaced = Arrays.asList(JOHN_ALREADY_HAS_BLUE_EYES);
+		List<String> removed = Arrays.asList(JOHN_ALREADY_HAS_SILVER_HAIR.getStatementId());
+		StatementUpdate update = new StatementUpdateImpl(added, replaced, removed);
+		assertFalse(update.equals(null));
+		assertFalse(update.equals(this));
+		assertTrue(update.equals(update));
+		assertTrue(update.equals(new StatementUpdateImpl(added, replaced, removed)));
+		assertFalse(update.equals(new StatementUpdateImpl(NO_STATEMENTS, replaced, removed)));
+		assertFalse(update.equals(new StatementUpdateImpl(added, NO_STATEMENTS, removed)));
+		assertFalse(update.equals(new StatementUpdateImpl(added, replaced, NO_IDS)));
+	}
+
+	@Test
+	public void testHashCode() {
+		StatementUpdate update1 = new StatementUpdateImpl(
+				Arrays.asList(JOHN_HAS_BROWN_HAIR),
+				Arrays.asList(JOHN_ALREADY_HAS_BLUE_EYES),
+				Arrays.asList(JOHN_ALREADY_HAS_SILVER_HAIR.getStatementId()));
+		StatementUpdate update2 = new StatementUpdateImpl(
+				Arrays.asList(JOHN_HAS_BROWN_HAIR),
+				Arrays.asList(JOHN_ALREADY_HAS_BLUE_EYES),
+				Arrays.asList(JOHN_ALREADY_HAS_SILVER_HAIR.getStatementId()));
+		assertEquals(update1.hashCode(), update2.hashCode());
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementUpdateImplTest.java
@@ -46,7 +46,7 @@ public class StatementUpdateImplTest {
 
 	private static final Collection<Statement> NO_STATEMENTS = Collections.emptyList();
 	private static final Collection<String> NO_IDS = Collections.emptyList();
-	private static final EntityIdValue JOHN = Datamodel.makeWikidataItemIdValue("Q1");
+	static final ItemIdValue JOHN = Datamodel.makeWikidataItemIdValue("Q1");
 	private static final EntityIdValue RITA = Datamodel.makeWikidataItemIdValue("Q2");
 	private static final PropertyIdValue HAIR = Datamodel.makeWikidataPropertyIdValue("P1");
 	private static final PropertyIdValue EYES = Datamodel.makeWikidataPropertyIdValue("P2");
@@ -58,7 +58,7 @@ public class StatementUpdateImplTest {
 			.withValue(BROWN)
 			.build();
 	private static final Statement NOBODY_ALREADY_HAS_BROWN_HAIR = NOBODY_HAS_BROWN_HAIR.withStatementId("ID1");
-	private static final Statement JOHN_HAS_BROWN_HAIR = StatementBuilder
+	static final Statement JOHN_HAS_BROWN_HAIR = StatementBuilder
 			.forSubjectAndProperty(JOHN, HAIR)
 			.withValue(BROWN)
 			.build();

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermUpdateImplTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.producesJson;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -33,6 +34,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 
@@ -112,6 +114,15 @@ public class TermUpdateImplTest {
 		TermUpdate update1 = new TermUpdateImpl(Arrays.asList(EN, SK), Arrays.asList("cs", "fr"));
 		TermUpdate update2 = new TermUpdateImpl(Arrays.asList(EN, SK), Arrays.asList("cs", "fr"));
 		assertEquals(update1.hashCode(), update2.hashCode());
+	}
+
+	@Test
+	public void testJson() {
+		assertThat(TermUpdateBuilder.create().build(), producesJson("{}"));
+		assertThat(TermUpdateBuilder.create().put(EN).build(),
+				producesJson("{'en':{'language':'en','value':'hello'}}"));
+		assertThat(TermUpdateBuilder.create().remove("en").build(),
+				producesJson("{'en':{'language':'en','remove':''}}"));
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermUpdateImplTest.java
@@ -1,0 +1,117 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.implementation;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
+
+public class TermUpdateImplTest {
+
+	private static final MonolingualTextValue EN = Datamodel.makeMonolingualTextValue("hello", "en");
+	private static final MonolingualTextValue EN2 = Datamodel.makeMonolingualTextValue("hi", "en");
+	private static final MonolingualTextValue SK = Datamodel.makeMonolingualTextValue("ahoj", "sk");
+	private static final MonolingualTextValue CS = Datamodel.makeMonolingualTextValue("nazdar", "cs");
+
+	@Test
+	public void testFields() {
+		TermUpdate update = new TermUpdateImpl(Arrays.asList(EN, SK), Arrays.asList("de", "fr"));
+		assertThat(update.getRemoved(), containsInAnyOrder("de", "fr"));
+		assertThat(update.getModified().keySet(), containsInAnyOrder("sk", "en"));
+		assertEquals(EN, update.getModified().get("en"));
+		assertEquals(SK, update.getModified().get("sk"));
+	}
+
+	@Test
+	public void testValidation() {
+		assertThrows(NullPointerException.class, () -> new TermUpdateImpl(null, Collections.emptyList()));
+		assertThrows(NullPointerException.class, () -> new TermUpdateImpl(Collections.emptyList(), null));
+		assertThrows(NullPointerException.class,
+				() -> new TermUpdateImpl(Arrays.asList(EN, null), Collections.emptyList()));
+		assertThrows(NullPointerException.class,
+				() -> new TermUpdateImpl(Collections.emptyList(), Arrays.asList("en", null)));
+		assertThrows(IllegalArgumentException.class,
+				() -> new TermUpdateImpl(Arrays.asList(EN, EN2), Collections.emptyList()));
+		assertThrows(IllegalArgumentException.class,
+				() -> new TermUpdateImpl(Arrays.asList(EN, EN), Collections.emptyList()));
+		assertThrows(IllegalArgumentException.class,
+				() -> new TermUpdateImpl(Collections.emptyList(), Arrays.asList("en", "")));
+		assertThrows(IllegalArgumentException.class,
+				() -> new TermUpdateImpl(Collections.emptyList(), Arrays.asList("en", "en")));
+		assertThrows(IllegalArgumentException.class, () -> new TermUpdateImpl(Arrays.asList(EN), Arrays.asList("en")));
+	}
+
+	@Test
+	public void testImmutability() {
+		List<MonolingualTextValue> modified = new ArrayList<>();
+		List<String> removed = new ArrayList<>();
+		modified.add(EN);
+		removed.add("sk");
+		TermUpdate update = new TermUpdateImpl(modified, removed);
+		assertThrows(UnsupportedOperationException.class, () -> update.getModified().put("cs", CS));
+		assertThrows(UnsupportedOperationException.class, () -> update.getRemoved().add("fr"));
+		modified.add(CS);
+		removed.add("fr");
+		assertEquals(1, update.getModified().size());
+		assertEquals(1, update.getRemoved().size());
+	}
+
+	@Test
+	public void testEmpty() {
+		assertTrue(new TermUpdateImpl(Collections.emptyList(), Collections.emptyList()).isEmpty());
+		assertFalse(new TermUpdateImpl(Arrays.asList(EN), Collections.emptyList()).isEmpty());
+		assertFalse(new TermUpdateImpl(Collections.emptyList(), Arrays.asList("sk")).isEmpty());
+	}
+
+	@Test
+	@SuppressWarnings("unlikely-arg-type")
+	public void testEquality() {
+		List<MonolingualTextValue> modified = Arrays.asList(EN);
+		List<String> removed = Arrays.asList("sk");
+		TermUpdate update = new TermUpdateImpl(modified, removed);
+		assertFalse(update.equals(null));
+		assertFalse(update.equals(this));
+		assertTrue(update.equals(update));
+		assertTrue(update.equals(new TermUpdateImpl(modified, removed)));
+		assertFalse(update.equals(new TermUpdateImpl(Collections.emptyList(), removed)));
+		assertFalse(update.equals(new TermUpdateImpl(modified, Collections.emptyList())));
+	}
+
+	@Test
+	public void testHashCode() {
+		TermUpdate update1 = new TermUpdateImpl(Arrays.asList(EN, SK), Arrays.asList("cs", "fr"));
+		TermUpdate update2 = new TermUpdateImpl(Arrays.asList(EN, SK), Arrays.asList("cs", "fr"));
+		assertEquals(update1.hashCode(), update2.hashCode());
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermedDocumentUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermedDocumentUpdateImplTest.java
@@ -46,7 +46,7 @@ import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocumentUpdate;
 public class TermedDocumentUpdateImplTest {
 
 	private static final ItemIdValue JOHN = StatementUpdateImplTest.JOHN;
-	private static final StatementUpdate STATEMENTS = LabeledDocumentUpdateImplTest.STATEMENTS;
+	private static final StatementUpdate STATEMENTS = StatementDocumentUpdateImplTest.STATEMENTS;
 	private static final MonolingualTextValue EN = Datamodel.makeMonolingualTextValue("hello", "en");
 	private static final MonolingualTextValue SK = Datamodel.makeMonolingualTextValue("ahoj", "sk");
 	private static final TermUpdate LABELS = TermUpdateBuilder.create().remove("de").build();

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermedDocumentUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermedDocumentUpdateImplTest.java
@@ -1,0 +1,152 @@
+/*
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+package org.wikidata.wdtk.datamodel.implementation;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.helpers.AliasUpdateBuilder;
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.helpers.StatementUpdateBuilder;
+import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;
+import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
+import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocumentUpdate;
+
+public class TermedDocumentUpdateImplTest {
+
+	private static final ItemIdValue JOHN = StatementUpdateImplTest.JOHN;
+	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateImplTest.JOHN_HAS_BROWN_HAIR;
+	private static final StatementUpdate STATEMENTS = StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build();
+	private static final MonolingualTextValue EN = Datamodel.makeMonolingualTextValue("hello", "en");
+	private static final MonolingualTextValue SK = Datamodel.makeMonolingualTextValue("ahoj", "sk");
+	private static final TermUpdate LABELS = TermUpdateBuilder.create().remove("de").build();
+	private static final TermUpdate DESCRIPTIONS = TermUpdateBuilder.create().remove("en").build();
+	private static final Map<String, AliasUpdate> ALIASES = new HashMap<>();
+
+	static {
+		ALIASES.put("en", AliasUpdateBuilder.create().add(EN).build());
+	}
+
+	private static TermedStatementDocumentUpdate create(
+			ItemIdValue entityId,
+			long revisionId,
+			StatementUpdate statements,
+			TermUpdate labels,
+			TermUpdate descriptions,
+			Map<String, AliasUpdate> aliases) {
+		return new ItemUpdateImpl(entityId, revisionId, labels, descriptions, aliases, statements,
+				Collections.emptyList(), Collections.emptyList());
+	}
+
+	@Test
+	public void testFields() {
+		TermedStatementDocumentUpdate update = create(JOHN, 123, STATEMENTS, LABELS, DESCRIPTIONS, ALIASES);
+		assertEquals(JOHN, update.getEntityId());
+		assertEquals(123, update.getBaseRevisionId());
+		assertSame(STATEMENTS, update.getStatements());
+		assertSame(LABELS, update.getLabels());
+		assertSame(DESCRIPTIONS, update.getDescriptions());
+		assertEquals(ALIASES, update.getAliases());
+	}
+
+	@Test
+	public void testValidation() {
+		assertThrows(NullPointerException.class,
+				() -> create(JOHN, 123, StatementUpdate.EMPTY, TermUpdate.EMPTY, null, ALIASES));
+		assertThrows(NullPointerException.class,
+				() -> create(JOHN, 123, StatementUpdate.EMPTY, TermUpdate.EMPTY, TermUpdate.EMPTY, null));
+		Map<String, AliasUpdate> aliases = new HashMap<>();
+		aliases.put(null, AliasUpdate.EMPTY);
+		assertThrows(NullPointerException.class,
+				() -> create(JOHN, 123, StatementUpdate.EMPTY, TermUpdate.EMPTY, TermUpdate.EMPTY, aliases));
+		aliases.clear();
+		aliases.put("en", null);
+		assertThrows(NullPointerException.class,
+				() -> create(JOHN, 123, StatementUpdate.EMPTY, TermUpdate.EMPTY, TermUpdate.EMPTY, aliases));
+		aliases.clear();
+		aliases.put(" ", AliasUpdate.EMPTY);
+		assertThrows(IllegalArgumentException.class,
+				() -> create(JOHN, 123, StatementUpdate.EMPTY, TermUpdate.EMPTY, TermUpdate.EMPTY, aliases));
+		aliases.clear();
+		aliases.put("de", AliasUpdateBuilder.create().add(EN).build());
+		assertThrows(IllegalArgumentException.class,
+				() -> create(JOHN, 123, StatementUpdate.EMPTY, TermUpdate.EMPTY, TermUpdate.EMPTY, aliases));
+		aliases.clear();
+		aliases.put("en", AliasUpdate.EMPTY);
+		assertThat(
+				create(JOHN, 123, StatementUpdate.EMPTY, TermUpdate.EMPTY, TermUpdate.EMPTY, aliases).getAliases(),
+				is(anEmptyMap()));
+	}
+
+	@Test
+	public void testImmutability() {
+		Map<String, AliasUpdate> aliases = new HashMap<>();
+		aliases.put("en", AliasUpdateBuilder.create().add(EN).build());
+		TermedStatementDocumentUpdate update = create(
+				JOHN, 0, StatementUpdate.EMPTY, TermUpdate.EMPTY, TermUpdate.EMPTY, aliases);
+		assertThrows(UnsupportedOperationException.class, () -> update.getAliases().remove("en"));
+		aliases.put("sk", AliasUpdateBuilder.create().add(SK).build());
+		assertEquals(1, update.getAliases().size());
+	}
+
+	@Test
+	public void testEmpty() {
+		assertTrue(create(JOHN, 0, StatementUpdate.EMPTY, TermUpdate.EMPTY, TermUpdate.EMPTY, Collections.emptyMap())
+				.isEmpty());
+		assertFalse(create(JOHN, 0, StatementUpdate.EMPTY, LABELS, TermUpdate.EMPTY, Collections.emptyMap()).isEmpty());
+		assertFalse(create(JOHN, 0, StatementUpdate.EMPTY, TermUpdate.EMPTY, DESCRIPTIONS, Collections.emptyMap())
+				.isEmpty());
+		assertFalse(create(JOHN, 0, StatementUpdate.EMPTY, TermUpdate.EMPTY, TermUpdate.EMPTY, ALIASES).isEmpty());
+	}
+
+	@Test
+	public void testEquality() {
+		TermedStatementDocumentUpdate update = create(JOHN, 0, STATEMENTS, LABELS, DESCRIPTIONS, ALIASES);
+		assertTrue(update.equals(update));
+		assertTrue(update.equals(create(JOHN, 0, STATEMENTS, LABELS, DESCRIPTIONS, ALIASES)));
+		assertFalse(update.equals(create(JOHN, 0, STATEMENTS, TermUpdate.EMPTY, DESCRIPTIONS, ALIASES)));
+		assertFalse(update.equals(create(JOHN, 0, STATEMENTS, LABELS, TermUpdate.EMPTY, ALIASES)));
+		assertFalse(update.equals(create(JOHN, 0, STATEMENTS, LABELS, DESCRIPTIONS, Collections.emptyMap())));
+	}
+
+	@Test
+	public void testHashCode() {
+		TermedStatementDocumentUpdate update1 = create(JOHN, 123, STATEMENTS, LABELS, DESCRIPTIONS, ALIASES);
+		TermedStatementDocumentUpdate update2 = create(JOHN, 123, STATEMENTS, LABELS, DESCRIPTIONS, ALIASES);
+		assertEquals(update1.hashCode(), update2.hashCode());
+	}
+
+}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermedDocumentUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermedDocumentUpdateImplTest.java
@@ -51,10 +51,11 @@ public class TermedDocumentUpdateImplTest {
 	private static final MonolingualTextValue SK = Datamodel.makeMonolingualTextValue("ahoj", "sk");
 	private static final TermUpdate LABELS = TermUpdateBuilder.create().remove("de").build();
 	static final TermUpdate DESCRIPTIONS = TermUpdateBuilder.create().remove("en").build();
+	static final AliasUpdate ALIAS = AliasUpdateBuilder.create().add(EN).build();
 	static final Map<String, AliasUpdate> ALIASES = new HashMap<>();
 
 	static {
-		ALIASES.put("en", AliasUpdateBuilder.create().add(EN).build());
+		ALIASES.put("en", ALIAS);
 	}
 
 	private static TermedStatementDocumentUpdate create(

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermedDocumentUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermedDocumentUpdateImplTest.java
@@ -35,12 +35,10 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.wikidata.wdtk.datamodel.helpers.AliasUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
-import org.wikidata.wdtk.datamodel.helpers.StatementUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;
 import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
-import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocumentUpdate;
@@ -48,8 +46,7 @@ import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocumentUpdate;
 public class TermedDocumentUpdateImplTest {
 
 	private static final ItemIdValue JOHN = StatementUpdateImplTest.JOHN;
-	private static final Statement JOHN_HAS_BROWN_HAIR = StatementUpdateImplTest.JOHN_HAS_BROWN_HAIR;
-	private static final StatementUpdate STATEMENTS = StatementUpdateBuilder.create().add(JOHN_HAS_BROWN_HAIR).build();
+	private static final StatementUpdate STATEMENTS = LabeledDocumentUpdateImplTest.STATEMENTS;
 	private static final MonolingualTextValue EN = Datamodel.makeMonolingualTextValue("hello", "en");
 	private static final MonolingualTextValue SK = Datamodel.makeMonolingualTextValue("ahoj", "sk");
 	private static final TermUpdate LABELS = TermUpdateBuilder.create().remove("de").build();

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermedDocumentUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermedDocumentUpdateImplTest.java
@@ -50,8 +50,8 @@ public class TermedDocumentUpdateImplTest {
 	private static final MonolingualTextValue EN = Datamodel.makeMonolingualTextValue("hello", "en");
 	private static final MonolingualTextValue SK = Datamodel.makeMonolingualTextValue("ahoj", "sk");
 	private static final TermUpdate LABELS = TermUpdateBuilder.create().remove("de").build();
-	private static final TermUpdate DESCRIPTIONS = TermUpdateBuilder.create().remove("en").build();
-	private static final Map<String, AliasUpdate> ALIASES = new HashMap<>();
+	static final TermUpdate DESCRIPTIONS = TermUpdateBuilder.create().remove("en").build();
+	static final Map<String, AliasUpdate> ALIASES = new HashMap<>();
 
 	static {
 		ALIASES.put("en", AliasUpdateBuilder.create().add(EN).build());

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueTest.java
@@ -21,6 +21,7 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -114,4 +115,10 @@ public class UnsupportedEntityIdValueTest {
 		assertEquals("shiny", secondValue.getEntityTypeJsonString());
 		assertNull(noType.getEntityTypeJsonString());
 	}
+
+	@Test
+	public void testIsPlaceholder() {
+		assertFalse(firstValue.isPlaceholder());
+	}
+
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/interfaces/NullEntityIdsTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/interfaces/NullEntityIdsTest.java
@@ -80,12 +80,19 @@ public class NullEntityIdsTest {
 		TestValueVisitor tvv = new TestValueVisitor();
 		assertEquals("P0", PropertyIdValue.NULL.accept(tvv));
 		assertEquals("P0", PropertyIdValue.NULL.getId());
-		assertEquals("http://localhost/entity/",
-				PropertyIdValue.NULL.getSiteIri());
-		assertEquals(EntityIdValue.ET_PROPERTY,
-				PropertyIdValue.NULL.getEntityType());
-		assertEquals("http://localhost/entity/P0",
-				PropertyIdValue.NULL.getIri());
+		assertEquals("http://localhost/entity/", PropertyIdValue.NULL.getSiteIri());
+		assertEquals(EntityIdValue.ET_PROPERTY, PropertyIdValue.NULL.getEntityType());
+		assertEquals("http://localhost/entity/P0", PropertyIdValue.NULL.getIri());
+	}
+
+	@Test
+	public void testNullMediaInfoId() {
+		TestValueVisitor tvv = new TestValueVisitor();
+		assertEquals("M0", MediaInfoIdValue.NULL.accept(tvv));
+		assertEquals("M0", MediaInfoIdValue.NULL.getId());
+		assertEquals("http://localhost/entity/", MediaInfoIdValue.NULL.getSiteIri());
+		assertEquals(EntityIdValue.ET_MEDIA_INFO, MediaInfoIdValue.NULL.getEntityType());
+		assertEquals("http://localhost/entity/M0", MediaInfoIdValue.NULL.getIri());
 	}
 
 	@Test
@@ -96,6 +103,26 @@ public class NullEntityIdsTest {
 		assertEquals("http://localhost/entity/", LexemeIdValue.NULL.getSiteIri());
 		assertEquals(EntityIdValue.ET_LEXEME, LexemeIdValue.NULL.getEntityType());
 		assertEquals("http://localhost/entity/L0", LexemeIdValue.NULL.getIri());
+	}
+
+	@Test
+	public void testNullSenseId() {
+		TestValueVisitor tvv = new TestValueVisitor();
+		assertEquals("L0-S0", SenseIdValue.NULL.accept(tvv));
+		assertEquals("L0-S0", SenseIdValue.NULL.getId());
+		assertEquals("http://localhost/entity/", SenseIdValue.NULL.getSiteIri());
+		assertEquals(EntityIdValue.ET_SENSE, SenseIdValue.NULL.getEntityType());
+		assertEquals("http://localhost/entity/L0-S0", SenseIdValue.NULL.getIri());
+	}
+
+	@Test
+	public void testNullFormId() {
+		TestValueVisitor tvv = new TestValueVisitor();
+		assertEquals("L0-F0", FormIdValue.NULL.accept(tvv));
+		assertEquals("L0-F0", FormIdValue.NULL.getId());
+		assertEquals("http://localhost/entity/", FormIdValue.NULL.getSiteIri());
+		assertEquals(EntityIdValue.ET_FORM, FormIdValue.NULL.getEntityType());
+		assertEquals("http://localhost/entity/L0-F0", FormIdValue.NULL.getIri());
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/interfaces/NullEntityIdsTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/interfaces/NullEntityIdsTest.java
@@ -21,6 +21,7 @@
 package org.wikidata.wdtk.datamodel.interfaces;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -73,6 +74,7 @@ public class NullEntityIdsTest {
 		assertEquals("http://localhost/entity/", ItemIdValue.NULL.getSiteIri());
 		assertEquals(EntityIdValue.ET_ITEM, ItemIdValue.NULL.getEntityType());
 		assertEquals("http://localhost/entity/Q0", ItemIdValue.NULL.getIri());
+		assertTrue(ItemIdValue.NULL.isPlaceholder());
 	}
 
 	@Test
@@ -83,6 +85,7 @@ public class NullEntityIdsTest {
 		assertEquals("http://localhost/entity/", PropertyIdValue.NULL.getSiteIri());
 		assertEquals(EntityIdValue.ET_PROPERTY, PropertyIdValue.NULL.getEntityType());
 		assertEquals("http://localhost/entity/P0", PropertyIdValue.NULL.getIri());
+		assertTrue(PropertyIdValue.NULL.isPlaceholder());
 	}
 
 	@Test
@@ -93,6 +96,7 @@ public class NullEntityIdsTest {
 		assertEquals("http://localhost/entity/", MediaInfoIdValue.NULL.getSiteIri());
 		assertEquals(EntityIdValue.ET_MEDIA_INFO, MediaInfoIdValue.NULL.getEntityType());
 		assertEquals("http://localhost/entity/M0", MediaInfoIdValue.NULL.getIri());
+		assertTrue(MediaInfoIdValue.NULL.isPlaceholder());
 	}
 
 	@Test
@@ -103,6 +107,7 @@ public class NullEntityIdsTest {
 		assertEquals("http://localhost/entity/", LexemeIdValue.NULL.getSiteIri());
 		assertEquals(EntityIdValue.ET_LEXEME, LexemeIdValue.NULL.getEntityType());
 		assertEquals("http://localhost/entity/L0", LexemeIdValue.NULL.getIri());
+		assertTrue(LexemeIdValue.NULL.isPlaceholder());
 	}
 
 	@Test
@@ -113,6 +118,7 @@ public class NullEntityIdsTest {
 		assertEquals("http://localhost/entity/", SenseIdValue.NULL.getSiteIri());
 		assertEquals(EntityIdValue.ET_SENSE, SenseIdValue.NULL.getEntityType());
 		assertEquals("http://localhost/entity/L0-S0", SenseIdValue.NULL.getIri());
+		assertTrue(SenseIdValue.NULL.isPlaceholder());
 	}
 
 	@Test
@@ -123,6 +129,7 @@ public class NullEntityIdsTest {
 		assertEquals("http://localhost/entity/", FormIdValue.NULL.getSiteIri());
 		assertEquals(EntityIdValue.ET_FORM, FormIdValue.NULL.getEntityType());
 		assertEquals("http://localhost/entity/L0-F0", FormIdValue.NULL.getIri());
+		assertTrue(FormIdValue.NULL.isPlaceholder());
 	}
 
 }

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/StatementUpdate.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/StatementUpdate.java
@@ -57,7 +57,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
- * @deprecated Use {@link WikibaseDataEditor#editStatementDocument(StatementDocumentUpdate, boolean, String, List)} instead.
+ * @deprecated Use {@link WikibaseDataEditor#editEntityDocument(StatementDocumentUpdate, boolean, String, List)} instead.
  * Class to plan a statement update operation.
  *
  * @author Markus Kroetzsch

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/StatementUpdate.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/StatementUpdate.java
@@ -17,7 +17,6 @@
  * limitations under the License.
  * #L%
  */
-
 package org.wikidata.wdtk.wikibaseapi;
 
 import java.io.IOException;
@@ -36,13 +35,13 @@ import org.wikidata.wdtk.datamodel.helpers.JsonSerializer;
 import org.wikidata.wdtk.datamodel.implementation.StatementImpl;
 import org.wikidata.wdtk.datamodel.interfaces.Claim;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.EntityUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.Reference;
 import org.wikidata.wdtk.datamodel.interfaces.Snak;
 import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementDocument;
-import org.wikidata.wdtk.datamodel.interfaces.StatementDocumentUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
 import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
 import org.wikidata.wdtk.datamodel.interfaces.Value;
@@ -57,7 +56,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
- * @deprecated Use {@link WikibaseDataEditor#editEntityDocument(StatementDocumentUpdate, boolean, String, List)} instead.
+ * @deprecated Use {@link WikibaseDataEditor#editEntityDocument(EntityUpdate, boolean, String, List)} instead.
  * Class to plan a statement update operation.
  *
  * @author Markus Kroetzsch

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdate.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdate.java
@@ -39,7 +39,7 @@ import java.io.IOException;
 import java.util.*;
 
 /**
- * @deprecated Use {@link WikibaseDataEditor#editTermedStatementDocument(TermedStatementDocumentUpdate, boolean, String, List)} instead.
+ * @deprecated Use {@link WikibaseDataEditor#editEntityDocument(TermedStatementDocumentUpdate, boolean, String, List)} instead.
  * This class extends StatementUpdate to support update to terms (labels,
  * descriptions and aliases).
  * 

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdate.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdate.java
@@ -1,5 +1,3 @@
-package org.wikidata.wdtk.wikibaseapi;
-
 /*
  * #%L
  * Wikidata Toolkit Wikibase API
@@ -19,27 +17,35 @@ package org.wikidata.wdtk.wikibaseapi;
  * limitations under the License.
  * #L%
  */
+package org.wikidata.wdtk.wikibaseapi;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.wikidata.wdtk.datamodel.implementation.TermImpl;
+import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
+import org.wikidata.wdtk.datamodel.interfaces.EntityUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
+import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocument;
+import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.wikidata.wdtk.datamodel.implementation.TermImpl;
-import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
-import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
-import org.wikidata.wdtk.datamodel.interfaces.Statement;
-import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocument;
-import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocumentUpdate;
-import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
-
-import java.io.IOException;
-import java.util.*;
 
 /**
- * @deprecated Use {@link WikibaseDataEditor#editEntityDocument(TermedStatementDocumentUpdate, boolean, String, List)} instead.
+ * @deprecated Use {@link WikibaseDataEditor#editEntityDocument(EntityUpdate, boolean, String, List)} instead.
  * This class extends StatementUpdate to support update to terms (labels,
  * descriptions and aliases).
  * 

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
@@ -29,20 +29,15 @@ import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.EntityUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.ItemUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.LexemeDocument;
 import org.wikidata.wdtk.datamodel.interfaces.LexemeIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoDocument;
-import org.wikidata.wdtk.datamodel.interfaces.MediaInfoUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementDocument;
-import org.wikidata.wdtk.datamodel.interfaces.StatementDocumentUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocument;
-import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocumentUpdate;
 import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
 
 /**
@@ -390,7 +385,7 @@ public class WikibaseDataEditor {
 	}
 
 	/**
-	 * @deprecated Use {@link #editItemDocument(ItemUpdate, boolean, String, List)} instead.
+	 * @deprecated Use {@link #editEntityDocument(EntityUpdate, boolean, String, List)} instead.
 	 * Writes the data for the given item document with the summary message as
 	 * given. Optionally, the existing data is cleared (deleted).
 	 * <p>
@@ -479,7 +474,7 @@ public class WikibaseDataEditor {
 	}
 
 	/**
-	 * @deprecated Use {@link #editPropertyDocument(PropertyUpdate, boolean, String, List)} instead.
+	 * @deprecated Use {@link #editEntityDocument(EntityUpdate, boolean, String, List)} instead.
 	 * Writes the data for the given property document with the summary message
 	 * as given. Optionally, the existing data is cleared (deleted).
 	 * <p>
@@ -533,7 +528,7 @@ public class WikibaseDataEditor {
 	}
 
 	/**
-	 * @deprecated Use {@link #editMediaInfoDocument(MediaInfoUpdate, boolean, String, List)} instead.
+	 * @deprecated Use {@link #editEntityDocument(EntityUpdate, boolean, String, List)} instead.
 	 * Writes the data for the given media info document with the summary message
 	 * as given. Optionally, the existing data is cleared (deleted).
 	 * It creates the media info if needed.
@@ -724,7 +719,7 @@ public class WikibaseDataEditor {
 	}
 
 	/**
-	 * @deprecated {@link #editStatementDocument(StatementDocumentUpdate, boolean, String, List)} instead.
+	 * @deprecated Use {@link #editEntityDocument(EntityUpdate, boolean, String, List)} instead.
 	 * Updates statements of the given document. The document should be the
 	 * current revision of the data that is to be updated. The updates are
 	 * computed with respect to the data found in the document, making sure that
@@ -783,7 +778,7 @@ public class WikibaseDataEditor {
 	}
 	
 	/**
-	 * @deprecated Use {@link #editTermedStatementDocument(TermedStatementDocumentUpdate, boolean, String, List)} instead.
+	 * @deprecated Use {@link #editEntityDocument(EntityUpdate, boolean, String, List)} instead.
 	 * Updates the terms and statements of the current document.
 	 * The updates are computed with respect to the current data in the document,
 	 * making sure that no redundant deletions or duplicate insertions

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
@@ -1,10 +1,3 @@
-package org.wikidata.wdtk.wikibaseapi;
-
-import java.io.IOException;
-import java.util.List;
-
-import org.wikidata.wdtk.datamodel.helpers.EntityUpdateBuilder;
-
 /*
  * #%L
  * Wikidata Toolkit Wikibase API
@@ -24,34 +17,30 @@ import org.wikidata.wdtk.datamodel.helpers.EntityUpdateBuilder;
  * limitations under the License.
  * #L%
  */
+package org.wikidata.wdtk.wikibaseapi;
 
+import java.io.IOException;
+import java.util.List;
+
+import org.wikidata.wdtk.datamodel.helpers.EntityUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.JsonSerializer;
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.EntityUpdate;
-import org.wikidata.wdtk.datamodel.interfaces.FormUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ItemUpdate;
-import org.wikidata.wdtk.datamodel.interfaces.LabeledDocument;
-import org.wikidata.wdtk.datamodel.interfaces.LabeledDocumentUpdate;
-import org.wikidata.wdtk.datamodel.interfaces.LabeledStatementDocument;
-import org.wikidata.wdtk.datamodel.interfaces.LabeledStatementDocumentUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.LexemeDocument;
 import org.wikidata.wdtk.datamodel.interfaces.LexemeIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.LexemeUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoDocument;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyUpdate;
-import org.wikidata.wdtk.datamodel.interfaces.SenseUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementDocument;
 import org.wikidata.wdtk.datamodel.interfaces.StatementDocumentUpdate;
-import org.wikidata.wdtk.datamodel.interfaces.TermedDocument;
-import org.wikidata.wdtk.datamodel.interfaces.TermedDocumentUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocument;
 import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocumentUpdate;
 import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
@@ -490,40 +479,6 @@ public class WikibaseDataEditor {
 	}
 
 	/**
-	 * Updates item entity. ID of the entity to update is taken from the update
-	 * object. Its site IRI is ignored.
-	 * <p>
-	 * If the update object references base revision of the document, its revision
-	 * ID is used to specify the base revision in the API request, enabling the API
-	 * to detect edit conflicts. It is strongly recommended to specify base revision
-	 * document in the update object.
-	 * <p>
-	 * Summary message will be prepended by an automatically generated comment. The
-	 * length limit of the autocomment together with the summary is 260 characters.
-	 * Everything above that limit will be cut off.
-	 *
-	 * @param update
-	 *            collection of changes to be written
-	 * @param clear
-	 *            if set to {@code true}, existing entity data will be removed and
-	 *            the update will be applied to empty entity
-	 * @param summary
-	 *            summary for the edit
-	 * @param tags
-	 *            string identifiers of the tags to apply to the edit, {@code null}
-	 *            or empty for no tags
-	 * @throws IOException
-	 *             if there was an IO problem, such as missing network connection
-	 * @throws MediaWikiApiErrorException
-	 *             if MediaWiki API returned an error response
-	 */
-	public void editItemDocument(
-			ItemUpdate update, boolean clear, String summary, List<String> tags)
-			throws IOException, MediaWikiApiErrorException {
-		editEntityDocument(update, clear, summary, tags);
-	}
-
-	/**
 	 * @deprecated Use {@link #editPropertyDocument(PropertyUpdate, boolean, String, List)} instead.
 	 * Writes the data for the given property document with the summary message
 	 * as given. Optionally, the existing data is cleared (deleted).
@@ -578,40 +533,6 @@ public class WikibaseDataEditor {
 	}
 
 	/**
-	 * Updates property entity. ID of the entity to update is taken from the
-	 * update object. Its site IRI is ignored.
-	 * <p>
-	 * If the update object references base revision of the document, its revision
-	 * ID is used to specify the base revision in the API request, enabling the API
-	 * to detect edit conflicts. It is strongly recommended to specify base revision
-	 * document in the update object.
-	 * <p>
-	 * Summary message will be prepended by an automatically generated comment. The
-	 * length limit of the autocomment together with the summary is 260 characters.
-	 * Everything above that limit will be cut off.
-	 *
-	 * @param update
-	 *            collection of changes to be written
-	 * @param clear
-	 *            if set to {@code true}, existing entity data will be removed and
-	 *            the update will be applied to empty entity
-	 * @param summary
-	 *            summary for the edit
-	 * @param tags
-	 *            string identifiers of the tags to apply to the edit, {@code null}
-	 *            or empty for no tags
-	 * @throws IOException
-	 *             if there was an IO problem, such as missing network connection
-	 * @throws MediaWikiApiErrorException
-	 *             if MediaWiki API returned an error response
-	 */
-	public void editPropertyDocument(
-			PropertyUpdate update, boolean clear, String summary, List<String> tags)
-			throws IOException, MediaWikiApiErrorException {
-		editEntityDocument(update, clear, summary, tags);
-	}
-
-	/**
 	 * @deprecated Use {@link #editMediaInfoDocument(MediaInfoUpdate, boolean, String, List)} instead.
 	 * Writes the data for the given media info document with the summary message
 	 * as given. Optionally, the existing data is cleared (deleted).
@@ -661,312 +582,6 @@ public class WikibaseDataEditor {
 				mediaInfoDocument.getEntityId().getId(), null, null, null,
 				data, clear, this.editAsBot, mediaInfoDocument.getRevisionId(),
 				summary, tags);
-	}
-
-	/**
-	 * Updates media entity. ID of the entity to update is taken from the update
-	 * object. Its site IRI is ignored.
-	 * <p>
-	 * If the update object references base revision of the document, its revision
-	 * ID is used to specify the base revision in the API request, enabling the API
-	 * to detect edit conflicts. It is strongly recommended to specify base revision
-	 * document in the update object.
-	 * <p>
-	 * Summary message will be prepended by an automatically generated comment. The
-	 * length limit of the autocomment together with the summary is 260 characters.
-	 * Everything above that limit will be cut off.
-	 *
-	 * @param update
-	 *            collection of changes to be written
-	 * @param clear
-	 *            if set to {@code true}, existing entity data will be removed and
-	 *            the update will be applied to empty entity
-	 * @param summary
-	 *            summary for the edit
-	 * @param tags
-	 *            string identifiers of the tags to apply to the edit, {@code null}
-	 *            or empty for no tags
-	 * @throws IOException
-	 *             if there was an IO problem, such as missing network connection
-	 * @throws MediaWikiApiErrorException
-	 *             if MediaWiki API returned an error response
-	 */
-	public void editMediaInfoDocument(
-			MediaInfoUpdate update, boolean clear, String summary, List<String> tags)
-			throws IOException, MediaWikiApiErrorException {
-		editEntityDocument(update, clear, summary, tags);
-	}
-
-	/**
-	 * Updates sense entity. ID of the entity to update is taken from the update
-	 * object. Its site IRI is ignored.
-	 * <p>
-	 * If the update object references base revision of the document, its revision
-	 * ID is used to specify the base revision in the API request, enabling the API
-	 * to detect edit conflicts. It is strongly recommended to specify base revision
-	 * document in the update object.
-	 * <p>
-	 * Summary message will be prepended by an automatically generated comment. The
-	 * length limit of the autocomment together with the summary is 260 characters.
-	 * Everything above that limit will be cut off.
-	 *
-	 * @param update
-	 *            collection of changes to be written
-	 * @param clear
-	 *            if set to {@code true}, existing entity data will be removed and
-	 *            the update will be applied to empty entity
-	 * @param summary
-	 *            summary for the edit
-	 * @param tags
-	 *            string identifiers of the tags to apply to the edit, {@code null}
-	 *            or empty for no tags
-	 * @throws IOException
-	 *             if there was an IO problem, such as missing network connection
-	 * @throws MediaWikiApiErrorException
-	 *             if MediaWiki API returned an error response
-	 */
-	public void editSenseDocument(
-			SenseUpdate update, boolean clear, String summary, List<String> tags)
-			throws IOException, MediaWikiApiErrorException {
-		editEntityDocument(update, clear, summary, tags);
-	}
-
-	/**
-	 * Updates form entity. ID of the entity to update is taken from the update
-	 * object. Its site IRI is ignored.
-	 * <p>
-	 * If the update object references base revision of the document, its revision
-	 * ID is used to specify the base revision in the API request, enabling the API
-	 * to detect edit conflicts. It is strongly recommended to specify base revision
-	 * document in the update object.
-	 * <p>
-	 * Summary message will be prepended by an automatically generated comment. The
-	 * length limit of the autocomment together with the summary is 260 characters.
-	 * Everything above that limit will be cut off.
-	 *
-	 * @param update
-	 *            collection of changes to be written
-	 * @param clear
-	 *            if set to {@code true}, existing entity data will be removed and
-	 *            the update will be applied to empty entity
-	 * @param summary
-	 *            summary for the edit
-	 * @param tags
-	 *            string identifiers of the tags to apply to the edit, {@code null}
-	 *            or empty for no tags
-	 * @throws IOException
-	 *             if there was an IO problem, such as missing network connection
-	 * @throws MediaWikiApiErrorException
-	 *             if MediaWiki API returned an error response
-	 */
-	public void editFormDocument(
-			FormUpdate update, boolean clear, String summary, List<String> tags)
-			throws IOException, MediaWikiApiErrorException {
-		editEntityDocument(update, clear, summary, tags);
-	}
-
-	/**
-	 * Updates lexeme entity. ID of the entity to update is taken from the update
-	 * object. Its site IRI is ignored.
-	 * <p>
-	 * If the update object references base revision of the document, its revision
-	 * ID is used to specify the base revision in the API request, enabling the API
-	 * to detect edit conflicts. It is strongly recommended to specify base revision
-	 * document in the update object.
-	 * <p>
-	 * Summary message will be prepended by an automatically generated comment. The
-	 * length limit of the autocomment together with the summary is 260 characters.
-	 * Everything above that limit will be cut off.
-	 *
-	 * @param update
-	 *            collection of changes to be written
-	 * @param clear
-	 *            if set to {@code true}, existing entity data will be removed and
-	 *            the update will be applied to empty entity
-	 * @param summary
-	 *            summary for the edit
-	 * @param tags
-	 *            string identifiers of the tags to apply to the edit, {@code null}
-	 *            or empty for no tags
-	 * @throws IOException
-	 *             if there was an IO problem, such as missing network connection
-	 * @throws MediaWikiApiErrorException
-	 *             if MediaWiki API returned an error response
-	 */
-	public void editLexemeDocument(
-			LexemeUpdate update, boolean clear, String summary, List<String> tags)
-			throws IOException, MediaWikiApiErrorException {
-		editEntityDocument(update, clear, summary, tags);
-	}
-
-	/**
-	 * Updates {@link StatementDocument} entity. ID of the entity to update is taken
-	 * from the update object. Its site IRI is ignored.
-	 * <p>
-	 * If the update object references base revision of the document, its revision
-	 * ID is used to specify the base revision in the API request, enabling the API
-	 * to detect edit conflicts. It is strongly recommended to specify base revision
-	 * document in the update object.
-	 * <p>
-	 * Summary message will be prepended by an automatically generated comment. The
-	 * length limit of the autocomment together with the summary is 260 characters.
-	 * Everything above that limit will be cut off.
-	 *
-	 * @param update
-	 *            collection of changes to be written
-	 * @param clear
-	 *            if set to {@code true}, existing entity data will be removed and
-	 *            the update will be applied to empty entity
-	 * @param summary
-	 *            summary for the edit
-	 * @param tags
-	 *            string identifiers of the tags to apply to the edit, {@code null}
-	 *            or empty for no tags
-	 * @throws IOException
-	 *             if there was an IO problem, such as missing network connection
-	 * @throws MediaWikiApiErrorException
-	 *             if MediaWiki API returned an error response
-	 */
-	public void editStatementDocument(
-			StatementDocumentUpdate update, boolean clear, String summary, List<String> tags)
-			throws IOException, MediaWikiApiErrorException {
-		editEntityDocument(update, clear, summary, tags);
-	}
-
-	/**
-	 * Updates {@link LabeledDocument} entity. ID of the entity to update is taken
-	 * from the update object. Its site IRI is ignored.
-	 * <p>
-	 * If the update object references base revision of the document, its revision
-	 * ID is used to specify the base revision in the API request, enabling the API
-	 * to detect edit conflicts. It is strongly recommended to specify base revision
-	 * document in the update object.
-	 * <p>
-	 * Summary message will be prepended by an automatically generated comment. The
-	 * length limit of the autocomment together with the summary is 260 characters.
-	 * Everything above that limit will be cut off.
-	 *
-	 * @param update
-	 *            collection of changes to be written
-	 * @param clear
-	 *            if set to {@code true}, existing entity data will be removed and
-	 *            the update will be applied to empty entity
-	 * @param summary
-	 *            summary for the edit
-	 * @param tags
-	 *            string identifiers of the tags to apply to the edit, {@code null}
-	 *            or empty for no tags
-	 * @throws IOException
-	 *             if there was an IO problem, such as missing network connection
-	 * @throws MediaWikiApiErrorException
-	 *             if MediaWiki API returned an error response
-	 */
-	public void editLabeledDocument(
-			LabeledDocumentUpdate update, boolean clear, String summary, List<String> tags)
-			throws IOException, MediaWikiApiErrorException {
-		editEntityDocument(update, clear, summary, tags);
-	}
-
-	/**
-	 * Updates {@link LabeledStatementDocument} entity. ID of the entity to update
-	 * is taken from the update object. Its site IRI is ignored.
-	 * <p>
-	 * If the update object references base revision of the document, its revision
-	 * ID is used to specify the base revision in the API request, enabling the API
-	 * to detect edit conflicts. It is strongly recommended to specify base revision
-	 * document in the update object.
-	 * <p>
-	 * Summary message will be prepended by an automatically generated comment. The
-	 * length limit of the autocomment together with the summary is 260 characters.
-	 * Everything above that limit will be cut off.
-	 *
-	 * @param update
-	 *            collection of changes to be written
-	 * @param clear
-	 *            if set to {@code true}, existing entity data will be removed and
-	 *            the update will be applied to empty entity
-	 * @param summary
-	 *            summary for the edit
-	 * @param tags
-	 *            string identifiers of the tags to apply to the edit, {@code null}
-	 *            or empty for no tags
-	 * @throws IOException
-	 *             if there was an IO problem, such as missing network connection
-	 * @throws MediaWikiApiErrorException
-	 *             if MediaWiki API returned an error response
-	 */
-	public void editLabeledStatementDocument(
-			LabeledStatementDocumentUpdate update, boolean clear, String summary, List<String> tags)
-			throws IOException, MediaWikiApiErrorException {
-		editEntityDocument(update, clear, summary, tags);
-	}
-
-	/**
-	 * Updates {@link TermedDocument} entity. ID of the entity to update is taken
-	 * from the update object. Its site IRI is ignored.
-	 * <p>
-	 * If the update object references base revision of the document, its revision
-	 * ID is used to specify the base revision in the API request, enabling the API
-	 * to detect edit conflicts. It is strongly recommended to specify base revision
-	 * document in the update object.
-	 * <p>
-	 * Summary message will be prepended by an automatically generated comment. The
-	 * length limit of the autocomment together with the summary is 260 characters.
-	 * Everything above that limit will be cut off.
-	 *
-	 * @param update
-	 *            collection of changes to be written
-	 * @param clear
-	 *            if set to {@code true}, existing entity data will be removed and
-	 *            the update will be applied to empty entity
-	 * @param summary
-	 *            summary for the edit
-	 * @param tags
-	 *            string identifiers of the tags to apply to the edit, {@code null}
-	 *            or empty for no tags
-	 * @throws IOException
-	 *             if there was an IO problem, such as missing network connection
-	 * @throws MediaWikiApiErrorException
-	 *             if MediaWiki API returned an error response
-	 */
-	public void editTermedDocument(
-			TermedDocumentUpdate update, boolean clear, String summary, List<String> tags)
-			throws IOException, MediaWikiApiErrorException {
-		editEntityDocument(update, clear, summary, tags);
-	}
-
-	/**
-	 * Updates {@link TermedStatementDocument} entity. ID of the entity to update is
-	 * taken from the update object. Its site IRI is ignored.
-	 * <p>
-	 * If the update object references base revision of the document, its revision
-	 * ID is used to specify the base revision in the API request, enabling the API
-	 * to detect edit conflicts. It is strongly recommended to specify base revision
-	 * document in the update object.
-	 * <p>
-	 * Summary message will be prepended by an automatically generated comment. The
-	 * length limit of the autocomment together with the summary is 260 characters.
-	 * Everything above that limit will be cut off.
-	 *
-	 * @param update
-	 *            collection of changes to be written
-	 * @param clear
-	 *            if set to {@code true}, existing entity data will be removed and
-	 *            the update will be applied to empty entity
-	 * @param summary
-	 *            summary for the edit
-	 * @param tags
-	 *            string identifiers of the tags to apply to the edit, {@code null}
-	 *            or empty for no tags
-	 * @throws IOException
-	 *             if there was an IO problem, such as missing network connection
-	 * @throws MediaWikiApiErrorException
-	 *             if MediaWiki API returned an error response
-	 */
-	public void editTermedStatementDocument(
-			TermedStatementDocumentUpdate update, boolean clear, String summary, List<String> tags)
-			throws IOException, MediaWikiApiErrorException {
-		editEntityDocument(update, clear, summary, tags);
 	}
 
 	/**

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
@@ -135,6 +135,13 @@ public class WikibaseDataEditor {
 		this.guidGenerator = generator;
 	}
 
+	WikibaseDataEditor(WbEditingAction action, WikibaseDataFetcher fetcher, String siteUri, GuidGenerator generator) {
+		this.wbEditingAction = action;
+		this.wikibaseDataFetcher = fetcher;
+		this.siteIri = siteUri;
+		this.guidGenerator = generator;
+	}
+
 	/**
 	 * Returns true if edits should be flagged as bot edits. See
 	 * {@link #setEditAsBot(boolean)} for details.
@@ -496,7 +503,7 @@ public class WikibaseDataEditor {
 					Statement statement = typed.getStatements().getAdded().stream().findFirst().get();
 					builder.updateStatements(StatementUpdateBuilder.create().add(statement).build());
 					if (builder.build().equals(update)) {
-						String statementId = new RandomGuidGenerator().freshStatementId(typed.getEntityId().getId());
+						String statementId = guidGenerator.freshStatementId(typed.getEntityId().getId());
 						Statement prepared = statement.withStatementId(statementId);
 						wbEditingAction.wbSetClaim(JsonSerializer.getJsonString(prepared),
 								editAsBot, revisionId, summary, tags);

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
@@ -489,14 +489,12 @@ public class WikibaseDataEditor {
 				return;
 			if (update instanceof StatementDocumentUpdate) {
 				StatementDocumentUpdate typed = (StatementDocumentUpdate) update;
-				if (typed.getStatements().getAddedStatements().size() == 1) {
+				if (typed.getStatements().getAdded().size() == 1) {
 					StatementDocumentUpdateBuilder builder = typed.getBaseRevision() != null
 							? StatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
 							: StatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
-					Statement statement = typed.getStatements().getAddedStatements().stream().findFirst().get();
-					builder.updateStatements(StatementUpdateBuilder.create()
-							.addStatement(statement)
-							.build());
+					Statement statement = typed.getStatements().getAdded().stream().findFirst().get();
+					builder.updateStatements(StatementUpdateBuilder.create().add(statement).build());
 					if (builder.build().equals(update)) {
 						String statementId = new RandomGuidGenerator().freshStatementId(typed.getEntityId().getId());
 						Statement prepared = statement.withStatementId(statementId);
@@ -505,30 +503,27 @@ public class WikibaseDataEditor {
 						return;
 					}
 				}
-				if (typed.getStatements().getReplacedStatements().size() == 1) {
+				if (typed.getStatements().getReplaced().size() == 1) {
 					StatementDocumentUpdateBuilder builder = typed.getBaseRevision() != null
 							? StatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
 							: StatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
-					Statement statement = typed.getStatements().getReplacedStatements()
-							.values().stream().findFirst().get();
-					builder.updateStatements(StatementUpdateBuilder.create()
-							.replaceStatement(statement)
-							.build());
+					Statement statement = typed.getStatements().getReplaced().values().stream().findFirst().get();
+					builder.updateStatements(StatementUpdateBuilder.create().replace(statement).build());
 					if (builder.build().equals(update)) {
 						wbEditingAction.wbSetClaim(JsonSerializer.getJsonString(statement),
 								editAsBot, revisionId, summary, tags);
 						return;
 					}
 				}
-				if (!typed.getStatements().getRemovedStatements().isEmpty()
-						&& typed.getStatements().getRemovedStatements().size() <= 50) {
+				if (!typed.getStatements().getRemoved().isEmpty()
+						&& typed.getStatements().getRemoved().size() <= 50) {
 					StatementDocumentUpdateBuilder builder = typed.getBaseRevision() != null
 							? StatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
 							: StatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
-					List<String> statementIds = new ArrayList<>(typed.getStatements().getRemovedStatements());
+					List<String> statementIds = new ArrayList<>(typed.getStatements().getRemoved());
 					StatementUpdateBuilder statementBuilder = StatementUpdateBuilder.create();
 					for (String statementId : statementIds) {
-						statementBuilder.removeStatement(statementId);
+						statementBuilder.remove(statementId);
 					}
 					builder.updateStatements(statementBuilder.build());
 					if (builder.build().equals(update)) {
@@ -539,29 +534,24 @@ public class WikibaseDataEditor {
 			}
 			if (update instanceof LabeledStatementDocumentUpdate) {
 				LabeledStatementDocumentUpdate typed = (LabeledStatementDocumentUpdate) update;
-				if (typed.getLabels().getModifiedTerms().size() == 1) {
+				if (typed.getLabels().getModified().size() == 1) {
 					LabeledDocumentUpdateBuilder builder = typed.getBaseRevision() != null
 							? LabeledDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
 							: LabeledDocumentUpdateBuilder.forEntityId(typed.getEntityId());
-					MonolingualTextValue label = typed.getLabels().getModifiedTerms()
-							.values().stream().findFirst().get();
-					builder.updateLabels(TermUpdateBuilder.create()
-							.setTerm(label)
-							.build());
+					MonolingualTextValue label = typed.getLabels().getModified().values().stream().findFirst().get();
+					builder.updateLabels(TermUpdateBuilder.create().put(label).build());
 					if (builder.build().equals(update)) {
 						wbEditingAction.wbSetLabel(update.getEntityId().getId(), null, null, null,
 								label.getLanguageCode(), label.getText(), editAsBot, revisionId, summary, tags);
 						return;
 					}
 				}
-				if (typed.getLabels().getRemovedTerms().size() == 1) {
+				if (typed.getLabels().getRemoved().size() == 1) {
 					LabeledDocumentUpdateBuilder builder = typed.getBaseRevision() != null
 							? LabeledDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
 							: LabeledDocumentUpdateBuilder.forEntityId(typed.getEntityId());
-					String language = typed.getLabels().getRemovedTerms().stream().findFirst().get();
-					builder.updateLabels(TermUpdateBuilder.create()
-							.removeTerm(language)
-							.build());
+					String language = typed.getLabels().getRemoved().stream().findFirst().get();
+					builder.updateLabels(TermUpdateBuilder.create().remove(language).build());
 					if (builder.build().equals(update)) {
 						wbEditingAction.wbSetLabel(update.getEntityId().getId(), null, null, null,
 								language, null, editAsBot, revisionId, summary, tags);
@@ -571,15 +561,13 @@ public class WikibaseDataEditor {
 			}
 			if (update instanceof TermedStatementDocumentUpdate) {
 				TermedStatementDocumentUpdate typed = (TermedStatementDocumentUpdate) update;
-				if (typed.getDescriptions().getModifiedTerms().size() == 1) {
+				if (typed.getDescriptions().getModified().size() == 1) {
 					TermedDocumentUpdateBuilder builder = typed.getBaseRevision() != null
 							? TermedDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
 							: TermedDocumentUpdateBuilder.forEntityId(typed.getEntityId());
-					MonolingualTextValue description = typed.getDescriptions().getModifiedTerms()
+					MonolingualTextValue description = typed.getDescriptions().getModified()
 							.values().stream().findFirst().get();
-					builder.updateDescriptions(TermUpdateBuilder.create()
-							.setTerm(description)
-							.build());
+					builder.updateDescriptions(TermUpdateBuilder.create().put(description).build());
 					if (builder.build().equals(update)) {
 						wbEditingAction.wbSetDescription(update.getEntityId().getId(), null, null, null,
 								description.getLanguageCode(), description.getText(),
@@ -587,14 +575,12 @@ public class WikibaseDataEditor {
 						return;
 					}
 				}
-				if (typed.getDescriptions().getRemovedTerms().size() == 1) {
+				if (typed.getDescriptions().getRemoved().size() == 1) {
 					TermedDocumentUpdateBuilder builder = typed.getBaseRevision() != null
 							? TermedDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
 							: TermedDocumentUpdateBuilder.forEntityId(typed.getEntityId());
-					String language = typed.getDescriptions().getRemovedTerms().stream().findFirst().get();
-					builder.updateDescriptions(TermUpdateBuilder.create()
-							.removeTerm(language)
-							.build());
+					String language = typed.getDescriptions().getRemoved().stream().findFirst().get();
+					builder.updateDescriptions(TermUpdateBuilder.create().remove(language).build());
 					if (builder.build().equals(update)) {
 						wbEditingAction.wbSetDescription(update.getEntityId().getId(), null, null, null,
 								language, null, editAsBot, revisionId, summary, tags);
@@ -606,11 +592,11 @@ public class WikibaseDataEditor {
 							? TermedDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
 							: TermedDocumentUpdateBuilder.forEntityId(typed.getEntityId());
 					String language = typed.getAliases().keySet().stream().findFirst().get();
-					List<String> aliases = typed.getAliases().get(language).stream()
-							.map(v -> v.getText())
-							.collect(toList());
-					builder.setAliases(language, aliases);
+					builder.putAliases(language, typed.getAliases().get(language));
 					if (builder.build().equals(update)) {
+						List<String> aliases = typed.getAliases().get(language).stream()
+								.map(v -> v.getText())
+								.collect(toList());
 						if (typed.getBaseRevision() != null
 								&& typed.getBaseRevision().getAliases().containsKey(language)) {
 							List<String> original = typed.getBaseRevision().getAliases().get(language).stream()

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
@@ -33,6 +33,7 @@ import org.wikidata.wdtk.datamodel.helpers.StatementDocumentUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.StatementUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.TermedDocumentUpdateBuilder;
+import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.EntityUpdate;
@@ -584,35 +585,20 @@ public class WikibaseDataEditor {
 					TermedDocumentUpdateBuilder builder = TermedDocumentUpdateBuilder
 							.forBaseRevisionId(typed.getEntityId(), typed.getBaseRevisionId());
 					String language = typed.getAliases().keySet().stream().findFirst().get();
-					builder.putAliases(language, typed.getAliases().get(language));
+					AliasUpdate aliases = typed.getAliases().get(language);
+					builder.updateAliases(language, aliases);
 					if (builder.build().equals(update)) {
-						List<String> aliases = typed.getAliases().get(language).stream()
-								.map(v -> v.getText())
-								.collect(toList());
-						/*if (typed.getBaseRevision() != null
-								&& typed.getBaseRevision().getAliases().containsKey(language)) {
-							List<String> original = typed.getBaseRevision().getAliases().get(language).stream()
-									.map(v -> v.getText())
-									.collect(toList());
-							List<String> added = aliases.stream()
-									.filter(a -> !original.contains(a))
-									.collect(toList());
-							List<String> removed = original.stream()
-									.filter(a -> !aliases.contains(a))
-									.collect(toList());
-							List<String> simulated = new ArrayList<>(original);
-							for (String alias : removed) {
-								simulated.remove(alias);
-							}
-							simulated.addAll(added);
-							if (simulated.equals(aliases)) {
-								wbEditingAction.wbSetAliases(update.getEntityId().getId(), null, null, null,
-										language, added, removed, null, editAsBot, revisionId, summary, tags);
-								return;
-							}
-						}*/
+						List<String> added = !aliases.getAdded().isEmpty()
+								? aliases.getAdded().stream().map(a -> a.getText()).collect(toList())
+								: null;
+						List<String> removed = !aliases.getRemoved().isEmpty()
+								? aliases.getRemoved().stream().map(a -> a.getText()).collect(toList())
+								: null;
+						List<String> recreated = aliases.getRecreated()
+								.map(l -> l.stream().map(a -> a.getText()).collect(toList()))
+								.orElse(null);
 						wbEditingAction.wbSetAliases(update.getEntityId().getId(), null, null, null,
-								language, null, null, aliases, editAsBot, revisionId, summary, tags);
+								language, added, removed, recreated, editAsBot, revisionId, summary, tags);
 						return;
 					}
 				}

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
@@ -483,16 +483,15 @@ public class WikibaseDataEditor {
 	public void editEntityDocument(
 			EntityUpdate update, boolean clear, String summary, List<String> tags)
 			throws IOException, MediaWikiApiErrorException {
-		long revisionId = update.getBaseRevision() != null ? update.getBaseRevision().getRevisionId() : 0;
+		long revisionId = update.getBaseRevisionId();
 		if (!clear) {
 			if (update.isEmpty())
 				return;
 			if (update instanceof StatementDocumentUpdate) {
 				StatementDocumentUpdate typed = (StatementDocumentUpdate) update;
 				if (typed.getStatements().getAdded().size() == 1) {
-					StatementDocumentUpdateBuilder builder = typed.getBaseRevision() != null
-							? StatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
-							: StatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
+					StatementDocumentUpdateBuilder builder = StatementDocumentUpdateBuilder
+							.forBaseRevisionId(typed.getEntityId(), typed.getBaseRevisionId());
 					Statement statement = typed.getStatements().getAdded().stream().findFirst().get();
 					builder.updateStatements(StatementUpdateBuilder.create().add(statement).build());
 					if (builder.build().equals(update)) {
@@ -504,9 +503,8 @@ public class WikibaseDataEditor {
 					}
 				}
 				if (typed.getStatements().getReplaced().size() == 1) {
-					StatementDocumentUpdateBuilder builder = typed.getBaseRevision() != null
-							? StatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
-							: StatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
+					StatementDocumentUpdateBuilder builder = StatementDocumentUpdateBuilder
+							.forBaseRevisionId(typed.getEntityId(), typed.getBaseRevisionId());
 					Statement statement = typed.getStatements().getReplaced().values().stream().findFirst().get();
 					builder.updateStatements(StatementUpdateBuilder.create().replace(statement).build());
 					if (builder.build().equals(update)) {
@@ -517,9 +515,8 @@ public class WikibaseDataEditor {
 				}
 				if (!typed.getStatements().getRemoved().isEmpty()
 						&& typed.getStatements().getRemoved().size() <= 50) {
-					StatementDocumentUpdateBuilder builder = typed.getBaseRevision() != null
-							? StatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
-							: StatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
+					StatementDocumentUpdateBuilder builder = StatementDocumentUpdateBuilder
+							.forBaseRevisionId(typed.getEntityId(), typed.getBaseRevisionId());
 					List<String> statementIds = new ArrayList<>(typed.getStatements().getRemoved());
 					StatementUpdateBuilder statementBuilder = StatementUpdateBuilder.create();
 					for (String statementId : statementIds) {
@@ -535,9 +532,8 @@ public class WikibaseDataEditor {
 			if (update instanceof LabeledStatementDocumentUpdate) {
 				LabeledStatementDocumentUpdate typed = (LabeledStatementDocumentUpdate) update;
 				if (typed.getLabels().getModified().size() == 1) {
-					LabeledDocumentUpdateBuilder builder = typed.getBaseRevision() != null
-							? LabeledDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
-							: LabeledDocumentUpdateBuilder.forEntityId(typed.getEntityId());
+					LabeledDocumentUpdateBuilder builder = LabeledDocumentUpdateBuilder
+							.forBaseRevisionId(typed.getEntityId(), typed.getBaseRevisionId());
 					MonolingualTextValue label = typed.getLabels().getModified().values().stream().findFirst().get();
 					builder.updateLabels(TermUpdateBuilder.create().put(label).build());
 					if (builder.build().equals(update)) {
@@ -547,9 +543,8 @@ public class WikibaseDataEditor {
 					}
 				}
 				if (typed.getLabels().getRemoved().size() == 1) {
-					LabeledDocumentUpdateBuilder builder = typed.getBaseRevision() != null
-							? LabeledDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
-							: LabeledDocumentUpdateBuilder.forEntityId(typed.getEntityId());
+					LabeledDocumentUpdateBuilder builder = LabeledDocumentUpdateBuilder
+							.forBaseRevisionId(typed.getEntityId(), typed.getBaseRevisionId());
 					String language = typed.getLabels().getRemoved().stream().findFirst().get();
 					builder.updateLabels(TermUpdateBuilder.create().remove(language).build());
 					if (builder.build().equals(update)) {
@@ -562,9 +557,8 @@ public class WikibaseDataEditor {
 			if (update instanceof TermedStatementDocumentUpdate) {
 				TermedStatementDocumentUpdate typed = (TermedStatementDocumentUpdate) update;
 				if (typed.getDescriptions().getModified().size() == 1) {
-					TermedDocumentUpdateBuilder builder = typed.getBaseRevision() != null
-							? TermedDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
-							: TermedDocumentUpdateBuilder.forEntityId(typed.getEntityId());
+					TermedDocumentUpdateBuilder builder = TermedDocumentUpdateBuilder
+							.forBaseRevisionId(typed.getEntityId(), typed.getBaseRevisionId());
 					MonolingualTextValue description = typed.getDescriptions().getModified()
 							.values().stream().findFirst().get();
 					builder.updateDescriptions(TermUpdateBuilder.create().put(description).build());
@@ -576,9 +570,8 @@ public class WikibaseDataEditor {
 					}
 				}
 				if (typed.getDescriptions().getRemoved().size() == 1) {
-					TermedDocumentUpdateBuilder builder = typed.getBaseRevision() != null
-							? TermedDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
-							: TermedDocumentUpdateBuilder.forEntityId(typed.getEntityId());
+					TermedDocumentUpdateBuilder builder = TermedDocumentUpdateBuilder
+							.forBaseRevisionId(typed.getEntityId(), typed.getBaseRevisionId());
 					String language = typed.getDescriptions().getRemoved().stream().findFirst().get();
 					builder.updateDescriptions(TermUpdateBuilder.create().remove(language).build());
 					if (builder.build().equals(update)) {
@@ -588,16 +581,15 @@ public class WikibaseDataEditor {
 					}
 				}
 				if (typed.getAliases().size() == 1) {
-					TermedDocumentUpdateBuilder builder = typed.getBaseRevision() != null
-							? TermedDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
-							: TermedDocumentUpdateBuilder.forEntityId(typed.getEntityId());
+					TermedDocumentUpdateBuilder builder = TermedDocumentUpdateBuilder
+							.forBaseRevisionId(typed.getEntityId(), typed.getBaseRevisionId());
 					String language = typed.getAliases().keySet().stream().findFirst().get();
 					builder.putAliases(language, typed.getAliases().get(language));
 					if (builder.build().equals(update)) {
 						List<String> aliases = typed.getAliases().get(language).stream()
 								.map(v -> v.getText())
 								.collect(toList());
-						if (typed.getBaseRevision() != null
+						/*if (typed.getBaseRevision() != null
 								&& typed.getBaseRevision().getAliases().containsKey(language)) {
 							List<String> original = typed.getBaseRevision().getAliases().get(language).stream()
 									.map(v -> v.getText())
@@ -618,7 +610,7 @@ public class WikibaseDataEditor {
 										language, added, removed, null, editAsBot, revisionId, summary, tags);
 								return;
 							}
-						}
+						}*/
 						wbEditingAction.wbSetAliases(update.getEntityId().getId(), null, null, null,
 								language, null, null, aliases, editAsBot, revisionId, summary, tags);
 						return;
@@ -628,9 +620,8 @@ public class WikibaseDataEditor {
 			if (update instanceof LexemeUpdate) {
 				LexemeUpdate typed = (LexemeUpdate) update;
 				if (typed.getUpdatedSenses().size() == 1) {
-					LexemeUpdateBuilder builder = typed.getBaseRevision() != null
-							? LexemeUpdateBuilder.forBaseRevision(typed.getBaseRevision())
-							: LexemeUpdateBuilder.forEntityId(typed.getEntityId());
+					LexemeUpdateBuilder builder = LexemeUpdateBuilder
+							.forBaseRevisionId(typed.getEntityId(), typed.getBaseRevisionId());
 					SenseUpdate sense = typed.getUpdatedSenses().values().stream().findFirst().get();
 					builder.updateSense(sense);
 					if (builder.build().equals(update)) {
@@ -639,9 +630,8 @@ public class WikibaseDataEditor {
 					}
 				}
 				if (typed.getUpdatedForms().size() == 1) {
-					LexemeUpdateBuilder builder = typed.getBaseRevision() != null
-							? LexemeUpdateBuilder.forBaseRevision(typed.getBaseRevision())
-							: LexemeUpdateBuilder.forEntityId(typed.getEntityId());
+					LexemeUpdateBuilder builder = LexemeUpdateBuilder
+							.forBaseRevisionId(typed.getEntityId(), typed.getBaseRevisionId());
 					FormUpdate form = typed.getUpdatedForms().values().stream().findFirst().get();
 					builder.updateForm(form);
 					if (builder.build().equals(update)) {

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
@@ -27,12 +27,12 @@ import java.util.List;
 
 import org.wikidata.wdtk.datamodel.helpers.EntityUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.JsonSerializer;
-import org.wikidata.wdtk.datamodel.helpers.LabeledStatementDocumentUpdateBuilder;
+import org.wikidata.wdtk.datamodel.helpers.LabeledDocumentUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.LexemeUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.StatementDocumentUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.StatementUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;
-import org.wikidata.wdtk.datamodel.helpers.TermedStatementDocumentUpdateBuilder;
+import org.wikidata.wdtk.datamodel.helpers.TermedDocumentUpdateBuilder;
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.EntityUpdate;
@@ -540,9 +540,9 @@ public class WikibaseDataEditor {
 			if (update instanceof LabeledStatementDocumentUpdate) {
 				LabeledStatementDocumentUpdate typed = (LabeledStatementDocumentUpdate) update;
 				if (typed.getLabels().getModifiedTerms().size() == 1) {
-					LabeledStatementDocumentUpdateBuilder builder = typed.getBaseRevision() != null
-							? LabeledStatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
-							: LabeledStatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
+					LabeledDocumentUpdateBuilder builder = typed.getBaseRevision() != null
+							? LabeledDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
+							: LabeledDocumentUpdateBuilder.forEntityId(typed.getEntityId());
 					MonolingualTextValue label = typed.getLabels().getModifiedTerms()
 							.values().stream().findFirst().get();
 					builder.updateLabels(TermUpdateBuilder.create()
@@ -555,9 +555,9 @@ public class WikibaseDataEditor {
 					}
 				}
 				if (typed.getLabels().getRemovedTerms().size() == 1) {
-					LabeledStatementDocumentUpdateBuilder builder = typed.getBaseRevision() != null
-							? LabeledStatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
-							: LabeledStatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
+					LabeledDocumentUpdateBuilder builder = typed.getBaseRevision() != null
+							? LabeledDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
+							: LabeledDocumentUpdateBuilder.forEntityId(typed.getEntityId());
 					String language = typed.getLabels().getRemovedTerms().stream().findFirst().get();
 					builder.updateLabels(TermUpdateBuilder.create()
 							.removeTerm(language)
@@ -572,9 +572,9 @@ public class WikibaseDataEditor {
 			if (update instanceof TermedStatementDocumentUpdate) {
 				TermedStatementDocumentUpdate typed = (TermedStatementDocumentUpdate) update;
 				if (typed.getDescriptions().getModifiedTerms().size() == 1) {
-					TermedStatementDocumentUpdateBuilder builder = typed.getBaseRevision() != null
-							? TermedStatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
-							: TermedStatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
+					TermedDocumentUpdateBuilder builder = typed.getBaseRevision() != null
+							? TermedDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
+							: TermedDocumentUpdateBuilder.forEntityId(typed.getEntityId());
 					MonolingualTextValue description = typed.getDescriptions().getModifiedTerms()
 							.values().stream().findFirst().get();
 					builder.updateDescriptions(TermUpdateBuilder.create()
@@ -588,9 +588,9 @@ public class WikibaseDataEditor {
 					}
 				}
 				if (typed.getDescriptions().getRemovedTerms().size() == 1) {
-					TermedStatementDocumentUpdateBuilder builder = typed.getBaseRevision() != null
-							? TermedStatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
-							: TermedStatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
+					TermedDocumentUpdateBuilder builder = typed.getBaseRevision() != null
+							? TermedDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
+							: TermedDocumentUpdateBuilder.forEntityId(typed.getEntityId());
 					String language = typed.getDescriptions().getRemovedTerms().stream().findFirst().get();
 					builder.updateDescriptions(TermUpdateBuilder.create()
 							.removeTerm(language)
@@ -602,9 +602,9 @@ public class WikibaseDataEditor {
 					}
 				}
 				if (typed.getAliases().size() == 1) {
-					TermedStatementDocumentUpdateBuilder builder = typed.getBaseRevision() != null
-							? TermedStatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
-							: TermedStatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
+					TermedDocumentUpdateBuilder builder = typed.getBaseRevision() != null
+							? TermedDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
+							: TermedDocumentUpdateBuilder.forEntityId(typed.getEntityId());
 					String language = typed.getAliases().keySet().stream().findFirst().get();
 					List<String> aliases = typed.getAliases().get(language).stream()
 							.map(v -> v.getText())

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
@@ -29,7 +29,6 @@ import org.wikidata.wdtk.datamodel.helpers.JsonSerializer;
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.EntityUpdate;
-import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
 import org.wikidata.wdtk.datamodel.interfaces.FormUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
@@ -47,7 +46,6 @@ import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyUpdate;
-import org.wikidata.wdtk.datamodel.interfaces.SenseDocument;
 import org.wikidata.wdtk.datamodel.interfaces.SenseUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementDocument;
@@ -477,19 +475,17 @@ public class WikibaseDataEditor {
 	 * @param tags
 	 *            string identifiers of the tags to apply to the edit, {@code null}
 	 *            or empty for no tags
-	 * @return updated {@link EntityDocument} or {@code null} for simulated edit
-	 *         (see {@link #disableEditing()}
 	 * @throws IOException
 	 *             if there was an IO problem, such as missing network connection
 	 * @throws MediaWikiApiErrorException
 	 *             if MediaWiki API returned an error response
 	 */
-	public EntityDocument editEntityDocument(
+	public void editEntityDocument(
 			EntityUpdate update, boolean clear, String summary, List<String> tags)
 			throws IOException, MediaWikiApiErrorException {
 		String data = JsonSerializer.getJsonString(update);
 		long revisionId = update.getBaseRevision() != null ? update.getBaseRevision().getRevisionId() : 0;
-		return this.wbEditingAction.wbEditEntity(
+		this.wbEditingAction.wbEditEntity(
 				update.getEntityId().getId(), null, null, null, data, clear, editAsBot, revisionId, summary, tags);
 	}
 
@@ -516,17 +512,15 @@ public class WikibaseDataEditor {
 	 * @param tags
 	 *            string identifiers of the tags to apply to the edit, {@code null}
 	 *            or empty for no tags
-	 * @return updated item document or {@code null} for simulated edit (see
-	 *         {@link #disableEditing()}
 	 * @throws IOException
 	 *             if there was an IO problem, such as missing network connection
 	 * @throws MediaWikiApiErrorException
 	 *             if MediaWiki API returned an error response
 	 */
-	public ItemDocument editItemDocument(
+	public void editItemDocument(
 			ItemUpdate update, boolean clear, String summary, List<String> tags)
 			throws IOException, MediaWikiApiErrorException {
-		return (ItemDocument) editEntityDocument(update, clear, summary, tags);
+		editEntityDocument(update, clear, summary, tags);
 	}
 
 	/**
@@ -606,17 +600,15 @@ public class WikibaseDataEditor {
 	 * @param tags
 	 *            string identifiers of the tags to apply to the edit, {@code null}
 	 *            or empty for no tags
-	 * @return updated property document or {@code null} for simulated edit (see
-	 *         {@link #disableEditing()}
 	 * @throws IOException
 	 *             if there was an IO problem, such as missing network connection
 	 * @throws MediaWikiApiErrorException
 	 *             if MediaWiki API returned an error response
 	 */
-	public PropertyDocument editPropertyDocument(
+	public void editPropertyDocument(
 			PropertyUpdate update, boolean clear, String summary, List<String> tags)
 			throws IOException, MediaWikiApiErrorException {
-		return (PropertyDocument) editEntityDocument(update, clear, summary, tags);
+		editEntityDocument(update, clear, summary, tags);
 	}
 
 	/**
@@ -694,17 +686,15 @@ public class WikibaseDataEditor {
 	 * @param tags
 	 *            string identifiers of the tags to apply to the edit, {@code null}
 	 *            or empty for no tags
-	 * @return updated media document or {@code null} for simulated edit (see
-	 *         {@link #disableEditing()}
 	 * @throws IOException
 	 *             if there was an IO problem, such as missing network connection
 	 * @throws MediaWikiApiErrorException
 	 *             if MediaWiki API returned an error response
 	 */
-	public MediaInfoDocument editMediaInfoDocument(
+	public void editMediaInfoDocument(
 			MediaInfoUpdate update, boolean clear, String summary, List<String> tags)
 			throws IOException, MediaWikiApiErrorException {
-		return (MediaInfoDocument) editEntityDocument(update, clear, summary, tags);
+		editEntityDocument(update, clear, summary, tags);
 	}
 
 	/**
@@ -730,17 +720,15 @@ public class WikibaseDataEditor {
 	 * @param tags
 	 *            string identifiers of the tags to apply to the edit, {@code null}
 	 *            or empty for no tags
-	 * @return updated sense document or {@code null} for simulated edit (see
-	 *         {@link #disableEditing()}
 	 * @throws IOException
 	 *             if there was an IO problem, such as missing network connection
 	 * @throws MediaWikiApiErrorException
 	 *             if MediaWiki API returned an error response
 	 */
-	public SenseDocument editSenseDocument(
+	public void editSenseDocument(
 			SenseUpdate update, boolean clear, String summary, List<String> tags)
 			throws IOException, MediaWikiApiErrorException {
-		return (SenseDocument) editEntityDocument(update, clear, summary, tags);
+		editEntityDocument(update, clear, summary, tags);
 	}
 
 	/**
@@ -766,17 +754,15 @@ public class WikibaseDataEditor {
 	 * @param tags
 	 *            string identifiers of the tags to apply to the edit, {@code null}
 	 *            or empty for no tags
-	 * @return updated form document or {@code null} for simulated edit (see
-	 *         {@link #disableEditing()}
 	 * @throws IOException
 	 *             if there was an IO problem, such as missing network connection
 	 * @throws MediaWikiApiErrorException
 	 *             if MediaWiki API returned an error response
 	 */
-	public FormDocument editFormDocument(
+	public void editFormDocument(
 			FormUpdate update, boolean clear, String summary, List<String> tags)
 			throws IOException, MediaWikiApiErrorException {
-		return (FormDocument) editEntityDocument(update, clear, summary, tags);
+		editEntityDocument(update, clear, summary, tags);
 	}
 
 	/**
@@ -802,17 +788,15 @@ public class WikibaseDataEditor {
 	 * @param tags
 	 *            string identifiers of the tags to apply to the edit, {@code null}
 	 *            or empty for no tags
-	 * @return updated lexeme document or {@code null} for simulated edit (see
-	 *         {@link #disableEditing()}
 	 * @throws IOException
 	 *             if there was an IO problem, such as missing network connection
 	 * @throws MediaWikiApiErrorException
 	 *             if MediaWiki API returned an error response
 	 */
-	public LexemeDocument editLexemeDocument(
+	public void editLexemeDocument(
 			LexemeUpdate update, boolean clear, String summary, List<String> tags)
 			throws IOException, MediaWikiApiErrorException {
-		return (LexemeDocument) editEntityDocument(update, clear, summary, tags);
+		editEntityDocument(update, clear, summary, tags);
 	}
 
 	/**
@@ -838,17 +822,15 @@ public class WikibaseDataEditor {
 	 * @param tags
 	 *            string identifiers of the tags to apply to the edit, {@code null}
 	 *            or empty for no tags
-	 * @return updated {@link StatementDocument} or {@code null} for simulated edit
-	 *         (see {@link #disableEditing()}
 	 * @throws IOException
 	 *             if there was an IO problem, such as missing network connection
 	 * @throws MediaWikiApiErrorException
 	 *             if MediaWiki API returned an error response
 	 */
-	public StatementDocument editStatementDocument(
+	public void editStatementDocument(
 			StatementDocumentUpdate update, boolean clear, String summary, List<String> tags)
 			throws IOException, MediaWikiApiErrorException {
-		return (StatementDocument) editEntityDocument(update, clear, summary, tags);
+		editEntityDocument(update, clear, summary, tags);
 	}
 
 	/**
@@ -874,17 +856,15 @@ public class WikibaseDataEditor {
 	 * @param tags
 	 *            string identifiers of the tags to apply to the edit, {@code null}
 	 *            or empty for no tags
-	 * @return updated {@link LabeledDocument} or {@code null} for simulated edit
-	 *         (see {@link #disableEditing()}
 	 * @throws IOException
 	 *             if there was an IO problem, such as missing network connection
 	 * @throws MediaWikiApiErrorException
 	 *             if MediaWiki API returned an error response
 	 */
-	public LabeledDocument editLabeledDocument(
+	public void editLabeledDocument(
 			LabeledDocumentUpdate update, boolean clear, String summary, List<String> tags)
 			throws IOException, MediaWikiApiErrorException {
-		return (LabeledDocument) editEntityDocument(update, clear, summary, tags);
+		editEntityDocument(update, clear, summary, tags);
 	}
 
 	/**
@@ -910,17 +890,15 @@ public class WikibaseDataEditor {
 	 * @param tags
 	 *            string identifiers of the tags to apply to the edit, {@code null}
 	 *            or empty for no tags
-	 * @return updated {@link LabeledStatementDocument} or {@code null} for
-	 *         simulated edit (see {@link #disableEditing()}
 	 * @throws IOException
 	 *             if there was an IO problem, such as missing network connection
 	 * @throws MediaWikiApiErrorException
 	 *             if MediaWiki API returned an error response
 	 */
-	public LabeledStatementDocument editLabeledStatementDocument(
+	public void editLabeledStatementDocument(
 			LabeledStatementDocumentUpdate update, boolean clear, String summary, List<String> tags)
 			throws IOException, MediaWikiApiErrorException {
-		return (LabeledStatementDocument) editEntityDocument(update, clear, summary, tags);
+		editEntityDocument(update, clear, summary, tags);
 	}
 
 	/**
@@ -946,17 +924,15 @@ public class WikibaseDataEditor {
 	 * @param tags
 	 *            string identifiers of the tags to apply to the edit, {@code null}
 	 *            or empty for no tags
-	 * @return updated {@link TermedDocument} or {@code null} for simulated edit
-	 *         (see {@link #disableEditing()}
 	 * @throws IOException
 	 *             if there was an IO problem, such as missing network connection
 	 * @throws MediaWikiApiErrorException
 	 *             if MediaWiki API returned an error response
 	 */
-	public TermedDocument editTermedDocument(
+	public void editTermedDocument(
 			TermedDocumentUpdate update, boolean clear, String summary, List<String> tags)
 			throws IOException, MediaWikiApiErrorException {
-		return (TermedDocument) editEntityDocument(update, clear, summary, tags);
+		editEntityDocument(update, clear, summary, tags);
 	}
 
 	/**
@@ -982,17 +958,15 @@ public class WikibaseDataEditor {
 	 * @param tags
 	 *            string identifiers of the tags to apply to the edit, {@code null}
 	 *            or empty for no tags
-	 * @return updated {@link TermedStatementDocument} or {@code null} for simulated
-	 *         edit (see {@link #disableEditing()}
 	 * @throws IOException
 	 *             if there was an IO problem, such as missing network connection
 	 * @throws MediaWikiApiErrorException
 	 *             if MediaWiki API returned an error response
 	 */
-	public TermedStatementDocument editTermedStatementDocument(
+	public void editTermedStatementDocument(
 			TermedStatementDocumentUpdate update, boolean clear, String summary, List<String> tags)
 			throws IOException, MediaWikiApiErrorException {
-		return (TermedStatementDocument) editEntityDocument(update, clear, summary, tags);
+		editEntityDocument(update, clear, summary, tags);
 	}
 
 	/**

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
@@ -19,16 +19,25 @@
  */
 package org.wikidata.wdtk.wikibaseapi;
 
+import static java.util.stream.Collectors.toList;
+
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 import org.wikidata.wdtk.datamodel.helpers.EntityUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.JsonSerializer;
+import org.wikidata.wdtk.datamodel.helpers.LabeledStatementDocumentUpdateBuilder;
+import org.wikidata.wdtk.datamodel.helpers.StatementDocumentUpdateBuilder;
+import org.wikidata.wdtk.datamodel.helpers.StatementUpdateBuilder;
+import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;
+import org.wikidata.wdtk.datamodel.helpers.TermedStatementDocumentUpdateBuilder;
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.EntityUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.LabeledStatementDocumentUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.LexemeDocument;
 import org.wikidata.wdtk.datamodel.interfaces.LexemeIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoDocument;
@@ -37,7 +46,9 @@ import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementDocument;
+import org.wikidata.wdtk.datamodel.interfaces.StatementDocumentUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocument;
+import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocumentUpdate;
 import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
 
 /**
@@ -467,9 +478,151 @@ public class WikibaseDataEditor {
 	public void editEntityDocument(
 			EntityUpdate update, boolean clear, String summary, List<String> tags)
 			throws IOException, MediaWikiApiErrorException {
-		String data = JsonSerializer.getJsonString(update);
 		long revisionId = update.getBaseRevision() != null ? update.getBaseRevision().getRevisionId() : 0;
-		this.wbEditingAction.wbEditEntity(
+		if (update instanceof StatementDocumentUpdate) {
+			StatementDocumentUpdate typed = (StatementDocumentUpdate) update;
+			if (typed.getStatements().getAddedStatements().size() == 1) {
+				StatementDocumentUpdateBuilder builder = typed.getBaseRevision() != null
+						? StatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
+						: StatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
+				Statement statement = typed.getStatements().getAddedStatements().stream().findFirst().get();
+				builder.updateStatements(new StatementUpdateBuilder()
+						.addStatement(statement)
+						.build());
+				if (builder.build().equals(update)) {
+					String statementId = new RandomGuidGenerator().freshStatementId(typed.getEntityId().getId());
+					Statement prepared = statement.withStatementId(statementId);
+					wbEditingAction.wbSetClaim(JsonSerializer.getJsonString(prepared),
+							editAsBot, revisionId, summary, tags);
+					return;
+				}
+			}
+			if (typed.getStatements().getReplacedStatements().size() == 1) {
+				StatementDocumentUpdateBuilder builder = typed.getBaseRevision() != null
+						? StatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
+						: StatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
+				Statement statement = typed.getStatements().getReplacedStatements().values().stream().findFirst().get();
+				builder.updateStatements(new StatementUpdateBuilder()
+						.replaceStatement(statement)
+						.build());
+				if (builder.build().equals(update)) {
+					wbEditingAction.wbSetClaim(JsonSerializer.getJsonString(statement),
+							editAsBot, revisionId, summary, tags);
+					return;
+				}
+			}
+			if (!typed.getStatements().getRemovedStatements().isEmpty()
+					&& typed.getStatements().getRemovedStatements().size() <= 50) {
+				StatementDocumentUpdateBuilder builder = typed.getBaseRevision() != null
+						? StatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
+						: StatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
+				List<String> statementIds = new ArrayList<>(typed.getStatements().getRemovedStatements());
+				StatementUpdateBuilder statementBuilder = new StatementUpdateBuilder();
+				for (String statementId : statementIds)
+					statementBuilder.removeStatement(statementId);
+				builder.updateStatements(statementBuilder.build());
+				if (builder.build().equals(update)) {
+					wbEditingAction.wbRemoveClaims(statementIds, editAsBot, revisionId, summary, tags);
+					return;
+				}
+			}
+		}
+		if (update instanceof LabeledStatementDocumentUpdate) {
+			LabeledStatementDocumentUpdate typed = (LabeledStatementDocumentUpdate) update;
+			if (typed.getLabels().getModifiedTerms().size() == 1) {
+				LabeledStatementDocumentUpdateBuilder builder = typed.getBaseRevision() != null
+						? LabeledStatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
+						: LabeledStatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
+				MonolingualTextValue label = typed.getLabels().getModifiedTerms().values().stream().findFirst().get();
+				builder.updateLabels(new TermUpdateBuilder()
+						.setTerm(label)
+						.build());
+				if (builder.build().equals(update)) {
+					wbEditingAction.wbSetLabel(update.getEntityId().getId(), null, null, null,
+							label.getLanguageCode(), label.getText(), editAsBot, revisionId, summary, tags);
+					return;
+				}
+			}
+			if (typed.getLabels().getRemovedTerms().size() == 1) {
+				LabeledStatementDocumentUpdateBuilder builder = typed.getBaseRevision() != null
+						? LabeledStatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
+						: LabeledStatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
+				String language = typed.getLabels().getRemovedTerms().stream().findFirst().get();
+				builder.updateLabels(new TermUpdateBuilder()
+						.removeTerm(language)
+						.build());
+				if (builder.build().equals(update)) {
+					wbEditingAction.wbSetLabel(update.getEntityId().getId(), null, null, null,
+							language, null, editAsBot, revisionId, summary, tags);
+					return;
+				}
+			}
+		}
+		if (update instanceof TermedStatementDocumentUpdate) {
+			TermedStatementDocumentUpdate typed = (TermedStatementDocumentUpdate) update;
+			if (typed.getDescriptions().getModifiedTerms().size() == 1) {
+				TermedStatementDocumentUpdateBuilder builder = typed.getBaseRevision() != null
+						? TermedStatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
+						: TermedStatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
+				MonolingualTextValue description = typed.getDescriptions().getModifiedTerms()
+						.values().stream().findFirst().get();
+				builder.updateDescriptions(new TermUpdateBuilder()
+						.setTerm(description)
+						.build());
+				if (builder.build().equals(update)) {
+					wbEditingAction.wbSetDescription(update.getEntityId().getId(), null, null, null,
+							description.getLanguageCode(), description.getText(), editAsBot, revisionId, summary, tags);
+					return;
+				}
+			}
+			if (typed.getDescriptions().getRemovedTerms().size() == 1) {
+				TermedStatementDocumentUpdateBuilder builder = typed.getBaseRevision() != null
+						? TermedStatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
+						: TermedStatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
+				String language = typed.getDescriptions().getRemovedTerms().stream().findFirst().get();
+				builder.updateDescriptions(new TermUpdateBuilder()
+						.removeTerm(language)
+						.build());
+				if (builder.build().equals(update)) {
+					wbEditingAction.wbSetDescription(update.getEntityId().getId(), null, null, null,
+							language, null, editAsBot, revisionId, summary, tags);
+					return;
+				}
+			}
+			if (typed.getAliases().size() == 1) {
+				TermedStatementDocumentUpdateBuilder builder = typed.getBaseRevision() != null
+						? TermedStatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
+						: TermedStatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
+				String language = typed.getAliases().keySet().stream().findFirst().get();
+				List<String> aliases = typed.getAliases().get(language).stream()
+						.map(v -> v.getText())
+						.collect(toList());
+				builder.setAliases(language, aliases);
+				if (builder.build().equals(update)) {
+					if (typed.getBaseRevision() != null && typed.getBaseRevision().getAliases().containsKey(language)) {
+						List<String> original = typed.getBaseRevision().getAliases().get(language).stream()
+								.map(v -> v.getText())
+								.collect(toList());
+						List<String> added = aliases.stream().filter(a -> !original.contains(a)).collect(toList());
+						List<String> removed = original.stream().filter(a -> !aliases.contains(a)).collect(toList());
+						List<String> simulated = new ArrayList<>(original);
+						for (String alias : removed)
+							simulated.remove(alias);
+						simulated.addAll(added);
+						if (simulated.equals(aliases)) {
+							wbEditingAction.wbSetAliases(update.getEntityId().getId(), null, null, null,
+									language, added, removed, null, editAsBot, revisionId, summary, tags);
+							return;
+						}
+					}
+					wbEditingAction.wbSetAliases(update.getEntityId().getId(), null, null, null,
+							language, null, null, aliases, editAsBot, revisionId, summary, tags);
+					return;
+				}
+			}
+		}
+		String data = JsonSerializer.getJsonString(update);
+		wbEditingAction.wbEditEntity(
 				update.getEntityId().getId(), null, null, null, data, clear, editAsBot, revisionId, summary, tags);
 	}
 

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
@@ -763,6 +763,7 @@ public class WikibaseDataEditor {
 	}
 
 	/**
+	 * @deprecated Use {@link #editEntityDocument(EntityUpdate, boolean, String, List)} instead.
 	 * Updates the statements of the item document identified by the given item
 	 * id. The updates are computed with respect to the current data found
 	 * online, making sure that no redundant deletions or duplicate insertions
@@ -791,6 +792,7 @@ public class WikibaseDataEditor {
 	 * @throws IOException
 	 *             if there are IO problems, such as missing network connection
 	 */
+	@Deprecated
 	public ItemDocument updateStatements(ItemIdValue itemIdValue,
 			List<Statement> addStatements, List<Statement> deleteStatements,
 			String summary, List<String> tags)
@@ -805,6 +807,7 @@ public class WikibaseDataEditor {
 	
 	
 	/**
+	 * @deprecated Use {@link #editEntityDocument(EntityUpdate, boolean, String, List)} instead.
 	 * Updates the terms and statements of the item document identified by the
 	 * given item id. The updates are computed with respect to the current data
 	 * found online, making sure that no redundant deletions or duplicate insertions
@@ -844,6 +847,7 @@ public class WikibaseDataEditor {
 	 * @throws IOException
 	 *          if there are any IO errors, such as missing network connection
 	 */
+	@Deprecated
 	public ItemDocument updateTermsStatements(ItemIdValue itemIdValue,
 			List<MonolingualTextValue> addLabels,
 			List<MonolingualTextValue> addDescriptions,
@@ -862,6 +866,7 @@ public class WikibaseDataEditor {
 	}
 
 	/**
+	 * @deprecated Use {@link #editEntityDocument(EntityUpdate, boolean, String, List)} instead.
 	 * Updates the statements of the property document identified by the given
 	 * property id. The computation of updates is the same as for
 	 * {@link #updateStatements(ItemIdValue, List, List, String, List)}.
@@ -889,6 +894,7 @@ public class WikibaseDataEditor {
 	 * @throws IOException
 	 *             if there are IO problems, such as missing network connection
 	 */
+	@Deprecated
 	public PropertyDocument updateStatements(PropertyIdValue propertyIdValue,
 			List<Statement> addStatements, List<Statement> deleteStatements,
 			String summary, List<String> tags)

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
@@ -449,7 +449,8 @@ public class WikibaseDataEditor {
 
 	/**
 	 * Updates {@link EntityDocument} entity. ID of the entity to update is taken
-	 * from the update object. Its site IRI is ignored.
+	 * from the update object. Its site IRI is ignored. No action is taken if the
+	 * update is empty.
 	 * <p>
 	 * If the update object references base revision of the document, its revision
 	 * ID is used to specify the base revision in the API request, enabling the API
@@ -478,6 +479,8 @@ public class WikibaseDataEditor {
 	public void editEntityDocument(
 			EntityUpdate update, boolean clear, String summary, List<String> tags)
 			throws IOException, MediaWikiApiErrorException {
+		if (update.isEmpty())
+			return;
 		long revisionId = update.getBaseRevision() != null ? update.getBaseRevision().getRevisionId() : 0;
 		if (update instanceof StatementDocumentUpdate) {
 			StatementDocumentUpdate typed = (StatementDocumentUpdate) update;
@@ -486,7 +489,7 @@ public class WikibaseDataEditor {
 						? StatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
 						: StatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
 				Statement statement = typed.getStatements().getAddedStatements().stream().findFirst().get();
-				builder.updateStatements(new StatementUpdateBuilder()
+				builder.updateStatements(StatementUpdateBuilder.create()
 						.addStatement(statement)
 						.build());
 				if (builder.build().equals(update)) {
@@ -502,7 +505,7 @@ public class WikibaseDataEditor {
 						? StatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
 						: StatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
 				Statement statement = typed.getStatements().getReplacedStatements().values().stream().findFirst().get();
-				builder.updateStatements(new StatementUpdateBuilder()
+				builder.updateStatements(StatementUpdateBuilder.create()
 						.replaceStatement(statement)
 						.build());
 				if (builder.build().equals(update)) {
@@ -517,7 +520,7 @@ public class WikibaseDataEditor {
 						? StatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
 						: StatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
 				List<String> statementIds = new ArrayList<>(typed.getStatements().getRemovedStatements());
-				StatementUpdateBuilder statementBuilder = new StatementUpdateBuilder();
+				StatementUpdateBuilder statementBuilder = StatementUpdateBuilder.create();
 				for (String statementId : statementIds)
 					statementBuilder.removeStatement(statementId);
 				builder.updateStatements(statementBuilder.build());
@@ -534,7 +537,7 @@ public class WikibaseDataEditor {
 						? LabeledStatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
 						: LabeledStatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
 				MonolingualTextValue label = typed.getLabels().getModifiedTerms().values().stream().findFirst().get();
-				builder.updateLabels(new TermUpdateBuilder()
+				builder.updateLabels(TermUpdateBuilder.create()
 						.setTerm(label)
 						.build());
 				if (builder.build().equals(update)) {
@@ -548,7 +551,7 @@ public class WikibaseDataEditor {
 						? LabeledStatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
 						: LabeledStatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
 				String language = typed.getLabels().getRemovedTerms().stream().findFirst().get();
-				builder.updateLabels(new TermUpdateBuilder()
+				builder.updateLabels(TermUpdateBuilder.create()
 						.removeTerm(language)
 						.build());
 				if (builder.build().equals(update)) {
@@ -566,7 +569,7 @@ public class WikibaseDataEditor {
 						: TermedStatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
 				MonolingualTextValue description = typed.getDescriptions().getModifiedTerms()
 						.values().stream().findFirst().get();
-				builder.updateDescriptions(new TermUpdateBuilder()
+				builder.updateDescriptions(TermUpdateBuilder.create()
 						.setTerm(description)
 						.build());
 				if (builder.build().equals(update)) {
@@ -580,7 +583,7 @@ public class WikibaseDataEditor {
 						? TermedStatementDocumentUpdateBuilder.forBaseRevision(typed.getBaseRevision())
 						: TermedStatementDocumentUpdateBuilder.forEntityId(typed.getEntityId());
 				String language = typed.getDescriptions().getRemovedTerms().stream().findFirst().get();
-				builder.updateDescriptions(new TermUpdateBuilder()
+				builder.updateDescriptions(TermUpdateBuilder.create()
 						.removeTerm(language)
 						.build());
 				if (builder.build().equals(update)) {

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditorTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditorTest.java
@@ -24,6 +24,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.only;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.wikidata.wdtk.datamodel.helpers.Datamodel.makeStringValue;
+import static org.wikidata.wdtk.datamodel.helpers.Datamodel.makeWikidataFormIdValue;
+import static org.wikidata.wdtk.datamodel.helpers.Datamodel.makeWikidataItemIdValue;
+import static org.wikidata.wdtk.datamodel.helpers.Datamodel.makeWikidataLexemeIdValue;
+import static org.wikidata.wdtk.datamodel.helpers.Datamodel.makeWikidataPropertyIdValue;
+import static org.wikidata.wdtk.datamodel.helpers.Datamodel.makeWikidataSenseIdValue;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -34,19 +44,31 @@ import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.wikidata.wdtk.datamodel.helpers.AliasUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.helpers.FormUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.ItemDocumentBuilder;
+import org.wikidata.wdtk.datamodel.helpers.ItemUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.JsonSerializer;
+import org.wikidata.wdtk.datamodel.helpers.LexemeUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.PropertyDocumentBuilder;
+import org.wikidata.wdtk.datamodel.helpers.SenseUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.StatementBuilder;
+import org.wikidata.wdtk.datamodel.helpers.StatementUpdateBuilder;
+import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.EntityUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.FormUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.ItemUpdate;
+import org.wikidata.wdtk.datamodel.interfaces.LexemeUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoDocument;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.SenseUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.util.CompressionType;
 import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
@@ -58,6 +80,8 @@ public class WikibaseDataEditorTest {
 	MockBasicApiConnection con;
 	ItemIdValue Q5 = Datamodel.makeWikidataItemIdValue("Q5");
 	PropertyIdValue P31 = Datamodel.makeWikidataPropertyIdValue("P31");
+	static final String TEST_GUID = "427C0317-BA8C-95B0-16C8-1A1B5FAC1081";
+	MockGuidGenerator guids = new MockGuidGenerator(TEST_GUID);
 
 	@BeforeEach
 	public void setUp() throws IOException {
@@ -842,6 +866,171 @@ public class WikibaseDataEditorTest {
 				Collections.singletonList(description),	Collections.<MonolingualTextValue>emptyList(),
 				Collections.<MonolingualTextValue>emptyList(), Collections.<Statement>emptyList(),
 				Collections.<Statement>emptyList(), "testing tags", Collections.singletonList("tag_which_does_not_exist")));
+	}
+
+	private WbEditingAction mockEntityUpdate(EntityUpdate update) throws MediaWikiApiErrorException, IOException {
+		WbEditingAction action = mock(WbEditingAction.class);
+		WikibaseDataFetcher fetcher = new WikibaseDataFetcher(con, Datamodel.SITE_WIKIDATA);
+		WikibaseDataEditor wde = new WikibaseDataEditor(action, fetcher, Datamodel.SITE_WIKIDATA, guids);
+		wde.editEntityDocument(update, false, "test summary", Arrays.asList("tag1"));
+		return action;
+	}
+
+	@Test
+	public void testReductionToSetNewClaim() throws MediaWikiApiErrorException, IOException {
+		ItemIdValue subject = makeWikidataItemIdValue("Q1");
+		Statement statement = StatementBuilder.forSubjectAndProperty(subject, makeWikidataPropertyIdValue("P1"))
+				.withValue(makeStringValue("some value"))
+				.build();
+		WbEditingAction action = mockEntityUpdate(ItemUpdateBuilder.forBaseRevisionId(subject, 123)
+				.updateStatements(StatementUpdateBuilder.create()
+						.add(statement)
+						.build())
+				.build());
+		Statement statementWithId = statement.withStatementId(guids.freshStatementId(subject.getId()));
+		verify(action, only()).wbSetClaim(
+				JsonSerializer.getJsonString(statementWithId), false, 123, "test summary", Arrays.asList("tag1"));
+	}
+
+	@Test
+	public void testReductionToSetExistingClaim() throws MediaWikiApiErrorException, IOException {
+		ItemIdValue subject = makeWikidataItemIdValue("Q1");
+		Statement statement = StatementBuilder.forSubjectAndProperty(subject, makeWikidataPropertyIdValue("P1"))
+				.withValue(makeStringValue("some value"))
+				.withId(guids.freshStatementId(subject.getId()))
+				.build();
+		WbEditingAction action = mockEntityUpdate(ItemUpdateBuilder.forBaseRevisionId(subject, 123)
+				.updateStatements(StatementUpdateBuilder.create().replace(statement).build())
+				.build());
+		verify(action, only()).wbSetClaim(
+				JsonSerializer.getJsonString(statement), false, 123, "test summary", Arrays.asList("tag1"));
+	}
+
+	@Test
+	public void testReductionToRemoveClaims() throws MediaWikiApiErrorException, IOException {
+		ItemIdValue subject = makeWikidataItemIdValue("Q1");
+		String id = guids.freshStatementId(subject.getId());
+		WbEditingAction action = mockEntityUpdate(ItemUpdateBuilder.forBaseRevisionId(subject, 123)
+				.updateStatements(StatementUpdateBuilder.create().remove(id).build())
+				.build());
+		verify(action, only()).wbRemoveClaims(Arrays.asList(id), false, 123, "test summary", Arrays.asList("tag1"));
+	}
+
+	@Test
+	public void testReductionToSetLabel() throws MediaWikiApiErrorException, IOException {
+		WbEditingAction action = mockEntityUpdate(ItemUpdateBuilder
+				.forBaseRevisionId(makeWikidataItemIdValue("Q1"), 123)
+				.updateLabels(TermUpdateBuilder.create()
+						.put(Datamodel.makeMonolingualTextValue("hello", "en"))
+						.build())
+				.build());
+		verify(action, only()).wbSetLabel(
+				"Q1", null, null, null, "en", "hello", false, 123, "test summary", Arrays.asList("tag1"));
+	}
+
+	@Test
+	public void testReductionToSetNullLabel() throws MediaWikiApiErrorException, IOException {
+		WbEditingAction action = mockEntityUpdate(ItemUpdateBuilder
+				.forBaseRevisionId(makeWikidataItemIdValue("Q1"), 123)
+				.updateLabels(TermUpdateBuilder.create().remove("en").build())
+				.build());
+		verify(action, only()).wbSetLabel(
+				"Q1", null, null, null, "en", null, false, 123, "test summary", Arrays.asList("tag1"));
+	}
+
+	@Test
+	public void testReductionToSetDescription() throws MediaWikiApiErrorException, IOException {
+		WbEditingAction action = mockEntityUpdate(ItemUpdateBuilder
+				.forBaseRevisionId(makeWikidataItemIdValue("Q1"), 123)
+				.updateDescriptions(TermUpdateBuilder.create()
+						.put(Datamodel.makeMonolingualTextValue("hello", "en"))
+						.build())
+				.build());
+		verify(action, only()).wbSetDescription(
+				"Q1", null, null, null, "en", "hello", false, 123, "test summary", Arrays.asList("tag1"));
+	}
+
+	@Test
+	public void testReductionToSetNullDescription() throws MediaWikiApiErrorException, IOException {
+		WbEditingAction action = mockEntityUpdate(ItemUpdateBuilder
+				.forBaseRevisionId(makeWikidataItemIdValue("Q1"), 123)
+				.updateDescriptions(TermUpdateBuilder.create().remove("en").build())
+				.build());
+		verify(action, only()).wbSetDescription(
+				"Q1", null, null, null, "en", null, false, 123, "test summary", Arrays.asList("tag1"));
+	}
+
+	@Test
+	public void testReductionToSetAliases() throws MediaWikiApiErrorException, IOException {
+		WbEditingAction action = mockEntityUpdate(ItemUpdateBuilder
+				.forBaseRevisionId(makeWikidataItemIdValue("Q1"), 123)
+				.updateAliases("en", AliasUpdateBuilder.create()
+						.add(Datamodel.makeMonolingualTextValue("hello", "en"))
+						.remove(Datamodel.makeMonolingualTextValue("bye", "en"))
+						.build())
+				.build());
+		verify(action, only()).wbSetAliases("Q1", null, null, null, "en",
+				Arrays.asList("hello"), Arrays.asList("bye"), null, false, 123, "test summary", Arrays.asList("tag1"));
+	}
+
+	@Test
+	public void testReductionToSenseEdit() throws MediaWikiApiErrorException, IOException {
+		SenseUpdate update = SenseUpdateBuilder
+				.forEntityId(makeWikidataSenseIdValue("L1-S1"))
+				.updateGlosses(TermUpdateBuilder.create().remove("en").build())
+				.build();
+		WbEditingAction action = mockEntityUpdate(LexemeUpdateBuilder
+				.forBaseRevisionId(makeWikidataLexemeIdValue("L1"), 123)
+				.updateSense(update)
+				.build());
+		verify(action, only()).wbEditEntity("L1-S1", null, null, null, JsonSerializer.getJsonString(update),
+				false, false, 123, "test summary", Arrays.asList("tag1"));
+	}
+
+	@Test
+	public void testReductionToFormEdit() throws MediaWikiApiErrorException, IOException {
+		FormUpdate update = FormUpdateBuilder
+				.forEntityId(makeWikidataFormIdValue("L1-F1"))
+				.updateRepresentations(TermUpdateBuilder.create().remove("en").build())
+				.build();
+		WbEditingAction action = mockEntityUpdate(LexemeUpdateBuilder
+				.forBaseRevisionId(makeWikidataLexemeIdValue("L1"), 123)
+				.updateForm(update)
+				.build());
+		verify(action, only()).wbEditEntity("L1-F1", null, null, null, JsonSerializer.getJsonString(update),
+				false, false, 123, "test summary", Arrays.asList("tag1"));
+	}
+
+	@Test
+	public void testUnreducedEntityEdit() throws MediaWikiApiErrorException, IOException {
+		LexemeUpdate update = LexemeUpdateBuilder
+				.forBaseRevisionId(makeWikidataLexemeIdValue("L1"), 123)
+				.setLanguage(Datamodel.makeWikidataItemIdValue("Q1"))
+				.build();
+		WbEditingAction action = mockEntityUpdate(update);
+		verify(action, only()).wbEditEntity("L1", null, null, null, JsonSerializer.getJsonString(update),
+				false, false, 123, "test summary", Arrays.asList("tag1"));
+	}
+
+	@Test
+	public void testIrreducibleClearingEdit() throws MediaWikiApiErrorException, IOException {
+		ItemUpdate update = ItemUpdateBuilder
+				.forBaseRevisionId(makeWikidataItemIdValue("Q1"), 123)
+				.updateLabels(TermUpdateBuilder.create().remove("en").build())
+				.build();
+		WbEditingAction action = mock(WbEditingAction.class);
+		WikibaseDataFetcher fetcher = new WikibaseDataFetcher(con, Datamodel.SITE_WIKIDATA);
+		WikibaseDataEditor wde = new WikibaseDataEditor(action, fetcher, Datamodel.SITE_WIKIDATA, guids);
+		wde.editEntityDocument(update, true, "test summary", Arrays.asList("tag1"));
+		verify(action, only()).wbEditEntity("Q1", null, null, null, JsonSerializer.getJsonString(update),
+				true, false, 123, "test summary", Arrays.asList("tag1"));
+	}
+
+	@Test
+	public void testReductionToNoEdit() throws MediaWikiApiErrorException, IOException {
+		verifyNoInteractions(mockEntityUpdate(LexemeUpdateBuilder
+				.forBaseRevisionId(makeWikidataLexemeIdValue("L1"), 123)
+				.build()));
 	}
 
 }

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditorTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditorTest.java
@@ -545,7 +545,7 @@ public class WikibaseDataEditorTest {
 		params.put("format", "json");
 		params.put("baserevid", "1234");
 		params.put("maxlag", "5");
-		params.put("data", "{\"id\":\"Q1234\"}");
+		params.put("data", "{}");
 		String data = JsonSerializer.getJsonString(itemDocument);
 		String expectedResult = "{\"entity\":"+data+",\"success\":1}";
 		con.setWebResource(params, expectedResult);


### PR DESCRIPTION
This PR includes entity editing via `WikibaseDataEditor.editEntityDocument`. Most of the code consists of update representations and update builders. All edit operations (add/modify/remove all parts of all entity types) have been manually tested. Some related changes have been omitted though, because this is already a moster PR:

* Lots of convenience methods on builders have been omitted.
* Builder constructor `fromUpdate(EntityUpdate)` has been omitted.
* Classes `DatamodelConverter`, `DatamodelFilter`, `ToString`, and `ValueVisitor` need new methods to support the new `EntityUpdate` interfaces.
* Examples are still using the old deprecated APIs.
* `EntityUpdateImpl` classes don't have validation. They rely on validation in `EntityUpdateBuilder` classes.
* There are no unit tests. The code has been however tested manually using special test app on test Wikidata.
* Special-casing of edit operations works only for APIs that were already implemented. WDTK currently does not have implementation for `wbsetsitelink`, `wbsetclaimvalue`, `wbsetqualifier`, `wbsetreference`, `wbremovequalifiers`, `wbremovereferences`.

Some of this missing functionality needs further discussion. I think all of it needs separate PR in order to limit size of this PR. Some of these should be a separate issue.

This PR resolves  #437,  #376, and most of #403.