### PR TITLE
Store QuantityValue units as ItemIdValue instead of Strings.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,12 +93,6 @@
 			<version>${junitVersion}</version>
 			<scope>test</scope>
 		</dependency>
-                <dependency>
-                        <groupId>org.junit.jupiter</groupId>
-                        <artifactId>junit-jupiter-engine</artifactId>
-                        <version>${junitVersion}</version>
-                        <scope>test</scope>
-                </dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -93,6 +93,12 @@
 			<version>${junitVersion}</version>
 			<scope>test</scope>
 		</dependency>
+                <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>${junitVersion}</version>
+                        <scope>test</scope>
+                </dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
 			<artifactId>hamcrest-core</artifactId>

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Datamodel.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Datamodel.java
@@ -384,7 +384,7 @@ public class Datamodel {
 	public static QuantityValue makeQuantityValue(BigDecimal numericValue,
 			BigDecimal lowerBound, BigDecimal upperBound, ItemIdValue unit) {
 		return factory.getQuantityValue(numericValue, lowerBound, upperBound,
-				unit.getIri());
+				unit);
 	}
 
 	/**
@@ -397,7 +397,7 @@ public class Datamodel {
 	 * @return a {@link QuantityValue} corresponding to the input
 	 */
 	public static QuantityValue makeQuantityValue(BigDecimal numericValue, ItemIdValue unit) {
-		return factory.getQuantityValue(numericValue, unit.getIri());
+		return factory.getQuantityValue(numericValue, unit);
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImpl.java
@@ -123,11 +123,22 @@ public class DataObjectFactoryImpl implements DataObjectFactory {
 	public QuantityValue getQuantityValue(BigDecimal numericValue, String unit) {
 		return getQuantityValue(numericValue, null, null, unit);
 	}
+	
+    @Override
+    public QuantityValue getQuantityValue(BigDecimal numericValue, ItemIdValue unit) {
+        return getQuantityValue(numericValue, null, null, unit);
+    }
 
 	@Override
 	public QuantityValue getQuantityValue(BigDecimal numericValue,
 			BigDecimal lowerBound, BigDecimal upperBound, String unit) {
 		return new QuantityValueImpl(numericValue, lowerBound, upperBound, unit);
+	}
+	
+	@Override
+	public QuantityValue getQuantityValue(BigDecimal numericValue,
+	        BigDecimal lowerBound, BigDecimal upperBound, ItemIdValue unit) {
+	    return new QuantityValueImpl(numericValue, lowerBound, upperBound, unit);
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/QuantityValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/QuantityValueImpl.java
@@ -50,6 +50,31 @@ public class QuantityValueImpl extends ValueImpl implements QuantityValue {
 	private final JacksonInnerQuantity value;
 	
 	/**
+     * Constructor.
+     *
+     * @param numericValue
+     *            the numeric value of this quantity
+     * @param lowerBound
+     *            the lower bound of the numeric value of this quantity or null
+     *            if not set
+     * @param upperBound
+     *            the upper bound of the numeric value of this quantity or null
+     *            if not set
+     * @param unit
+     *            the unit of this quantity, or null if there is no
+     *            unit
+     */
+    public QuantityValueImpl(
+            BigDecimal numericValue,
+            BigDecimal lowerBound,
+            BigDecimal upperBound,
+            ItemIdValue unit) {
+        super(JSON_VALUE_TYPE_QUANTITY);
+        this.value = new JacksonInnerQuantity(numericValue, lowerBound,
+                upperBound, unit);
+    }
+	
+	/**
 	 * Constructor.
 	 *
 	 * @param numericValue
@@ -63,6 +88,7 @@ public class QuantityValueImpl extends ValueImpl implements QuantityValue {
 	 * @param unit
 	 *            the unit of this quantity, or the empty string if there is no
 	 *            unit
+	 * @deprecated supply the unit as an ItemIdValue instead
 	 */
 	public QuantityValueImpl(
 			BigDecimal numericValue,
@@ -71,7 +97,7 @@ public class QuantityValueImpl extends ValueImpl implements QuantityValue {
 			String unit) {
 		super(JSON_VALUE_TYPE_QUANTITY);
 		this.value = new JacksonInnerQuantity(numericValue, lowerBound,
-				upperBound, unit);
+				upperBound, "1".equals(unit) ? null : ItemIdValueImpl.fromIri(unit));
 	}
 
 	/**
@@ -121,12 +147,7 @@ public class QuantityValueImpl extends ValueImpl implements QuantityValue {
 	@JsonIgnore
 	@Override
 	public ItemIdValue getUnitItemId() {
-		String unit = this.value.getUnit();
-		if(unit.equals("1")) {
-			return null;
-		} else {
-			return ItemIdValueImpl.fromIri(unit);
-		}
+		return this.value.getUnitItemId();
 	}
 
 	@Override
@@ -158,11 +179,11 @@ public class QuantityValueImpl extends ValueImpl implements QuantityValue {
 		private final BigDecimal amount;
 		private final BigDecimal upperBound;
 		private final BigDecimal lowerBound;
-		private final String unit;
+		private final ItemIdValue unit;
 
 		/**
-		 * Constructor. The unit given here is a unit string as used in WDTK, with
-		 * the empty string meaning "no unit".
+		 * Constructor for JSON deserialization. The unit given here is a unit string as used in WDTK, with
+		 * the string "1" meaning "no unit".
 		 *
 		 * @param amount
 		 * 		the main value of this quantity
@@ -171,7 +192,7 @@ public class QuantityValueImpl extends ValueImpl implements QuantityValue {
 		 * @param upperBound
 		 * 		the upper bound of this quantity
 		 * @param unit
-		 * 		the unit of this string, as an IRI to the relevant entity
+		 * 		the unit of this quantity, as an IRI to the relevant entity
 		 */
 		@JsonCreator
 		JacksonInnerQuantity(
@@ -179,28 +200,40 @@ public class QuantityValueImpl extends ValueImpl implements QuantityValue {
 				@JsonProperty("lowerBound") BigDecimal lowerBound,
 				@JsonProperty("upperBound") BigDecimal upperBound,
 				@JsonProperty("unit") String unit) {
-			Validate.notNull(amount, "Numeric value cannot be null");
-			Validate.notNull(unit, "Unit cannot be null");
-			Validate.notEmpty(unit, "Unit cannot be empty. Use \"1\" for unit-less quantities.");
-
-			if(lowerBound != null || upperBound != null) {
-				Validate.notNull(lowerBound, "Lower and upper bounds should be null at the same time");
-				Validate.notNull(upperBound, "Lower and upper bounds should be null at the same time");
-
-				if (lowerBound.compareTo(amount) > 0) {
-					throw new IllegalArgumentException(
-							"Lower bound cannot be strictly greater than numeric value");
-				}
-				if (amount.compareTo(upperBound) > 0) {
-					throw new IllegalArgumentException(
-							"Upper bound cannot be strictly smaller than numeric value");
-				}
-			}
-			this.amount = amount;
-			this.upperBound = upperBound;
-			this.lowerBound = lowerBound;
-			this.unit = unit;
+		    this(amount, lowerBound, upperBound, parseUnit(unit));
 		}
+
+        protected static ItemIdValue parseUnit(String unit) {
+		    Validate.notNull(unit, "Unit cannot be null");
+            Validate.notEmpty(unit, "Unit cannot be empty. Use \"1\" for unit-less quantities.");
+            return "1".equals(unit) ? null : ItemIdValueImpl.fromIri(unit);
+        }
+		
+        JacksonInnerQuantity(
+                BigDecimal amount,
+                BigDecimal lowerBound,
+                BigDecimal upperBound,
+                ItemIdValue unit) {
+            Validate.notNull(amount, "Numeric value cannot be null");
+
+            if(lowerBound != null || upperBound != null) {
+                Validate.notNull(lowerBound, "Lower and upper bounds should be null at the same time");
+                Validate.notNull(upperBound, "Lower and upper bounds should be null at the same time");
+
+                if (lowerBound.compareTo(amount) > 0) {
+                    throw new IllegalArgumentException(
+                            "Lower bound cannot be strictly greater than numeric value");
+                }
+                if (amount.compareTo(upperBound) > 0) {
+                    throw new IllegalArgumentException(
+                            "Upper bound cannot be strictly smaller than numeric value");
+                }
+            }
+            this.amount = amount;
+            this.upperBound = upperBound;
+            this.lowerBound = lowerBound;
+            this.unit = unit;
+        }
 
 		/**
 		 * Returns the numeric value.
@@ -261,8 +294,17 @@ public class QuantityValueImpl extends ValueImpl implements QuantityValue {
 		 */
 		@JsonProperty("unit")
 		String getUnit() {
-			return this.unit;
+			return unit == null ? "1" : unit.getIri();
 		}
+		
+		/**
+		 * Returns the unit represented as an {@link ItemIdValue}.
+		 * @return
+		 */
+		@JsonIgnore
+        public ItemIdValue getUnitItemId() {
+            return unit;
+        }
 
 		/**
 		 * Formats the string output with a leading signum as JSON expects it.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/QuantityValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/QuantityValueImpl.java
@@ -302,9 +302,9 @@ public class QuantityValueImpl extends ValueImpl implements QuantityValue {
 		 * @return
 		 */
 		@JsonIgnore
-        public ItemIdValue getUnitItemId() {
-            return unit;
-        }
+		public ItemIdValue getUnitItemId() {
+		    return unit;
+		}
 
 		/**
 		 * Formats the string output with a leading signum as JSON expects it.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DataObjectFactory.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DataObjectFactory.java
@@ -238,8 +238,22 @@ public interface DataObjectFactory {
 	 *            the unit of this quantity, or the empty string if there is no
 	 *            unit
 	 * @return a {@link QuantityValue} corresponding to the input
+	 * @deprecated use {@link #getQuantityValue(BigDecimal, ItemIdValue)}
 	 */
+	@Deprecated
 	QuantityValue getQuantityValue(BigDecimal numericValue, String unit);
+	
+	/**
+     * Creates a {@link QuantityValue} without bounds.
+     *
+     * @param numericValue
+     *            the numeric value of this quantity
+     * @param unit
+     *            the unit of this quantity, or null if there is no
+     *            unit
+     * @return a {@link QuantityValue} corresponding to the input
+     */
+    QuantityValue getQuantityValue(BigDecimal numericValue, ItemIdValue unit);
 
 	/**
 	 * Creates a {@link QuantityValue}.
@@ -254,9 +268,27 @@ public interface DataObjectFactory {
 	 *            the unit of this quantity, or the empty string if there is no
 	 *            unit
 	 * @return a {@link QuantityValue} corresponding to the input
+	 * @deprecated use {@link #getQuantityValue(BigDecimal, BigDecimal, BigDecimal, ItemIdValue)}
 	 */
 	QuantityValue getQuantityValue(BigDecimal numericValue,
 			BigDecimal lowerBound, BigDecimal upperBound, String unit);
+	
+	/**
+     * Creates a {@link QuantityValue}.
+     *
+     * @param numericValue
+     *            the numeric value of this quantity
+     * @param lowerBound
+     *            the lower bound of the numeric value of this quantity
+     * @param upperBound
+     *            the upper bound of the numeric value of this quantity
+     * @param unit
+     *            the unit of this quantity, or null if there is no
+     *            unit
+     * @return a {@link QuantityValue} corresponding to the input
+     */
+    QuantityValue getQuantityValue(BigDecimal numericValue,
+            BigDecimal lowerBound, BigDecimal upperBound, ItemIdValue unit);
 
 	/**
 	 * Creates a {@link ValueSnak}.

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImplTest.java
@@ -147,8 +147,9 @@ public class DataObjectFactoryImplTest {
 		BigDecimal nv = new BigDecimal("0.123456789012345678901234567890123456789");
 		BigDecimal lb = new BigDecimal("0.123456789012345678901234567890123456788");
 		BigDecimal ub = new BigDecimal("0.123456789012345678901234567890123456790");
-		QuantityValue o1 = new QuantityValueImpl(nv, lb, ub, "unit");
-		QuantityValue o2 = factory.getQuantityValue(nv, lb, ub, "unit");
+		ItemIdValue unit = ItemIdValueImpl.fromIri("http://wikidata.org/entity/Q123");
+		QuantityValue o1 = new QuantityValueImpl(nv, lb, ub, unit);
+		QuantityValue o2 = factory.getQuantityValue(nv, lb, ub, unit);
 		assertEquals(o1, o2);
 	}
 
@@ -160,7 +161,7 @@ public class DataObjectFactoryImplTest {
 				"0.123456789012345678901234567890123456788");
 		BigDecimal ub = new BigDecimal(
 				"0.123456789012345678901234567890123456790");
-		QuantityValue o1 = new QuantityValueImpl(nv, lb, ub, "1");
+		QuantityValue o1 = new QuantityValueImpl(nv, lb, ub, (ItemIdValue)null);
 		QuantityValue o2 = factory.getQuantityValue(nv, lb, ub);
 		assertEquals(o1, o2);
 	}
@@ -169,8 +170,9 @@ public class DataObjectFactoryImplTest {
 	public final void testGetQuantityValueNoBounds() {
 		BigDecimal nv = new BigDecimal(
 				"0.123456789012345678901234567890123456789");
-		QuantityValue o1 = new QuantityValueImpl(nv, null, null, "unit");
-		QuantityValue o2 = factory.getQuantityValue(nv, "unit");
+		ItemIdValue unit = ItemIdValueImpl.fromIri("http://wikidata.org/entity/Q2334");
+		QuantityValue o1 = new QuantityValueImpl(nv, null, null, unit);
+		QuantityValue o2 = factory.getQuantityValue(nv, unit);
 		assertEquals(o1, o2);
 	}
 
@@ -178,7 +180,7 @@ public class DataObjectFactoryImplTest {
 	public final void testGetQuantityValueNoBoundsAndUnits() {
 		BigDecimal nv = new BigDecimal(
 				"0.123456789012345678901234567890123456789");
-		QuantityValue o1 = new QuantityValueImpl(nv, null, null, "1");
+		QuantityValue o1 = new QuantityValueImpl(nv, null, null, (ItemIdValue)null);
 		QuantityValue o2 = factory.getQuantityValue(nv);
 		assertEquals(o1, o2);
 	}


### PR DESCRIPTION
Closes #580.
Replacement for #582.