### PR TITLE
Add support for file uploads to ApiConnection.

### DIFF
--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/MockBasicApiConnection.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/MockBasicApiConnection.java
@@ -21,12 +21,14 @@ package org.wikidata.wdtk.wikibaseapi;
  */
 
 import java.io.ByteArrayInputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wikidata.wdtk.testing.MockStringContentFactory;
@@ -100,7 +102,9 @@ public class MockBasicApiConnection extends BasicApiConnection {
 
 	@Override
 	public InputStream sendRequest(String requestMethod,
-			Map<String, String> parameters) throws IOException {
+			Map<String, String> parameters,
+			Map<String, ImmutablePair<String, File>> files) throws IOException {
+		// files parameter purposely ignored because we do not support mocking that yet
 		if (this.webResources.containsKey(parameters.hashCode())) {
 			return new ByteArrayInputStream(this.webResources.get(parameters
 					.hashCode()));


### PR DESCRIPTION
Closes #638.

This makes the ApiConnection classes reusable to perform API calls which require uploading a file. Adding an actual wrapper on top of those actions is out of scope for WDTK, but this makes it possible for users to implement that on their side, without having to hack the user credentials out of the ApiConnection object.