### PR TITLE
Add test for SiteLinkImpl.getSiteKey and MonolingualTextValueImpl$JacksonInnerMonolingualText.getLanguage

### DIFF
--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverterTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverterTest.java
@@ -27,19 +27,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.wikidata.wdtk.datamodel.implementation.DataObjectFactoryImpl;
-import org.wikidata.wdtk.datamodel.implementation.GlobeCoordinatesValueImpl;
-import org.wikidata.wdtk.datamodel.implementation.ItemIdValueImpl;
-import org.wikidata.wdtk.datamodel.implementation.MonolingualTextValueImpl;
-import org.wikidata.wdtk.datamodel.implementation.PropertyIdValueImpl;
-import org.wikidata.wdtk.datamodel.implementation.QuantityValueImpl;
-import org.wikidata.wdtk.datamodel.implementation.SnakGroupImpl;
-import org.wikidata.wdtk.datamodel.implementation.StatementGroupImpl;
-import org.wikidata.wdtk.datamodel.implementation.StatementImpl;
-import org.wikidata.wdtk.datamodel.implementation.StringValueImpl;
-import org.wikidata.wdtk.datamodel.implementation.TimeValueImpl;
-import org.wikidata.wdtk.datamodel.implementation.ValueSnakImpl;
+import org.wikidata.wdtk.datamodel.implementation.*;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
 import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
@@ -225,7 +215,19 @@ public class DatamodelConverterTest {
 		DatamodelConverter converter = new DatamodelConverter(new DataObjectFactoryImpl());
 		assertEquals(item, converter.copy(item));
 	}
-	
+
+	@Test
+	public void testGetJsonId() throws Exception {
+		ItemDocument item = Datamodel.makeItemDocument(
+				Datamodel.makeWikidataItemIdValue("Q42"),
+				Collections.singletonList(Datamodel.makeMonolingualTextValue("en", "label")),
+				Collections.singletonList(Datamodel.makeMonolingualTextValue("en", "desc")),
+				Collections.singletonList(Datamodel.makeMonolingualTextValue("en", "alias")),
+				Collections.emptyList(),
+				Collections.singletonMap("enwiki", Datamodel.makeSiteLink("foo", "enwiki", Collections.emptyList())));
+		DatamodelConverter converter = new DatamodelConverter(new DataObjectFactoryImpl());
+		Assertions.assertEquals("Q42", ((ItemDocumentImpl) (item)).getJsonId());
+	}
 	
     @Test
     public void testCopyMediaInfoIdValue() {

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverterTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverterTest.java
@@ -27,9 +27,19 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-import org.wikidata.wdtk.datamodel.implementation.*;
+import org.wikidata.wdtk.datamodel.implementation.DataObjectFactoryImpl;
+import org.wikidata.wdtk.datamodel.implementation.GlobeCoordinatesValueImpl;
+import org.wikidata.wdtk.datamodel.implementation.ItemIdValueImpl;
+import org.wikidata.wdtk.datamodel.implementation.MonolingualTextValueImpl;
+import org.wikidata.wdtk.datamodel.implementation.PropertyIdValueImpl;
+import org.wikidata.wdtk.datamodel.implementation.QuantityValueImpl;
+import org.wikidata.wdtk.datamodel.implementation.SnakGroupImpl;
+import org.wikidata.wdtk.datamodel.implementation.StatementGroupImpl;
+import org.wikidata.wdtk.datamodel.implementation.StatementImpl;
+import org.wikidata.wdtk.datamodel.implementation.StringValueImpl;
+import org.wikidata.wdtk.datamodel.implementation.TimeValueImpl;
+import org.wikidata.wdtk.datamodel.implementation.ValueSnakImpl;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
 import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
@@ -215,6 +225,7 @@ public class DatamodelConverterTest {
 		DatamodelConverter converter = new DatamodelConverter(new DataObjectFactoryImpl());
 		assertEquals(item, converter.copy(item));
 	}
+	
 	
     @Test
     public void testCopyMediaInfoIdValue() {

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverterTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverterTest.java
@@ -215,19 +215,6 @@ public class DatamodelConverterTest {
 		DatamodelConverter converter = new DatamodelConverter(new DataObjectFactoryImpl());
 		assertEquals(item, converter.copy(item));
 	}
-
-	@Test
-	public void testGetJsonId() throws Exception {
-		ItemDocument item = Datamodel.makeItemDocument(
-				Datamodel.makeWikidataItemIdValue("Q42"),
-				Collections.singletonList(Datamodel.makeMonolingualTextValue("en", "label")),
-				Collections.singletonList(Datamodel.makeMonolingualTextValue("en", "desc")),
-				Collections.singletonList(Datamodel.makeMonolingualTextValue("en", "alias")),
-				Collections.emptyList(),
-				Collections.singletonMap("enwiki", Datamodel.makeSiteLink("foo", "enwiki", Collections.emptyList())));
-		DatamodelConverter converter = new DatamodelConverter(new DataObjectFactoryImpl());
-		Assertions.assertEquals("Q42", ((ItemDocumentImpl) (item)).getJsonId());
-	}
 	
     @Test
     public void testCopyMediaInfoIdValue() {

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImplTest.java
@@ -415,4 +415,16 @@ public class ItemDocumentImplTest {
 		);
 	}
 
+	@Test
+	public void testGetJsonId() throws Exception {
+		ItemDocument item = Datamodel.makeItemDocument(
+				Datamodel.makeWikidataItemIdValue("Q42"),
+				Collections.singletonList(Datamodel.makeMonolingualTextValue("en", "label")),
+				Collections.singletonList(Datamodel.makeMonolingualTextValue("en", "desc")),
+				Collections.singletonList(Datamodel.makeMonolingualTextValue("en", "alias")),
+				Collections.emptyList(),
+				Collections.singletonMap("enwiki", Datamodel.makeSiteLink("foo", "enwiki", Collections.emptyList())));
+		assertEquals("Q42", ((ItemDocumentImpl) (item)).getJsonId());
+	}
+
 }


### PR DESCRIPTION
Hey 😊
I want to contribute the following test:

Test that `item.getJsonId()` is equal to `"Q42"`.
This tests the methods [`SiteLinkImpl.getSiteKey`](https://github.com/Wikidata/Wikidata-Toolkit/blob/544ca6e4e8dbdf7e9102592ce4dec11d0e6030d3/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SiteLinkImpl.java#L117) and [`MonolingualTextValueImpl$JacksonInnerMonolingualText.getLanguage`](https://github.com/Wikidata/Wikidata-Toolkit/blob/544ca6e4e8dbdf7e9102592ce4dec11d0e6030d3/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/MonolingualTextValueImpl.java#L153).
This test is based on the test [`testGenerationFromOtherItemDocument`](https://github.com/lacinoire/Wikidata-Toolkit/blob/544ca6e4e8dbdf7e9102592ce4dec11d0e6030d3/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverterTest.java#L215).

Curious to hear what you think!

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))