### PR TITLE
Fixup: content-type of POST requests with files

### DIFF
--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/ApiConnection.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/ApiConnection.java
@@ -169,7 +169,7 @@ public abstract class ApiConnection {
 	}
 
 	/**
-	 * Subclasses can customized their own {@link OkHttpClient.Builder} instances.
+	 * Subclasses can customize their own {@link OkHttpClient.Builder} instances.
 	 *
 	 * An example:
 	 * <pre>

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/ApiConnection.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/ApiConnection.java
@@ -434,12 +434,14 @@ public abstract class ApiConnection {
 		} else if ("POST".equalsIgnoreCase(requestMethod)) {
 			RequestBody body;
 			if (files != null && !files.isEmpty()) {
+				MediaType formDataMediaType = MediaType.parse("multipart/form-data");
 				MultipartBody.Builder builder = new MultipartBody.Builder();
+				builder.setType(formDataMediaType);
 				parameters.entrySet().stream()
 					.forEach(entry -> builder.addFormDataPart(entry.getKey(), entry.getValue()));
 				files.entrySet().stream()
 					.forEach(entry -> builder.addFormDataPart(entry.getKey(), entry.getValue().getLeft(),
-							RequestBody.create(MediaType.parse("application/octet-stream"),entry.getValue().getRight())));
+							RequestBody.create(formDataMediaType,entry.getValue().getRight())));
 				body = builder.build();
 			} else {
 				body = RequestBody.create(queryString, URLENCODED_MEDIA_TYPE);

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnectionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnectionTest.java
@@ -103,7 +103,8 @@ public class BasicApiConnectionTest {
 					String requestBody = request.getBody().readUtf8();
 					// in the case of file uploads, the string representation of the request body is not stable
 					// so we only check that some file was uploaded (for testPostFile)
-					if (requestBody.contains("Content-Disposition: form-data; name=\"file\"; filename=\"hello.txt\"")) {
+					if (requestBody.contains("Content-Disposition: form-data; name=\"file\"; filename=\"hello.txt\"") &&
+							requestBody.contains("multipart/form-data")) {
 						return new MockResponse()
 								.setHeader("Content-Type", "application/json; charset=utf-8")
 								.setBody("{\"success\":\"true\"}");


### PR DESCRIPTION
With more testing I discovered that it is  important that the content disposition of the POST data is `multipart/form-data`, and not `multipart/mixed`, when uploading files to a MediaWiki API endpoint.