### PR TITLE
Revert "Upgraded to JUnit5 (#536)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,20 +76,20 @@
 		<apacheCommonsLangVersion>3.12.0</apacheCommonsLangVersion>
 		<apacheCommonsIOVersion>2.11.0</apacheCommonsIOVersion>
 		<jacksonVersion>2.13.3</jacksonVersion>
-		<junitVersion>5.8.2</junitVersion>
+		<junitVersion>4.13.1</junitVersion>
 		<hamcrestVersion>2.2</hamcrestVersion>
 		<mockitoVersion>4.6.1</mockitoVersion>
 		<rdf4jVersion>3.7.7</rdf4jVersion>
 		<slf4jVersion>1.7.36</slf4jVersion>
 		<threetenVersion>1.7.0</threetenVersion>
 		<okhttpSignpostVersion>1.1.0</okhttpSignpostVersion>
-		<okhttpVersion>5.0.0-alpha.8</okhttpVersion>
+		<okhttpVersion>4.2.2</okhttpVersion>
 	</properties>
 
 	<dependencies>
 		<dependency>
-			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter</artifactId>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
 			<version>${junitVersion}</version>
 			<scope>test</scope>
 		</dependency>
@@ -121,11 +121,6 @@
 	<build>
 		<pluginManagement>
 			<plugins>
-				<plugin>
-					<!-- Older surefire versions did not support JUnit 5. -->
-					<artifactId>maven-surefire-plugin</artifactId>
-					<version>2.22.2</version>
-				</plugin>
 				<plugin>
 					<groupId>org.codehaus.mojo</groupId>
 					<artifactId>license-maven-plugin</artifactId>

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/AliasUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/AliasUpdateBuilderTest.java
@@ -24,13 +24,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverterTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverterTest.java
@@ -20,14 +20,14 @@
 
 package org.wikidata.wdtk.datamodel.helpers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.*;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.implementation.DataObjectFactoryImpl;
 import org.wikidata.wdtk.datamodel.implementation.GlobeCoordinatesValueImpl;
 import org.wikidata.wdtk.datamodel.implementation.ItemIdValueImpl;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelFilterTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelFilterTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.helpers;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,36 +20,13 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.helpers;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.implementation.DataObjectFactoryImpl;
-import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.DocumentDataFilter;
-import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
-import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.LexemeDocument;
-import org.wikidata.wdtk.datamodel.interfaces.LexemeIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.MediaInfoDocument;
-import org.wikidata.wdtk.datamodel.interfaces.MediaInfoIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.SenseIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
-import org.wikidata.wdtk.datamodel.interfaces.Statement;
-import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
-import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
+import org.wikidata.wdtk.datamodel.interfaces.*;
+
+import java.util.*;
+
+import static org.junit.Assert.assertEquals;
 
 public class DatamodelFilterTest {
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatamodelTest.java
@@ -20,12 +20,12 @@
 
 package org.wikidata.wdtk.datamodel.helpers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
 import java.util.Collections;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.implementation.DataObjectFactoryImpl;
 import org.wikidata.wdtk.datamodel.interfaces.Claim;
 import org.wikidata.wdtk.datamodel.interfaces.DataObjectFactory;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatatypeConvertersTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/DatatypeConvertersTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.helpers;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,13 +20,11 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.helpers;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.TimeValue;
 
 public class DatatypeConvertersTest {

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/EntityUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/EntityUpdateBuilderTest.java
@@ -22,14 +22,11 @@ package org.wikidata.wdtk.datamodel.helpers;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.*;
 
 import java.util.Collections;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
 import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
@@ -78,7 +75,7 @@ public class EntityUpdateBuilderTest {
 		assertEquals(0, builder.getBaseRevisionId());
 	}
 
-	@Test
+    @Test
 	public void testForBaseRevisionId() {
 		EntityUpdateBuilder builder = EntityUpdateBuilder.forBaseRevisionId(Q1, 123);
 		assertEquals(Q1, builder.getEntityId());

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/FormUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/FormUpdateBuilderTest.java
@@ -23,13 +23,11 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.*;
 
 import java.util.Arrays;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
 import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.FormUpdate;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/ItemDocumentBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/ItemDocumentBuilderTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.helpers;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,16 +20,13 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.helpers;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
@@ -43,7 +42,7 @@ public class ItemDocumentBuilderTest {
 	Statement s2;
 	Statement s1;
 	
-	@BeforeEach
+	@Before
 	public void setUp() {
 		i = ItemIdValue.NULL;
 		s1 = StatementBuilder.forSubjectAndProperty(i,
@@ -136,16 +135,15 @@ public class ItemDocumentBuilderTest {
 		assertEquals("pleutre", copy.findLabel("fr"));
 	}
 	
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testInvalidChangeOfSubjectId() {
-		ItemDocumentBuilder builder = ItemDocumentBuilder.forItemId(ItemIdValue.NULL).withRevisionId(1234);
-		assertThrows(IllegalArgumentException.class, () -> builder.withEntityId(PropertyIdValue.NULL));
+		ItemDocumentBuilder.forItemId(ItemIdValue.NULL).withRevisionId(1234).withEntityId(PropertyIdValue.NULL);
 	}
 
-	@Test
+	@Test(expected = IllegalStateException.class)
 	public void testDoubleBuild() {
 		ItemDocumentBuilder b = ItemDocumentBuilder.forItemId(ItemIdValue.NULL);
 		b.build();
-		assertThrows(IllegalStateException.class, () -> b.build());
+		b.build();
 	}
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/ItemUpdateBuilderTest.java
@@ -24,10 +24,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.*;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ItemUpdate;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/JsonDeserializerTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/JsonDeserializerTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.helpers;
+
 /*-
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,17 +20,14 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.helpers;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 
 import org.apache.commons.io.IOUtils;
-import org.junit.jupiter.api.Test;
+import org.junit.Assert;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.LexemeDocument;
@@ -50,31 +49,31 @@ public class JsonDeserializerTest {
 	@Test
 	public void testLoadItemDocument() throws IOException {
 		ItemDocument doc = SUT.deserializeItemDocument(loadJson("item.json"));
-		assertEquals(doc.getEntityId(), Datamodel.makeWikidataItemIdValue("Q34987"));
+		Assert.assertEquals(doc.getEntityId(), Datamodel.makeWikidataItemIdValue("Q34987"));
 	}
 	
 	@Test
 	public void testLoadPropertyDocument() throws IOException {
 		PropertyDocument doc = SUT.deserializePropertyDocument(loadJson("property.json"));
-		assertEquals(doc.getEntityId(), Datamodel.makeWikidataPropertyIdValue("P3467"));
+		Assert.assertEquals(doc.getEntityId(), Datamodel.makeWikidataPropertyIdValue("P3467"));
 	}
 	
 	@Test
 	public void testLoadLexemeDocument() throws IOException {
 		LexemeDocument doc = SUT.deserializeLexemeDocument(loadJson("lexeme.json"));
-		assertEquals(doc.getEntityId(), Datamodel.makeWikidataLexemeIdValue("L3872"));
-		assertEquals(doc.getForm(Datamodel.makeWikidataFormIdValue("L3872-F2")).getStatementGroups(), Collections.emptyList());
+		Assert.assertEquals(doc.getEntityId(), Datamodel.makeWikidataLexemeIdValue("L3872"));
+		Assert.assertEquals(doc.getForm(Datamodel.makeWikidataFormIdValue("L3872-F2")).getStatementGroups(), Collections.emptyList());
 	}
 	
 	@Test
 	public void testLoadMediaInfoDocument() throws IOException {
 		MediaInfoDocument doc = SUTcommons.deserializeMediaInfoDocument(loadJson("mediainfo.json"));
-		assertEquals(doc.getEntityId(), Datamodel.makeWikimediaCommonsMediaInfoIdValue("M74698470"));
+		Assert.assertEquals(doc.getEntityId(), Datamodel.makeWikimediaCommonsMediaInfoIdValue("M74698470"));
 	}
 	
 	@Test
 	public void testDeserializeEntityDocument() throws IOException {
 		EntityDocument doc = SUT.deserializeEntityDocument(loadJson("property.json"));
-		assertEquals(doc.getEntityId(), Datamodel.makeWikidataPropertyIdValue("P3467"));
+		Assert.assertEquals(doc.getEntityId(), Datamodel.makeWikidataPropertyIdValue("P3467"));
 	}
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/JsonSerializerTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/JsonSerializerTest.java
@@ -20,8 +20,7 @@
 
 package org.wikidata.wdtk.datamodel.helpers;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.*;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -32,7 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.implementation.EntityDocumentImpl;
 import org.wikidata.wdtk.datamodel.implementation.JsonComparator;
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LabeledDocumentUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LabeledDocumentUpdateBuilderTest.java
@@ -24,10 +24,10 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.LabeledDocumentUpdate;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilderTest.java
@@ -24,14 +24,14 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
 import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.FormUpdate;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/MediaInfoUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/MediaInfoUpdateBuilderTest.java
@@ -21,10 +21,10 @@ package org.wikidata.wdtk.datamodel.helpers;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoDocument;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoUpdate;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/PropertyDocumentBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/PropertyDocumentBuilderTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.helpers;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,14 +20,11 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.helpers;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Collections;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
@@ -76,9 +75,8 @@ public class PropertyDocumentBuilderTest {
 		assertEquals(withAlias.getAliases().get("en"), Collections.singletonList(alias));
 	}
 	
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testInvalidSubjectId() {
-		PropertyDocumentBuilder builder = PropertyDocumentBuilder.forPropertyIdAndDatatype(PropertyIdValue.NULL, DatatypeIdValue.DT_EXTERNAL_ID);
-		assertThrows(IllegalArgumentException.class, () -> builder.withEntityId(ItemIdValue.NULL));
+		PropertyDocumentBuilder.forPropertyIdAndDatatype(PropertyIdValue.NULL, DatatypeIdValue.DT_EXTERNAL_ID).withEntityId(ItemIdValue.NULL);
 	}
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/PropertyUpdateBuilderTest.java
@@ -21,10 +21,10 @@ package org.wikidata.wdtk.datamodel.helpers;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/ReferenceBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/ReferenceBuilderTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.helpers;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,14 +20,12 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.helpers;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.Reference;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/SenseUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/SenseUpdateBuilderTest.java
@@ -23,10 +23,10 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.SenseDocument;
 import org.wikidata.wdtk.datamodel.interfaces.SenseIdValue;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementBuilderTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.helpers;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,14 +20,12 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.helpers;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.Reference;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.helpers;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,18 +20,13 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.helpers;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
+
+import static org.junit.Assert.*;
 
 public class StatementDocumentTest {
 	private static ItemIdValue Q1 = Datamodel.makeWikidataItemIdValue("Q1");

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementDocumentUpdateBuilderTest.java
@@ -24,10 +24,10 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
 import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/StatementUpdateBuilderTest.java
@@ -24,13 +24,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/TermUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/TermUpdateBuilderTest.java
@@ -24,12 +24,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.TermUpdate;
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/TermedDocumentUpdateBuilderTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/TermedDocumentUpdateBuilderTest.java
@@ -24,13 +24,13 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/AliasUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/AliasUpdateImplTest.java
@@ -23,10 +23,10 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.producesJson;
 
 import java.util.ArrayList;
@@ -35,7 +35,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.AliasUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ClaimImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ClaimImplTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,20 +20,14 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.Claim;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
@@ -56,19 +52,19 @@ public class ClaimImplTest {
 		assertEquals(c1.getQualifiers(), Collections.emptyList());
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void subjectNotNull() {
-		assertThrows(NullPointerException.class, () -> new ClaimImpl(null, mainSnak, Collections.emptyList()));
+		new ClaimImpl(null, mainSnak, Collections.emptyList());
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void mainSnakNotNull() {
-		assertThrows(NullPointerException.class, () -> new ClaimImpl(subject, null, Collections.emptyList()));
+		new ClaimImpl(subject, null, Collections.emptyList());
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void qualifiersNotNull() {
-		assertThrows(NullPointerException.class, () -> new ClaimImpl(subject, mainSnak, null));
+		new ClaimImpl(subject, mainSnak, null);
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImplTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,40 +20,13 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
 import java.util.Collections;
 
-import org.junit.jupiter.api.Test;
-import org.wikidata.wdtk.datamodel.interfaces.Claim;
-import org.wikidata.wdtk.datamodel.interfaces.DataObjectFactory;
-import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.GlobeCoordinatesValue;
-import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
-import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.LexemeIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.MediaInfoIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
-import org.wikidata.wdtk.datamodel.interfaces.NoValueSnak;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.QuantityValue;
-import org.wikidata.wdtk.datamodel.interfaces.Reference;
-import org.wikidata.wdtk.datamodel.interfaces.SenseIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
-import org.wikidata.wdtk.datamodel.interfaces.Snak;
-import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
-import org.wikidata.wdtk.datamodel.interfaces.SomeValueSnak;
-import org.wikidata.wdtk.datamodel.interfaces.Statement;
-import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
-import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
-import org.wikidata.wdtk.datamodel.interfaces.StringValue;
-import org.wikidata.wdtk.datamodel.interfaces.TimeValue;
-import org.wikidata.wdtk.datamodel.interfaces.ValueSnak;
+import org.junit.Test;
+import org.wikidata.wdtk.datamodel.interfaces.*;
 
 public class DataObjectFactoryImplTest {
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/DatatypeIdImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/DatatypeIdImplTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,13 +20,9 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
+import static org.junit.Assert.*;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
 
 public class DatatypeIdImplTest {
@@ -33,9 +31,9 @@ public class DatatypeIdImplTest {
 	private final DatatypeIdImpl d2 = new DatatypeIdImpl("http://wikiba.se/ontology#WikibaseItem");
 	private final DatatypeIdImpl d3 = new DatatypeIdImpl(DatatypeIdValue.DT_TIME);
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void datatypeIdNotNull() {
-		assertThrows(NullPointerException.class, () -> new DatatypeIdImpl((String) null));
+		new DatatypeIdImpl((String) null);
 	}
 
 	@Test
@@ -136,9 +134,9 @@ public class DatatypeIdImplTest {
 				DatatypeIdValue.DT_MONOLINGUAL_TEXT);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testIriForInvalidType() {
-		assertThrows(IllegalArgumentException.class, () -> DatatypeIdImpl.getDatatypeIriFromJsonDatatype("some wrong type"))	;
+		DatatypeIdImpl.getDatatypeIriFromJsonDatatype("some wrong type");
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/EntityIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/EntityIdValueImplTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,12 +20,9 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
+import org.junit.Test;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import org.junit.jupiter.api.Test;
+import static org.junit.Assert.assertEquals;
 
 public class EntityIdValueImplTest {
 
@@ -57,9 +56,9 @@ public class EntityIdValueImplTest {
 		assertEquals(new MediaInfoIdValueImpl("M42", "http://foo/"), EntityIdValueImpl.fromId("M42", "http://foo/"));
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testFromIdFailure() {
-		assertThrows(IllegalArgumentException.class, () -> EntityIdValueImpl.fromId("L42-P1", "http://foo/"));
+		EntityIdValueImpl.fromId("L42-P1", "http://foo/");
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/EntityRedirectDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/EntityRedirectDocumentImplTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,21 +20,17 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import java.io.IOException;
-
-import org.junit.jupiter.api.Test;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.EntityRedirectDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class EntityRedirectDocumentImplTest {
 
@@ -76,19 +74,19 @@ public class EntityRedirectDocumentImplTest {
 		assertEquals(itemRedirect.hashCode(), itemRedirect2.hashCode());
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void idNotNull() {
-		assertThrows(NullPointerException.class, () -> new EntityRedirectDocumentImpl(null, targetItemId, 0));
+		new EntityRedirectDocumentImpl(null, targetItemId, 0);
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void targetNotNull() {
-		assertThrows(NullPointerException.class, () -> new EntityRedirectDocumentImpl(entityItemId, null, 0));
+		new EntityRedirectDocumentImpl(entityItemId, null, 0);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void entityTypeEquality() {
-		assertThrows(IllegalArgumentException.class, () -> new EntityRedirectDocumentImpl(entityItemId, new LexemeIdValueImpl("L1", "http://example.com/entity/"), 0));
+		new EntityRedirectDocumentImpl(entityItemId, new LexemeIdValueImpl("L1", "http://example.com/entity/"), 0);
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/EntityUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/EntityUpdateImplTest.java
@@ -19,14 +19,14 @@
  */
 package org.wikidata.wdtk.datamodel.implementation;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.interfaces.EntityUpdate;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/FormDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/FormDocumentImplTest.java
@@ -1,3 +1,31 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import org.junit.Test;
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
+import org.wikidata.wdtk.datamodel.interfaces.Claim;
+import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
+import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
+import org.wikidata.wdtk.datamodel.interfaces.Statement;
+import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
+import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -17,35 +45,6 @@
  * limitations under the License.
  * #L%
  */
-
-package org.wikidata.wdtk.datamodel.implementation;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.List;
-
-import org.junit.jupiter.api.Test;
-import org.wikidata.wdtk.datamodel.helpers.Datamodel;
-import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
-import org.wikidata.wdtk.datamodel.interfaces.Claim;
-import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
-import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
-import org.wikidata.wdtk.datamodel.interfaces.Statement;
-import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
-import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -113,9 +112,9 @@ public class FormDocumentImplTest {
 		assertEquals(fd1.hashCode(), fd2.hashCode());
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void idNotNull() {
-		assertThrows(NullPointerException.class, () -> new FormDocumentImpl(null, repList, gramFeatures, statementGroups, 1234));
+		new FormDocumentImpl(null, repList, gramFeatures, statementGroups, 1234);
 	}
 
 	@Test
@@ -140,9 +139,9 @@ public class FormDocumentImplTest {
 		assertTrue(doc.getStatementGroups().isEmpty());
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void statementGroupsUseSameSubject() {
-		FormIdValue iid2 = new FormIdValueImpl("L23-F5", "http://example.org/");
+		FormIdValue iid2 = new FormIdValueImpl("Q23", "http://example.org/");
 		Statement s2 = new StatementImpl("MyId", StatementRank.NORMAL,
 				new SomeValueSnakImpl(new PropertyIdValueImpl("P42", "http://wikibase.org/entity/")),
 				Collections.emptyList(),  Collections.emptyList(), iid2);
@@ -152,7 +151,7 @@ public class FormDocumentImplTest {
 		statementGroups2.add(statementGroups.get(0));
 		statementGroups2.add(sg2);
 
-		assertThrows(IllegalArgumentException.class, () -> new FormDocumentImpl(fid, repList, gramFeatures, statementGroups2, 1234));
+		new FormDocumentImpl(fid, repList, gramFeatures, statementGroups2, 1234);
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/FormIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/FormIdValueImplTest.java
@@ -1,3 +1,7 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
+import static org.junit.Assert.*;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,21 +22,16 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 
-import org.junit.jupiter.api.Test;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 
 public class FormIdValueImplTest {
 
@@ -81,34 +80,34 @@ public class FormIdValueImplTest {
 		assertEquals(form1.hashCode(), form2.hashCode());
 	}
 
-	@Test
+	@Test(expected = RuntimeException.class)
 	public void idValidatedForFirstLetter() {
-		assertThrows(RuntimeException.class, () -> new FormIdValueImpl("Q12345", "http://www.wikidata.org/entity/"));
+		new FormIdValueImpl("Q12345", "http://www.wikidata.org/entity/");
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void idValidatedForNumber() {
-		assertThrows(IllegalArgumentException.class, () -> new FormIdValueImpl("L34d23", "http://www.wikidata.org/entity/"));
+		new FormIdValueImpl("L34d23", "http://www.wikidata.org/entity/");
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void idValidatedForLength() {
-		assertThrows(IllegalArgumentException.class, () -> new FormIdValueImpl("L", "http://www.wikidata.org/entity/"));
+		new FormIdValueImpl("L", "http://www.wikidata.org/entity/");
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void idValidatedForParts() {
-		assertThrows(IllegalArgumentException.class, () -> new FormIdValueImpl("L21", "http://www.wikidata.org/entity/"));
+		new FormIdValueImpl("L21", "http://www.wikidata.org/entity/");
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void idNotNull() {
-		assertThrows(IllegalArgumentException.class, () -> new FormIdValueImpl((String)null, "http://www.wikidata.org/entity/"));
+		new FormIdValueImpl((String)null, "http://www.wikidata.org/entity/");
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void baseIriNotNull() {
-		assertThrows(IllegalArgumentException.class, () -> new FormIdValueImpl("L42", null));
+		new FormIdValueImpl("L42", null);
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/FormUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/FormUpdateImplTest.java
@@ -22,11 +22,11 @@ package org.wikidata.wdtk.datamodel.implementation;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.producesJson;
 import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.toJson;
 
@@ -36,7 +36,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.FormUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/GlobeCoordinatesValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/GlobeCoordinatesValueImplTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,20 +20,14 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.IOException;
-
-import org.junit.jupiter.api.Test;
-import org.wikidata.wdtk.datamodel.interfaces.GlobeCoordinatesValue;
+import static org.junit.Assert.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.wikidata.wdtk.datamodel.interfaces.GlobeCoordinatesValue;
+
+import java.io.IOException;
 
 public class GlobeCoordinatesValueImplTest {
 
@@ -63,9 +59,9 @@ public class GlobeCoordinatesValueImplTest {
 		assertEquals(new ItemIdValueImpl("Q2", "http://www.wikidata.org/entity/"), c1.getGlobeItemId());
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void getGlobeItemIdInvalidIri() {
-		assertThrows(IllegalArgumentException.class, () -> c3.getGlobeItemId());
+		c3.getGlobeItemId();
 	}
 
 	@Test
@@ -98,10 +94,10 @@ public class GlobeCoordinatesValueImplTest {
 		assertEquals(c1.hashCode(), c2.hashCode());
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void globeNotNull() {
-		assertThrows(NullPointerException.class, () -> new GlobeCoordinatesValueImpl(12.3, 14.1,
-				GlobeCoordinatesValue.PREC_DEGREE, null));
+		new GlobeCoordinatesValueImpl(12.3, 14.1,
+				GlobeCoordinatesValue.PREC_DEGREE, null);
 	}
 
 	@Test
@@ -111,32 +107,32 @@ public class GlobeCoordinatesValueImplTest {
 		assertTrue(v.getPrecision() > 0.);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void latitudeWithinUpperRange() {
-		assertThrows(IllegalArgumentException.class, () -> new GlobeCoordinatesValueImpl(91.0, 270.0,
+		new GlobeCoordinatesValueImpl(91.0, 270.0,
 				GlobeCoordinatesValue.PREC_DEGREE,
-				GlobeCoordinatesValue.GLOBE_EARTH));
+				GlobeCoordinatesValue.GLOBE_EARTH);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void latitudeWithinLowerRange() {
-		assertThrows(IllegalArgumentException.class, () -> new GlobeCoordinatesValueImpl(-91.0, 270.0,
+		new GlobeCoordinatesValueImpl(-91.0, 270.0,
 				GlobeCoordinatesValue.PREC_DEGREE,
-				GlobeCoordinatesValue.GLOBE_EARTH));
+				GlobeCoordinatesValue.GLOBE_EARTH);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void longitudeWithinUpperRange() {
-		assertThrows(IllegalArgumentException.class, () -> new GlobeCoordinatesValueImpl(45.0, 500.0,
+		new GlobeCoordinatesValueImpl(45.0, 500.0,
 				GlobeCoordinatesValue.PREC_DEGREE,
-				GlobeCoordinatesValue.GLOBE_EARTH));
+				GlobeCoordinatesValue.GLOBE_EARTH);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void longitudeWithinLowerRange() {
-		assertThrows(IllegalArgumentException.class, () -> new GlobeCoordinatesValueImpl(45.0, -500.0,
+		new GlobeCoordinatesValueImpl(45.0, -500.0,
 				GlobeCoordinatesValue.PREC_DEGREE,
-				GlobeCoordinatesValue.GLOBE_EARTH));
+				GlobeCoordinatesValue.GLOBE_EARTH);
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImplTest.java
@@ -20,12 +20,7 @@
 
 package org.wikidata.wdtk.datamodel.implementation;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -33,7 +28,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.Claim;
@@ -102,7 +97,7 @@ public class ItemDocumentImplTest {
 	@Test
 	public void findTerms() {
 		assertEquals("label", ir1.findLabel("en"));
-		assertNull(ir1.findLabel("ja"));
+		assertNull( ir1.findLabel("ja"));
 		assertEquals("des", ir1.findDescription("fr"));
 		assertNull( ir1.findDescription("ja"));
 	}
@@ -161,13 +156,13 @@ public class ItemDocumentImplTest {
 		assertEquals(ir1.hashCode(), ir2.hashCode());
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void idNotNull() {
-		assertThrows(NullPointerException.class, () -> new ItemDocumentImpl(null,
+		new ItemDocumentImpl(null,
 				Collections.emptyList(),
 				Collections.emptyList(),
 				Collections.emptyList(),
-				statementGroups, sitelinks, 1234));
+				statementGroups, sitelinks, 1234);
 	}
 
 	@Test
@@ -207,7 +202,7 @@ public class ItemDocumentImplTest {
 		assertTrue(doc.getStatementGroups().isEmpty());
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void statementGroupsUseSameSubject() {
 		ItemIdValue iid2 = new ItemIdValueImpl("Q23", "http://example.org/");
 		Statement s2 = new StatementImpl("MyId", StatementRank.NORMAL,
@@ -219,20 +214,20 @@ public class ItemDocumentImplTest {
 		statementGroups2.add(statementGroups.get(0));
 		statementGroups2.add(sg2);
 
-		assertThrows(IllegalArgumentException.class, () -> new ItemDocumentImpl(iid,
+		new ItemDocumentImpl(iid,
 				Collections.emptyList(),
 				Collections.emptyList(),
 				Collections.emptyList(),
-				statementGroups2, sitelinks, 1234));
+				statementGroups2, sitelinks, 1234);
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void sitelinksNotNull() {
-		assertThrows(NullPointerException.class, () -> new ItemDocumentImpl(iid,
+		new ItemDocumentImpl(iid,
 				Collections.emptyList(),
 				Collections.emptyList(),
 				Collections.emptyList(),
-				statementGroups, null, 1234));
+				statementGroups, null, 1234);
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemIdValueImplTest.java
@@ -20,15 +20,11 @@
 
 package org.wikidata.wdtk.datamodel.implementation;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
@@ -90,29 +86,29 @@ public class ItemIdValueImplTest {
 		assertEquals(item1.hashCode(), item2.hashCode());
 	}
 
-	@Test
+	@Test(expected = RuntimeException.class)
 	public void idValidatedForFirstLetter() {
-		assertThrows(RuntimeException.class, () -> new ItemIdValueImpl("P12345", "http://www.wikidata.org/entity/"));
+		new ItemIdValueImpl("P12345", "http://www.wikidata.org/entity/");
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void idValidatedForNumber() {
-		assertThrows(IllegalArgumentException.class, () -> new ItemIdValueImpl("Q34d23", "http://www.wikidata.org/entity/"));
+		new ItemIdValueImpl("Q34d23", "http://www.wikidata.org/entity/");
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void idValidatedForLength() {
-		assertThrows(IllegalArgumentException.class, () -> new ItemIdValueImpl("Q", "http://www.wikidata.org/entity/"));
+		new ItemIdValueImpl("Q", "http://www.wikidata.org/entity/");
 	}
 
-	@Test
+	@Test(expected = RuntimeException.class)
 	public void idNotNull() {
-		assertThrows(RuntimeException.class, () -> new ItemIdValueImpl((String)null, "http://www.wikidata.org/entity/"));
+		new ItemIdValueImpl((String)null, "http://www.wikidata.org/entity/");
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void baseIriNotNull() {
-		assertThrows(NullPointerException.class, () -> new ItemIdValueImpl("Q42", null));
+		new ItemIdValueImpl("Q42", null);
 	}
 
 	@Test
@@ -148,9 +144,9 @@ public class ItemIdValueImplTest {
 		assertEquals("foo", ((UnsupportedEntityIdValue)unsupported).getEntityTypeJsonString());
 	}
 	
-	@Test
+	@Test(expected = JsonMappingException.class)
 	public void testToJavaUnsupportedWithoutId() throws IOException {
-		assertThrows(JsonMappingException.class, () -> mapper.readValue(JSON_ITEM_ID_VALUE_UNSUPPORTED_NO_ID, ValueImpl.class));
+		mapper.readValue(JSON_ITEM_ID_VALUE_UNSUPPORTED_NO_ID, ValueImpl.class);
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemUpdateImplTest.java
@@ -21,11 +21,11 @@ package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.producesJson;
 import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.toJson;
 
@@ -34,7 +34,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.ItemUpdateBuilder;
 import org.wikidata.wdtk.datamodel.interfaces.AliasUpdate;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/JsonComparator.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/JsonComparator.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,11 +20,9 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import java.io.IOException;
+
+import org.junit.Assert;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -45,7 +45,7 @@ public class JsonComparator {
 		try {
 			JsonNode tree1 = mapper.readTree(expected);
 			JsonNode tree2 = mapper.readTree(actual);
-			assertEquals(tree1, tree2);
+			Assert.assertEquals(tree1, tree2);
 		} catch (IOException e) {
 			e.printStackTrace();
 		}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/JsonTestUtils.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/JsonTestUtils.java
@@ -19,7 +19,7 @@
  */
 package org.wikidata.wdtk.datamodel.implementation;
 
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.util.TreeMap;
@@ -69,7 +69,8 @@ class JsonTestUtils {
 			JsonNode tree = mapper.readTree(json);
 			return mapper.writeValueAsString(tree);
 		} catch (IOException ex) {
-			return fail("JSON serialization failed.", ex);
+			fail("JSON serialization failed.");
+			return null;
 		}
 	}
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LabeledDocumentUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LabeledDocumentUpdateImplTest.java
@@ -19,16 +19,16 @@
  */
 package org.wikidata.wdtk.datamodel.implementation;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Collection;
 import java.util.Collections;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.StatementUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeDocumentImplTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,13 +20,13 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
+import com.fasterxml.jackson.core.JsonProcessingException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
+import org.wikidata.wdtk.datamodel.interfaces.*;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,24 +34,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
-import org.wikidata.wdtk.datamodel.helpers.Datamodel;
-import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
-import org.wikidata.wdtk.datamodel.interfaces.Claim;
-import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
-import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.LexemeDocument;
-import org.wikidata.wdtk.datamodel.interfaces.LexemeIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
-import org.wikidata.wdtk.datamodel.interfaces.SenseDocument;
-import org.wikidata.wdtk.datamodel.interfaces.Statement;
-import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
-import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.junit.Assert.*;
 
 public class LexemeDocumentImplTest {
 
@@ -102,9 +87,9 @@ public class LexemeDocumentImplTest {
 		assertEquals(form, ld1.getForm(form.getEntityId()));
 	}
 
-	@Test
+	@Test(expected=IndexOutOfBoundsException.class)
 	public void formGetterNotFound() {
-		assertThrows(IndexOutOfBoundsException.class, () -> ld1.getForm(new FormIdValueImpl("L42-F2", "http://example.com/entity/")));
+		ld1.getForm(new FormIdValueImpl("L42-F2", "http://example.com/entity/"));
 	}
 
 	@Test
@@ -112,9 +97,9 @@ public class LexemeDocumentImplTest {
 		assertEquals(sense, ld1.getSense(sense.getEntityId()));
 	}
 
-	@Test
+	@Test(expected=IndexOutOfBoundsException.class)
 	public void senseGetterNotFound() {
-		assertThrows(IndexOutOfBoundsException.class, () -> ld1.getSense(new SenseIdValueImpl("L42-S2", "http://example.com/entity/")));
+		ld1.getSense(new SenseIdValueImpl("L42-S2", "http://example.com/entity/"));
 	}
 
 	@Test
@@ -155,19 +140,19 @@ public class LexemeDocumentImplTest {
 		assertEquals(ld1.hashCode(), ld2.hashCode());
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void idNotNull() {
-		assertThrows(NullPointerException.class, () -> new LexemeDocumentImpl(null, lexCat, language, lemmaList, statementGroups, forms, senses,  1234));
+		new LexemeDocumentImpl(null, lexCat, language, lemmaList, statementGroups, forms, senses,  1234);
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void lexicalCategoryNotNull() {
-		assertThrows(NullPointerException.class, () -> new LexemeDocumentImpl(lid, null, language, lemmaList, statementGroups, forms, senses, 1234));
+		new LexemeDocumentImpl(lid, null, language, lemmaList, statementGroups, forms, senses, 1234);
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void languageNotNull() {
-		assertThrows(NullPointerException.class, () -> new LexemeDocumentImpl(lid, lexCat, null, lemmaList, statementGroups, forms, senses,  1234));
+		new LexemeDocumentImpl(lid, lexCat, null, lemmaList, statementGroups, forms, senses,  1234);
 	}
 
 	@Test
@@ -186,9 +171,9 @@ public class LexemeDocumentImplTest {
 		assertTrue(doc.getStatementGroups().isEmpty());
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void statementGroupsUseSameSubject() {
-		LexemeIdValue iid2 = new LexemeIdValueImpl("L23", "http://example.org/");
+		LexemeIdValue iid2 = new LexemeIdValueImpl("Q23", "http://example.org/");
 		Statement s2 = new StatementImpl("MyId", StatementRank.NORMAL,
 				new SomeValueSnakImpl(new PropertyIdValueImpl("P42", "http://wikibase.org/entity/")),
 				Collections.emptyList(),  Collections.emptyList(), iid2);
@@ -198,7 +183,7 @@ public class LexemeDocumentImplTest {
 		statementGroups2.add(statementGroups.get(0));
 		statementGroups2.add(sg2);
 
-		assertThrows(IllegalArgumentException.class, () -> new LexemeDocumentImpl(lid, lexCat, language, lemmaList, statementGroups2, forms, senses,  1234));
+		new LexemeDocumentImpl(lid, lexCat, language, lemmaList, statementGroups2, forms, senses,  1234);
 	}
 
 	@Test
@@ -285,14 +270,14 @@ public class LexemeDocumentImplTest {
 		assertEquals(ld1.getForms().size() + 1, ld1.withForm(newForm).getForms().size());
 		assertEquals(newForm, ld1.withForm(newForm).getForm(newForm.getEntityId()));
 	}
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testWithWrongFormId() {
-		assertThrows(IllegalArgumentException.class, () -> ld1.withForm(Datamodel.makeFormDocument(
+		ld1.withForm(Datamodel.makeFormDocument(
 				Datamodel.makeFormIdValue("L444-F32","http://example.com/entity/"),
 				Collections.singletonList(new TermImpl("en", "add1")),
 				Collections.emptyList(),
 				Collections.emptyList()
-		)));
+		));
 	}
 
 	@Test
@@ -303,13 +288,13 @@ public class LexemeDocumentImplTest {
 		assertEquals(newSense, ld1.withSense(newSense).getSense(newSense.getEntityId()));
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testWithWrongSenseId() {
-		assertThrows(IllegalArgumentException.class, () -> ld1.withSense(Datamodel.makeSenseDocument(
+		ld1.withSense(Datamodel.makeSenseDocument(
 				Datamodel.makeSenseIdValue("L444-S32","http://example.com/entity/"),
 				Collections.singletonList(new TermImpl("en", "add1")),
 				Collections.emptyList()
-		)));
+		));
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeIdValueImplTest.java
@@ -20,14 +20,13 @@
 
 package org.wikidata.wdtk.datamodel.implementation;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 
 import java.io.IOException;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
@@ -82,29 +81,29 @@ public class LexemeIdValueImplTest {
 		assertEquals(lexeme1.hashCode(), lexeme2.hashCode());
 	}
 
-	@Test
+	@Test(expected = RuntimeException.class)
 	public void idValidatedForFirstLetter() {
-		assertThrows(RuntimeException.class, () -> new LexemeIdValueImpl("Q12345", "http://www.wikidata.org/entity/"));
+		new LexemeIdValueImpl("Q12345", "http://www.wikidata.org/entity/");
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void idValidatedForNumber() {
-		assertThrows(IllegalArgumentException.class, () -> new LexemeIdValueImpl("L34d23", "http://www.wikidata.org/entity/"));
+		new LexemeIdValueImpl("L34d23", "http://www.wikidata.org/entity/");
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void idValidatedForLength() {
-		assertThrows(IllegalArgumentException.class, () -> new LexemeIdValueImpl("L", "http://www.wikidata.org/entity/"));
+		new LexemeIdValueImpl("L", "http://www.wikidata.org/entity/");
 	}
 
-	@Test
+	@Test(expected = RuntimeException.class)
 	public void idNotNull() {
-		assertThrows(RuntimeException.class, () -> new LexemeIdValueImpl((String)null, "http://www.wikidata.org/entity/"));
+		new LexemeIdValueImpl((String)null, "http://www.wikidata.org/entity/");
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void baseIriNotNull() {
-		assertThrows(NullPointerException.class, () -> new LexemeIdValueImpl("L42", null));
+		new LexemeIdValueImpl("L42", null);
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeUpdateImplTest.java
@@ -23,11 +23,11 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.producesJson;
 import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.toJson;
 
@@ -36,7 +36,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.FormUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.LexemeUpdateBuilder;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoDocumentImplTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,14 +20,12 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
+import org.wikidata.wdtk.datamodel.interfaces.*;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -33,7 +33,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.Claim;
@@ -49,6 +48,7 @@ import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.junit.Assert.*;
 
 public class MediaInfoDocumentImplTest {
 
@@ -83,7 +83,7 @@ public class MediaInfoDocumentImplTest {
 	@Test
 	public void findLabels() {
 		assertEquals("label", mi1.findLabel("en"));
-		assertNull(mi1.findLabel("ja"));
+		assertNull( mi1.findLabel("ja"));
 	}
 
 	@Test
@@ -125,9 +125,9 @@ public class MediaInfoDocumentImplTest {
 		assertEquals(mi1.hashCode(), mi2.hashCode());
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void idNotNull() {
-		assertThrows(NullPointerException.class, () -> new MediaInfoDocumentImpl(null, Collections.emptyList(), statementGroups, 1234));
+		new MediaInfoDocumentImpl(null, Collections.emptyList(), statementGroups, 1234);
 	}
 
 	@Test
@@ -142,9 +142,9 @@ public class MediaInfoDocumentImplTest {
 		assertTrue(doc.getStatementGroups().isEmpty());
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void statementGroupsUseSameSubject() {
-		MediaInfoIdValue mid2 = new MediaInfoIdValueImpl("M23", "http://example.org/");
+		MediaInfoIdValue mid2 = new MediaInfoIdValueImpl("Q23", "http://example.org/");
 		Statement s2 = new StatementImpl("MyId", StatementRank.NORMAL,
 				new SomeValueSnakImpl(new PropertyIdValueImpl("P42", "http://wikibase.org/entity/")),
 				Collections.emptyList(),  Collections.emptyList(), mid2);
@@ -154,7 +154,7 @@ public class MediaInfoDocumentImplTest {
 		statementGroups2.add(statementGroups.get(0));
 		statementGroups2.add(sg2);
 
-		assertThrows(IllegalArgumentException.class, () -> new MediaInfoDocumentImpl(mid, Collections.emptyList(), statementGroups2, 1234));
+		new MediaInfoDocumentImpl(mid, Collections.emptyList(), statementGroups2, 1234);
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoIdValueImplTest.java
@@ -20,14 +20,11 @@
 
 package org.wikidata.wdtk.datamodel.implementation;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
@@ -82,29 +79,29 @@ public class MediaInfoIdValueImplTest {
 		assertEquals(mediaInfo1.hashCode(), mediaInfo2.hashCode());
 	}
 
-	@Test
+	@Test(expected = RuntimeException.class)
 	public void idValidatedForFirstLetter() {
-		assertThrows(RuntimeException.class, () -> new MediaInfoIdValueImpl("Q12345", "http://commons.wikimedia.org/entity/"));
+		new MediaInfoIdValueImpl("Q12345", "http://commons.wikimedia.org/entity/");
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void idValidatedForNumber() {
-		assertThrows(IllegalArgumentException.class, () -> new MediaInfoIdValueImpl("L34d23", "http://commons.wikimedia.org/entity/"));
+		new MediaInfoIdValueImpl("L34d23", "http://commons.wikimedia.org/entity/");
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void idValidatedForLength() {
-		assertThrows(IllegalArgumentException.class, () -> new MediaInfoIdValueImpl("M", "http://commons.wikimedia.org/entity/"));
+		new MediaInfoIdValueImpl("M", "http://commons.wikimedia.org/entity/");
 	}
 
-	@Test
+	@Test(expected = RuntimeException.class)
 	public void idNotNull() {
-		assertThrows(RuntimeException.class, () -> new MediaInfoIdValueImpl((String)null, "http://commons.wikimedia.org/entity/"));
+		new MediaInfoIdValueImpl((String)null, "http://commons.wikimedia.org/entity/");
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void baseIriNotNull() {
-		assertThrows(NullPointerException.class, () -> new MediaInfoIdValueImpl("M42", null));
+		new MediaInfoIdValueImpl("M42", null);
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoUpdateImplTest.java
@@ -20,14 +20,14 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.producesJson;
 import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.toJson;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.MediaInfoUpdateBuilder;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoIdValue;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MonolingualTextValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MonolingualTextValueImplTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,19 +20,14 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import java.io.IOException;
-
-import org.junit.jupiter.api.Test;
-import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+import static org.junit.Assert.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+
+import java.io.IOException;
 
 public class MonolingualTextValueImplTest {
 
@@ -66,14 +63,14 @@ public class MonolingualTextValueImplTest {
 		assertEquals(mt1.hashCode(), mt2.hashCode());
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void textNotNull() {
-		assertThrows(NullPointerException.class, () -> new MonolingualTextValueImpl(null, "en"));
+		new MonolingualTextValueImpl(null, "en");
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void languageCodeNotNull() {
-		assertThrows(NullPointerException.class, () -> new MonolingualTextValueImpl("some text", null));
+		new MonolingualTextValueImpl("some text", null);
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImplTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,35 +20,20 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
+import static org.junit.Assert.*;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
-import org.wikidata.wdtk.datamodel.helpers.Datamodel;
-import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
-import org.wikidata.wdtk.datamodel.interfaces.Claim;
-import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
-import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.Statement;
-import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
-import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
+import org.wikidata.wdtk.datamodel.interfaces.*;
 
 
 public class PropertyDocumentImplTest {
@@ -99,9 +86,9 @@ public class PropertyDocumentImplTest {
 	@Test
 	public void findTerms() {
 		assertEquals("label", pd1.findLabel("en"));
-		assertNull(pd1.findLabel("ja"));
+		assertNull( pd1.findLabel("ja"));
 		assertEquals("des", pd1.findDescription("fr"));
-		assertNull(pd1.findDescription("ja"));
+		assertNull( pd1.findDescription("ja"));
 	}
 
 	@Test
@@ -146,10 +133,10 @@ public class PropertyDocumentImplTest {
 		assertEquals(pd1.hashCode(), pd2.hashCode());
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void idNotNull() {
-		assertThrows(NullPointerException.class, () -> new PropertyDocumentImpl(null, labelList, descList, aliasList,
-				statementGroups, datatypeId, 1234));
+		new PropertyDocumentImpl(null, labelList, descList, aliasList,
+				statementGroups, datatypeId, 1234);
 	}
 
 	@Test
@@ -180,28 +167,28 @@ public class PropertyDocumentImplTest {
 		assertEquals(Collections.emptyList(), doc.getStatementGroups());
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void datatypeNotNull() {
-		assertThrows(NullPointerException.class, () -> new PropertyDocumentImpl(pid, labelList, descList, aliasList,
-				statementGroups, null, 1234));
+		new PropertyDocumentImpl(pid, labelList, descList, aliasList,
+				statementGroups, null, 1234);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void labelUniquePerLanguage() {
 		List<MonolingualTextValue> labels2 = new ArrayList<>(labelList);
 		labels2.add(new MonolingualTextValueImpl("Property 42 label duplicate", "en"));
 
-		assertThrows(IllegalArgumentException.class, () -> new PropertyDocumentImpl(pid, labels2, descList, aliasList,
-				statementGroups, datatypeId, 1234));
+		new PropertyDocumentImpl(pid, labels2, descList, aliasList,
+				statementGroups, datatypeId, 1234);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void descriptionUniquePerLanguage() {
 		List<MonolingualTextValue> descriptions2 = new ArrayList<>(descList);
 		descriptions2.add(new MonolingualTextValueImpl("Duplicate desc P42", "fr"));
 
-		assertThrows(IllegalArgumentException.class, () -> new PropertyDocumentImpl(pid, labelList, descriptions2, aliasList,
-				statementGroups, datatypeId, 1234));
+		new PropertyDocumentImpl(pid, labelList, descriptions2, aliasList,
+				statementGroups, datatypeId, 1234);
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyIdValueImplTest.java
@@ -20,20 +20,16 @@
 
 package org.wikidata.wdtk.datamodel.implementation;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.*;
 
-import java.io.IOException;
-
-import org.junit.jupiter.api.Test;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 
 public class PropertyIdValueImplTest {
 
@@ -77,19 +73,19 @@ public class PropertyIdValueImplTest {
 		assertEquals(prop1.hashCode(), prop2.hashCode());
 	}
 
-	@Test
+	@Test(expected = RuntimeException.class)
 	public void idValidatedForFirstLetter() {
-		assertThrows(RuntimeException.class, () -> new PropertyIdValueImpl("Q12345", "http://www.wikidata.org/entity/"));
+		new PropertyIdValueImpl("Q12345", "http://www.wikidata.org/entity/");
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void idValidatedForLength() {
-		assertThrows(IllegalArgumentException.class, () -> new ItemIdValueImpl("P", "http://www.wikidata.org/entity/"));
+		new ItemIdValueImpl("P", "http://www.wikidata.org/entity/");
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void idValidatedForNumber() {
-		assertThrows(IllegalArgumentException.class, () -> new PropertyIdValueImpl("P34d23", "http://www.wikidata.org/entity/"));
+		new PropertyIdValueImpl("P34d23", "http://www.wikidata.org/entity/");
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyUpdateImplTest.java
@@ -20,17 +20,17 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.producesJson;
 import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.toJson;
 
 import java.util.Collections;
 import java.util.Map;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.PropertyUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.StatementUpdateBuilder;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/QuantityValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/QuantityValueImplTest.java
@@ -20,15 +20,15 @@
 
 package org.wikidata.wdtk.datamodel.implementation;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 import java.io.IOException;
 import java.math.BigDecimal;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.QuantityValue;
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ReferenceImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ReferenceImplTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,18 +20,12 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.Collections;
 import java.util.Iterator;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.Reference;
@@ -71,9 +67,9 @@ public class ReferenceImplTest {
 		assertEquals(r1.hashCode(), r2.hashCode());
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void snakListNotNull() {
-		assertThrows(NullPointerException.class, () -> new ReferenceImpl(null));
+		new ReferenceImpl(null);
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SenseDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SenseDocumentImplTest.java
@@ -20,11 +20,10 @@
 
 package org.wikidata.wdtk.datamodel.implementation;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,7 +31,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.Claim;
@@ -104,9 +103,9 @@ public class SenseDocumentImplTest {
 		assertEquals(sd1.hashCode(), sd2.hashCode());
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void idNotNull() {
-		assertThrows(NullPointerException.class, () -> new SenseDocumentImpl(null, repList, statementGroups, 1234));
+		new SenseDocumentImpl(null, repList, statementGroups, 1234);
 	}
 
 	@Test
@@ -125,9 +124,9 @@ public class SenseDocumentImplTest {
 		assertTrue(doc.getStatementGroups().isEmpty());
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void statementGroupsUseSameSubject() {
-		SenseIdValue iid2 = new SenseIdValueImpl("L23-S5", "http://example.org/");
+		SenseIdValue iid2 = new SenseIdValueImpl("Q23", "http://example.org/");
 		Statement s2 = new StatementImpl("MyId", StatementRank.NORMAL,
 				new SomeValueSnakImpl(new PropertyIdValueImpl("P42", "http://wikibase.org/entity/")),
 				Collections.emptyList(),  Collections.emptyList(), iid2);
@@ -137,7 +136,7 @@ public class SenseDocumentImplTest {
 		statementGroups2.add(statementGroups.get(0));
 		statementGroups2.add(sg2);
 
-		assertThrows(IllegalArgumentException.class, () -> new SenseDocumentImpl(sid, repList, statementGroups2, 1234));
+		new SenseDocumentImpl(sid, repList, statementGroups2, 1234);
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SenseIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SenseIdValueImplTest.java
@@ -20,14 +20,13 @@
 
 package org.wikidata.wdtk.datamodel.implementation;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 
 import java.io.IOException;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 
@@ -81,34 +80,34 @@ public class SenseIdValueImplTest {
 		assertEquals(sense1.hashCode(), sense2.hashCode());
 	}
 
-	@Test
+	@Test(expected = RuntimeException.class)
 	public void idValidatedForFirstLetter() {
-		assertThrows(RuntimeException.class, () -> new SenseIdValueImpl("Q12345", "http://www.wikidata.org/entity/"));
+		new SenseIdValueImpl("Q12345", "http://www.wikidata.org/entity/");
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void idValidatedForNumber() {
-		assertThrows(IllegalArgumentException.class, () -> new SenseIdValueImpl("L34d23", "http://www.wikidata.org/entity/"));
+		new SenseIdValueImpl("L34d23", "http://www.wikidata.org/entity/");
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void idValidatedForLength() {
-		assertThrows(IllegalArgumentException.class, () -> new SenseIdValueImpl("L", "http://www.wikidata.org/entity/"));
+		new SenseIdValueImpl("L", "http://www.wikidata.org/entity/");
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void idValidatedForParts() {
-		assertThrows(IllegalArgumentException.class, () -> new SenseIdValueImpl("L21", "http://www.wikidata.org/entity/"));
+		new SenseIdValueImpl("L21", "http://www.wikidata.org/entity/");
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void idNotNull() {
-		assertThrows(IllegalArgumentException.class, () -> new SenseIdValueImpl((String)null, "http://www.wikidata.org/entity/"));
+		new SenseIdValueImpl((String)null, "http://www.wikidata.org/entity/");
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void baseIriNotNull() {
-		assertThrows(IllegalArgumentException.class, () -> new SenseIdValueImpl("L42", null));
+		new SenseIdValueImpl("L42", null);
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SenseUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SenseUpdateImplTest.java
@@ -20,15 +20,15 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.producesJson;
 import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.toJson;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.SenseUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SiteLinkImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SiteLinkImplTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,24 +20,19 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class SiteLinkImplTest {
 
@@ -77,14 +74,14 @@ public class SiteLinkImplTest {
 		assertEquals(s1.hashCode(), s2.hashCode());
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void titleNotNull() {
-		assertThrows(NullPointerException.class, () -> new SiteLinkImpl(null, "enwiki", Collections.emptyList()));
+		new SiteLinkImpl(null, "enwiki", Collections.emptyList());
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void siteKeyNotNull() {
-		assertThrows(NullPointerException.class, () -> new SiteLinkImpl("Dresden", null, Collections.emptyList()));
+		new SiteLinkImpl("Dresden", null, Collections.emptyList());
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SitesImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SitesImplTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,22 +20,20 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.util.Collections;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.SiteLink;
 
 public class SitesImplTest {
 
 	private SitesImpl sites;
 
-	@BeforeEach
+	@Before
 	public void setUp() {
 		this.sites = new SitesImpl();
 		this.sites.setSiteInformation("enwiki", "wikipedia", "en", "mediawiki",

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SnakGroupTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SnakGroupTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,25 +20,15 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
-
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.Snak;
-import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
+import org.junit.Before;
+import org.junit.Test;
+import org.wikidata.wdtk.datamodel.interfaces.*;
 
 public class SnakGroupTest {
 
@@ -46,7 +38,7 @@ public class SnakGroupTest {
 	private Snak snak2;
 	private PropertyIdValue property;
 
-	@BeforeEach
+	@Before
 	public void setUp() {
 		EntityIdValue subject = new ItemIdValueImpl("Q42",
 				"http://wikidata.org/entity/");
@@ -100,17 +92,17 @@ public class SnakGroupTest {
 		assertEquals(sg1.hashCode(), sg2.hashCode());
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void snakListNotNull() {
-		assertThrows(IllegalArgumentException.class, () -> new SnakGroupImpl(null));
+		new SnakGroupImpl(null);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void snakListNotEmpty() {
-		assertThrows(IllegalArgumentException.class, () -> new SnakGroupImpl(Collections.emptyList()));
+		new SnakGroupImpl(Collections.emptyList());
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void snakListRequiresSameProperty() {
 		List<Snak> snaks = new ArrayList<>();
 
@@ -120,7 +112,7 @@ public class SnakGroupTest {
 		Snak snak3 = new NoValueSnakImpl(property2);
 		snaks.add(snak3);
 
-		assertThrows(IllegalArgumentException.class, () -> new SnakGroupImpl(snaks));
+		new SnakGroupImpl(snaks);
 	}
 
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SnakImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SnakImplTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,23 +20,18 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
+import static org.junit.Assert.*;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import java.io.IOException;
-
-import org.junit.jupiter.api.Test;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.NoValueSnak;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.SomeValueSnak;
 import org.wikidata.wdtk.datamodel.interfaces.ValueSnak;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 
 public class SnakImplTest {
 
@@ -108,15 +105,15 @@ public class SnakImplTest {
 		assertNotEquals(nvs1, null);
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void snakPropertyNotNull() {
-		assertThrows(NullPointerException.class, () -> new SomeValueSnakImpl(null));
+		new SomeValueSnakImpl(null);
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void snakValueNotNull() {
-		assertThrows(NullPointerException.class, () -> new ValueSnakImpl(new PropertyIdValueImpl("P42",
-				"http://example.com/entity/"), null));
+		new ValueSnakImpl(new PropertyIdValueImpl("P42",
+				"http://example.com/entity/"), null);
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementDocumentAccessTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementDocumentAccessTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,28 +20,14 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.mockito.internal.util.collections.Sets;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.ItemDocumentBuilder;
 import org.wikidata.wdtk.datamodel.helpers.StatementBuilder;
-import org.wikidata.wdtk.datamodel.interfaces.GlobeCoordinatesValue;
-import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
-import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.QuantityValue;
-import org.wikidata.wdtk.datamodel.interfaces.Statement;
-import org.wikidata.wdtk.datamodel.interfaces.StatementDocument;
-import org.wikidata.wdtk.datamodel.interfaces.StringValue;
-import org.wikidata.wdtk.datamodel.interfaces.TimeValue;
+import org.wikidata.wdtk.datamodel.interfaces.*;
+
+import static org.junit.Assert.*;
 
 /**
  * Test general statement access methods as implemented in

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementDocumentUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementDocumentUpdateImplTest.java
@@ -19,16 +19,16 @@
  */
 package org.wikidata.wdtk.datamodel.implementation;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Collection;
 import java.util.Collections;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.StatementUpdateBuilder;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.SiteLink;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementGroupTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementGroupTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,22 +20,11 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
+import static org.junit.Assert.*;
 
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.*;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.Snak;
@@ -94,6 +85,7 @@ public class StatementGroupTest {
 	public void getBestStatementsEmpty() {
 		assertNull(
 				new StatementGroupImpl(Collections.singletonList(statementDeprecrated)).getBestStatements()
+
 		);
 	}
 
@@ -126,17 +118,17 @@ public class StatementGroupTest {
 		assertEquals(sg1.hashCode(), sg2.hashCode());
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void statementListNotNull() {
-		assertThrows(NullPointerException.class, () -> new StatementGroupImpl(null));
+		new StatementGroupImpl(null);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void statementListNotEmpty() {
-		assertThrows(IllegalArgumentException.class, () -> new StatementGroupImpl(Collections.emptyList()));
+		new StatementGroupImpl(Collections.emptyList());
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void statementListRequiresSameSubject() {
 		List<Statement> statements = new ArrayList<>();
 
@@ -149,10 +141,10 @@ public class StatementGroupTest {
 				Collections.emptyList(),  Collections.emptyList(), subject2);
 		statements.add(s2);
 
-		assertThrows(IllegalArgumentException.class, () -> new StatementGroupImpl(statements));
+		new StatementGroupImpl(statements);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void statementListRequiresSameProperty() {
 		List<Statement> statements = new ArrayList<>();
 
@@ -164,7 +156,7 @@ public class StatementGroupTest {
 			Collections.emptyList(), Collections.emptyList(), subject);
 		statements.add(s2);
 
-		assertThrows(IllegalArgumentException.class, () -> new StatementGroupImpl(statements));
+		new StatementGroupImpl(statements);
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementImplTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,30 +20,17 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
-import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
-import org.wikidata.wdtk.datamodel.interfaces.Claim;
-import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.Reference;
-import org.wikidata.wdtk.datamodel.interfaces.SnakGroup;
-import org.wikidata.wdtk.datamodel.interfaces.Statement;
-import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
-import org.wikidata.wdtk.datamodel.interfaces.ValueSnak;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
+import org.wikidata.wdtk.datamodel.interfaces.*;
 
 public class StatementImplTest {
 
@@ -77,10 +66,10 @@ public class StatementImplTest {
 		assertEquals(s1.getSubject(), subjet);
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void mainSnakNotNull() {
-		assertThrows(NullPointerException.class, () -> new StatementImpl("MyId", StatementRank.NORMAL, null,
-				Collections.emptyList(), Collections.emptyList(), value));
+		new StatementImpl("MyId", StatementRank.NORMAL, null,
+				Collections.emptyList(), Collections.emptyList(), value);
 	}
 
 	@Test
@@ -89,10 +78,10 @@ public class StatementImplTest {
 		assertTrue(statement.getReferences().isEmpty());
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void rankNotNull() {
-		assertThrows(NullPointerException.class, () -> new StatementImpl("MyId", null, mainSnak,
-				Collections.emptyList(), Collections.emptyList(), value));
+		new StatementImpl("MyId", null, mainSnak,
+				Collections.emptyList(), Collections.emptyList(), value);
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementUpdateImplTest.java
@@ -21,10 +21,10 @@ package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.producesJson;
 import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.toJson;
 
@@ -34,7 +34,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.StatementBuilder;
 import org.wikidata.wdtk.datamodel.helpers.StatementUpdateBuilder;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StringValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StringValueImplTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,19 +20,14 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import java.io.IOException;
-
-import org.junit.jupiter.api.Test;
-import org.wikidata.wdtk.datamodel.interfaces.StringValue;
+import static org.junit.Assert.*;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.wikidata.wdtk.datamodel.interfaces.StringValue;
+
+import java.io.IOException;
 
 public class StringValueImplTest {
 
@@ -61,9 +58,9 @@ public class StringValueImplTest {
 		assertEquals(s1.hashCode(), s2.hashCode());
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void stringNotNull() {
-		assertThrows(NullPointerException.class, () -> new StringValueImpl(null));
+		new StringValueImpl(null);
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermImplTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,19 +20,15 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.Test;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 
 import java.io.IOException;
 
-import org.junit.jupiter.api.Test;
-import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class TermImplTest {
 
@@ -66,14 +64,14 @@ public class TermImplTest {
 		assertEquals(mt1.hashCode(), mt2.hashCode());
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void textNotNull() {
-		assertThrows(NullPointerException.class, () -> new TermImpl("en", null));
+		new TermImpl("en", null);
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void languageCodeNotNull() {
-		assertThrows(NullPointerException.class, () -> new TermImpl(null, "some text"));
+		new TermImpl(null, "some text");
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermUpdateImplTest.java
@@ -21,10 +21,10 @@ package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 import static org.wikidata.wdtk.datamodel.implementation.JsonTestUtils.producesJson;
 
 import java.util.ArrayList;
@@ -32,7 +32,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermedDocumentUpdateImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermedDocumentUpdateImplTest.java
@@ -22,17 +22,17 @@ package org.wikidata.wdtk.datamodel.implementation;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.AliasUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.TermUpdateBuilder;

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermedStatementDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermedStatementDocumentImplTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,27 +20,13 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
+import org.junit.Before;
+import org.junit.Test;
+import org.wikidata.wdtk.datamodel.interfaces.*;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.*;
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
-import org.wikidata.wdtk.datamodel.interfaces.Snak;
-import org.wikidata.wdtk.datamodel.interfaces.Statement;
-import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
+import static org.junit.Assert.*;
 
 public class TermedStatementDocumentImplTest {
 	
@@ -48,7 +36,7 @@ public class TermedStatementDocumentImplTest {
 	private String statementIdA = "myIdA";
 	private String statementIdB = "myIdB";
 
-	@BeforeEach
+	@Before
 	public void setUp() {
 		ItemIdValue subject = new ItemIdValueImpl("Q42",
 				"http://wikidata.org/entity/");

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TimeValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TimeValueImplTest.java
@@ -20,13 +20,12 @@
 
 package org.wikidata.wdtk.datamodel.implementation;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 import java.io.IOException;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.TimeValue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -66,9 +65,9 @@ public class TimeValueImplTest {
 		assertEquals(new ItemIdValueImpl("Q1985727", "http://www.wikidata.org/entity/"), t1.getPreferredCalendarModelItemId());
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void getPreferredCalendarModelItemIdInvalidIri() {
-		assertThrows(IllegalArgumentException.class, () -> t3.getPreferredCalendarModelItemId());
+		t3.getPreferredCalendarModelItemId();
 	}
 
 	@Test
@@ -129,10 +128,10 @@ public class TimeValueImplTest {
 		assertEquals(t1.hashCode(), t2.hashCode());
 	}
 
-	@Test
+	@Test(expected = NullPointerException.class)
 	public void calendarModelNotNull() {
-		assertThrows(NullPointerException.class, () -> new TimeValueImpl(2007, (byte) 5, (byte) 12, (byte) 10, (byte) 45,
-				(byte) 0, TimeValue.PREC_SECOND, 0, 1, 60, null));
+		new TimeValueImpl(2007, (byte) 5, (byte) 12, (byte) 10, (byte) 45,
+				(byte) 0, TimeValue.PREC_SECOND, 0, 1, 60, null);
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueTest.java
@@ -20,15 +20,15 @@
 
 package org.wikidata.wdtk.datamodel.implementation;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.helpers.ToString;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
@@ -47,7 +47,7 @@ public class UnsupportedEntityIdValueTest {
 	
 	private UnsupportedEntityIdValue firstValue, secondValue, noType;
 	
-	@BeforeEach
+	@Before
 	public void deserializeValues() throws IOException {
 		firstValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_1, UnsupportedEntityIdValueImpl.class);
 		secondValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_2, UnsupportedEntityIdValueImpl.class);

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedValueImplTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*-
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,18 +20,15 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-
-import java.io.IOException;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.wikidata.wdtk.datamodel.helpers.ToString;
 import org.wikidata.wdtk.datamodel.interfaces.UnsupportedValue;
 import org.wikidata.wdtk.datamodel.interfaces.Value;
+
+import static org.junit.Assert.*;
+import java.io.IOException;
+
+import org.junit.Before;
+import org.junit.Test;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -42,7 +41,7 @@ public class UnsupportedValueImplTest {
 	
 	private UnsupportedValue firstValue, secondValue;
 	
-	@BeforeEach
+	@Before
 	public void deserializeFirstValue() throws IOException {
 		firstValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_1, UnsupportedValueImpl.class);
 		secondValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_2, UnsupportedValueImpl.class);

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/WikimediaLanguageCodesTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/WikimediaLanguageCodesTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.datamodel.implementation;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,12 +20,9 @@
  * #L%
  */
 
-package org.wikidata.wdtk.datamodel.implementation;
+import static org.junit.Assert.assertEquals;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.WikimediaLanguageCodes;
 
 public class WikimediaLanguageCodesTest {
@@ -34,9 +33,9 @@ public class WikimediaLanguageCodesTest {
 		assertEquals("en", WikimediaLanguageCodes.getLanguageCode("en"));
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void getUnknownLanguageCode() {
-		assertThrows(IllegalArgumentException.class, () -> WikimediaLanguageCodes.getLanguageCode("unknown"));
+		WikimediaLanguageCodes.getLanguageCode("unknown");
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/interfaces/NullEntityIdsTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/interfaces/NullEntityIdsTest.java
@@ -20,10 +20,10 @@
 
 package org.wikidata.wdtk.datamodel.interfaces;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class NullEntityIdsTest {
 

--- a/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/JsonDumpFileProcessingTest.java
+++ b/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/JsonDumpFileProcessingTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.dumpfiles;
+
 /*
  * #%L
  * Wikidata Toolkit Dump File Handling
@@ -18,19 +20,16 @@
  * #L%
  */
 
-package org.wikidata.wdtk.dumpfiles;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.junit.jupiter.api.Disabled;
-import org.junit.jupiter.api.Test;
+import org.junit.Ignore;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocumentProcessor;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.dumpfiles.wmf.WmfDumpFile;
@@ -114,8 +113,8 @@ public class JsonDumpFileProcessingTest {
 	/**
 	 * TODO: fix on JDK 9 and enable again
 	 */
-	@Test
-	@Disabled
+	@Test(expected = EntityTimerProcessor.TimeoutException.class)
+	@Ignore
 	public void testTimeout() throws IOException {
 		Path dmPath = Paths.get(System.getProperty("user.dir"));
 		MockDirectoryManager dm = new MockDirectoryManager(dmPath, true, true);
@@ -133,7 +132,7 @@ public class JsonDumpFileProcessingTest {
 				true);
 
 		timer.open();
-		assertThrows(EntityTimerProcessor.TimeoutException.class, () -> dpc.processMostRecentJsonDump());
+		dpc.processMostRecentJsonDump();
 		timer.close();
 	}
 

--- a/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/MwDumpFileProcessingTest.java
+++ b/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/MwDumpFileProcessingTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.dumpfiles;
+
 /*
  * #%L
  * Wikidata Toolkit Dump File Handling
@@ -18,9 +20,7 @@
  * #L%
  */
 
-package org.wikidata.wdtk.dumpfiles;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.net.URL;
@@ -30,8 +30,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 import org.mockito.Mockito;
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocumentProcessor;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
@@ -99,7 +99,7 @@ public class MwDumpFileProcessingTest {
 
 	}
 
-	@BeforeEach
+	@Before
 	public void configureDirectoryManager() {
 		DirectoryManagerFactory
 				.setDirectoryManagerClass(MockDirectoryManager.class);
@@ -204,30 +204,30 @@ public class MwDumpFileProcessingTest {
 	 */
 	private void assertEqualRevisions(MwRevision rev1, MwRevision rev2,
 			String test) {
-		assertEquals(rev1.getPrefixedTitle(), rev2.getPrefixedTitle(),
-				"[" + test + "] Revision prefixed titles do not match:");
-		assertEquals(rev1.getNamespace(), rev2.getNamespace(),
-				"[" + test + "] Revision namespaces do not match:");
-		assertEquals(rev1.getPageId(), rev2.getPageId(),
-				"[" + test + "] Revision page ids do not match:");
-		assertEquals(rev1.getRevisionId(), rev2.getRevisionId(),
-				"[" + test + "] Revision ids do not match:");
-		assertEquals(rev1.getParentRevisionId(), rev2.getParentRevisionId(),
-				"[" + test + "] Revision parent ids do not match:");
-		assertEquals(rev1.getTimeStamp(), rev2.getTimeStamp(),
-				"[" + test + "] Revision timestamps do not match:");
-		assertEquals(rev1.getFormat(), rev2.getFormat(),
-				"[" + test + "] Revision formats do not match:");
-		assertEquals(rev1.getModel(), rev2.getModel(),
-				"[" + test + "] Revision models do not match:");
-		assertEquals(rev1.getComment(), rev2.getComment(),
-				"[" + test + "] Revision comments do not match:");
-		assertEquals(rev1.getText(), rev2.getText(),
-				"[" + test + "] Revision texts do not match:");
-		assertEquals(rev1.getContributor(), rev2.getContributor(),
-				"[" + test + "] Revision contributors do not match:");
-		assertEquals(rev1.getContributorId(), rev2.getContributorId(),
-				"[" + test + "] Revision contributor ids do not match:");
+		assertEquals("[" + test + "] Revision prefixed titles do not match:",
+				rev1.getPrefixedTitle(), rev2.getPrefixedTitle());
+		assertEquals("[" + test + "] Revision namespaces do not match:",
+				rev1.getNamespace(), rev2.getNamespace());
+		assertEquals("[" + test + "] Revision page ids do not match:",
+				rev1.getPageId(), rev2.getPageId());
+		assertEquals("[" + test + "] Revision ids do not match:",
+				rev1.getRevisionId(), rev2.getRevisionId());
+		assertEquals("[" + test + "] Revision parent ids do not match:",
+				rev1.getParentRevisionId(), rev2.getParentRevisionId());
+		assertEquals("[" + test + "] Revision timestamps do not match:",
+				rev1.getTimeStamp(), rev2.getTimeStamp());
+		assertEquals("[" + test + "] Revision formats do not match:",
+				rev1.getFormat(), rev2.getFormat());
+		assertEquals("[" + test + "] Revision models do not match:",
+				rev1.getModel(), rev2.getModel());
+		assertEquals("[" + test + "] Revision comments do not match:",
+				rev1.getComment(), rev2.getComment());
+		assertEquals("[" + test + "] Revision texts do not match:",
+				rev1.getText(), rev2.getText());
+		assertEquals("[" + test + "] Revision contributors do not match:",
+				rev1.getContributor(), rev2.getContributor());
+		assertEquals("[" + test + "] Revision contributor ids do not match:",
+				rev1.getContributorId(), rev2.getContributorId());
 	}
 
 	/**
@@ -238,8 +238,8 @@ public class MwDumpFileProcessingTest {
 	 */
 	private void assertEqualRevisionLists(List<MwRevision> list1,
 			List<MwRevision> list2, String test) {
-		assertEquals(list1.size(), list2.size(),
-				"[" + test + "] Size of revision lists does not match:");
+		assertEquals("[" + test + "] Size of revision lists does not match:",
+				list1.size(), list2.size());
 		for (int i = 0; i < list1.size(); i++) {
 			assertEqualRevisions(list1.get(i), list2.get(i), test + "-item" + i);
 		}

--- a/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/MwLocalDumpFileTest.java
+++ b/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/MwLocalDumpFileTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.dumpfiles;
+
 /*
  * #%L
  * Wikidata Toolkit Dump File Handling
@@ -18,30 +20,24 @@
  * #L%
  */
 
-package org.wikidata.wdtk.dumpfiles;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 import org.wikidata.wdtk.testing.MockDirectoryManager;
 import org.wikidata.wdtk.util.CompressionType;
 import org.wikidata.wdtk.util.DirectoryManagerFactory;
+
+import static org.junit.Assert.*;
 
 public class MwLocalDumpFileTest {
 	MockDirectoryManager dm;
 	Path dmPath;
 
-	@BeforeEach
+	@Before
 	public void setUp() throws Exception {
 		DirectoryManagerFactory
 				.setDirectoryManagerClass(MockDirectoryManager.class);
@@ -111,11 +107,11 @@ public class MwLocalDumpFileTest {
 		assertNull(br.readLine());
 	}
 
-	@Test
+	@Test(expected = IOException.class)
 	public void testUnavailableReader() throws IOException {
 		MwLocalDumpFile df = new MwLocalDumpFile(
 				"/testdump-20150512.json.gz");
-		assertThrows(IOException.class, () -> df.getDumpFileReader());
+		df.getDumpFileReader();
 	}
 
 	@Test

--- a/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/SitesTest.java
+++ b/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/SitesTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.dumpfiles;
+
 /*
  * #%L
  * Wikidata Toolkit Dump File Handling
@@ -18,9 +20,7 @@
  * #L%
  */
 
-package org.wikidata.wdtk.dumpfiles;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 import java.net.URL;
@@ -28,8 +28,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.implementation.DataObjectFactoryImpl;
 import org.wikidata.wdtk.datamodel.implementation.SitesImpl;
 import org.wikidata.wdtk.datamodel.interfaces.DataObjectFactory;
@@ -45,7 +45,7 @@ public class SitesTest {
 	Path dmPath;
 	DumpProcessingController dpc;
 
-	@BeforeEach
+	@Before
 	public void setUp() throws IOException {
 		this.dmPath = Paths.get(System.getProperty("user.dir"));
 		this.dm = new MockDirectoryManager(this.dmPath, true, true);

--- a/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/wmf/WmfDumpFileManagerTest.java
+++ b/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/wmf/WmfDumpFileManagerTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.dumpfiles.wmf;
+
 /*
  * #%L
  * Wikidata Toolkit Dump File Handling
@@ -18,11 +20,9 @@
  * #L%
  */
 
-package org.wikidata.wdtk.dumpfiles.wmf;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,8 +30,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 import org.wikidata.wdtk.dumpfiles.DumpContentType;
 import org.wikidata.wdtk.dumpfiles.MwDumpFile;
 import org.wikidata.wdtk.dumpfiles.MwDumpFileProcessor;
@@ -70,7 +70,7 @@ public class WmfDumpFileManagerTest {
 
 	}
 
-	@BeforeEach
+	@Before
 	public void setUp() throws IOException {
 		this.wrf = new MockWebResourceFetcher();
 		this.dmPath = Paths.get(System.getProperty("user.dir"));
@@ -134,12 +134,12 @@ public class WmfDumpFileManagerTest {
 			assertEquals(dumpFiles.get(i).getDateStamp(), dumpDates[i]);
 			if (dumpIsLocal[i]) {
 				assertTrue(
-						dumpFiles.get(i) instanceof WmfLocalDumpFile,
-						"Dumpfile " + dumpFiles.get(i) + " should be local.");
+						"Dumpfile " + dumpFiles.get(i) + " should be local.",
+						dumpFiles.get(i) instanceof WmfLocalDumpFile);
 			} else {
-				assertTrue(
-						dumpFiles.get(i) instanceof WmfOnlineDailyDumpFile,
-						"Dumpfile " + dumpFiles.get(i) + " should be online.");
+				assertTrue("Dumpfile " + dumpFiles.get(i)
+						+ " should be online.",
+						dumpFiles.get(i) instanceof WmfOnlineDailyDumpFile);
 			}
 		}
 	}
@@ -174,12 +174,12 @@ public class WmfDumpFileManagerTest {
 			assertEquals(dumpFiles.get(i).getDateStamp(), dumpDates[i]);
 			if (dumpIsLocal[i]) {
 				assertTrue(
-						dumpFiles.get(i) instanceof WmfLocalDumpFile,
-						"Dumpfile " + dumpFiles.get(i) + " should be local.");
+						"Dumpfile " + dumpFiles.get(i) + " should be local.",
+						dumpFiles.get(i) instanceof WmfLocalDumpFile);
 			} else {
-				assertTrue(
-						dumpFiles.get(i) instanceof JsonOnlineDumpFile,
-						"Dumpfile " + dumpFiles.get(i) + " should be online.");
+				assertTrue("Dumpfile " + dumpFiles.get(i)
+						+ " should be online.",
+						dumpFiles.get(i) instanceof JsonOnlineDumpFile);
 			}
 		}
 	}

--- a/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/wmf/WmfDumpFileTest.java
+++ b/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/wmf/WmfDumpFileTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.dumpfiles.wmf;
+
 /*
  * #%L
  * Wikidata Toolkit Dump File Handling
@@ -18,12 +20,10 @@
  * #L%
  */
 
-package org.wikidata.wdtk.dumpfiles.wmf;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.util.CompressionType;
+
+import static org.junit.Assert.assertEquals;
 
 public class WmfDumpFileTest {
 

--- a/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/wmf/WmfLocalDumpFileTest.java
+++ b/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/wmf/WmfLocalDumpFileTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.dumpfiles.wmf;
+
 /*
  * #%L
  * Wikidata Toolkit Dump File Handling
@@ -18,17 +20,14 @@
  * #L%
  */
 
-package org.wikidata.wdtk.dumpfiles.wmf;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertFalse;
 
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 import org.mockito.Mockito;
 import org.wikidata.wdtk.dumpfiles.DumpContentType;
 import org.wikidata.wdtk.testing.MockDirectoryManager;
@@ -38,28 +37,28 @@ public class WmfLocalDumpFileTest {
 	MockDirectoryManager dm;
 	Path dmPath;
 
-	@BeforeEach
+	@Before
 	public void setUp() throws Exception {
 		this.dmPath = Paths.get(System.getProperty("user.dir"))
 				.resolve("dumpfiles").resolve("wikidatawiki");
 		this.dm = new MockDirectoryManager(this.dmPath, true, true);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void directoryDoesNotExist() {
-		assertThrows(IllegalArgumentException.class, () -> new WmfLocalDumpFile("20140220", "wikidatawiki", dm,
-				DumpContentType.DAILY));
+		new WmfLocalDumpFile("20140220", "wikidatawiki", dm,
+				DumpContentType.DAILY);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void directoryNotReadable() throws IOException {
 		MockDirectoryManager dm = Mockito.mock(MockDirectoryManager.class);
 		Mockito.when(dm.hasSubdirectory("daily-20140220")).thenReturn(true);
 		Mockito.doThrow(new IOException()).when(dm)
 				.getSubdirectoryManager("daily-20140220");
 
-		assertThrows(IllegalArgumentException.class, () -> new WmfLocalDumpFile("20140220", "wikidatawiki", dm,
-				DumpContentType.DAILY));
+		new WmfLocalDumpFile("20140220", "wikidatawiki", dm,
+				DumpContentType.DAILY);
 	}
 
 	@Test

--- a/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/wmf/WmfOnlineDailyDumpFileTest.java
+++ b/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/wmf/WmfOnlineDailyDumpFileTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.dumpfiles.wmf;
+
 /*
  * #%L
  * Wikidata Toolkit Dump File Handling
@@ -18,31 +20,25 @@
  * #L%
  */
 
-package org.wikidata.wdtk.dumpfiles.wmf;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Paths;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 import org.wikidata.wdtk.dumpfiles.DumpContentType;
 import org.wikidata.wdtk.testing.MockDirectoryManager;
 import org.wikidata.wdtk.testing.MockWebResourceFetcher;
 import org.wikidata.wdtk.util.CompressionType;
+
+import static org.junit.Assert.*;
 
 public class WmfOnlineDailyDumpFileTest {
 
 	MockWebResourceFetcher wrf;
 	MockDirectoryManager dm;
 
-	@BeforeEach
+	@Before
 	public void setUp() throws IOException {
 		dm = new MockDirectoryManager(
 				Paths.get(System.getProperty("user.dir")), true, false);
@@ -112,7 +108,7 @@ public class WmfOnlineDailyDumpFileTest {
 		assertFalse(dump.isAvailable());
 	}
 
-	@Test
+	@Test(expected = IOException.class)
 	public void downloadNoRevisionId() throws IOException {
 		String dateStamp = "20140220";
 		wrf.setWebResourceContents(
@@ -122,10 +118,10 @@ public class WmfOnlineDailyDumpFileTest {
 				CompressionType.BZ2);
 		WmfOnlineDailyDumpFile dump = new WmfOnlineDailyDumpFile(dateStamp,
 				"wikidatawiki", wrf, dm);
-		assertThrows(IOException.class, () -> dump.getDumpFileReader());
+		dump.getDumpFileReader();
 	}
 
-	@Test
+	@Test(expected = IOException.class)
 	public void downloadNoDumpFile() throws IOException {
 		String dateStamp = "20140220";
 		wrf.setWebResourceContents(
@@ -133,7 +129,7 @@ public class WmfOnlineDailyDumpFileTest {
 						+ dateStamp + "/status.txt", "done");
 		WmfOnlineDailyDumpFile dump = new WmfOnlineDailyDumpFile(dateStamp,
 				"wikidatawiki", wrf, dm);
-		assertThrows(IOException.class, () -> dump.getDumpFileReader());
+		dump.getDumpFileReader();
 	}
 
 }

--- a/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/wmf/WmfOnlineStandardDumpFileTest.java
+++ b/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/wmf/WmfOnlineStandardDumpFileTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.dumpfiles.wmf;
+
 /*
  * #%L
  * Wikidata Toolkit Dump File Handling
@@ -18,32 +20,26 @@
  * #L%
  */
 
-package org.wikidata.wdtk.dumpfiles.wmf;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.nio.file.Paths;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 import org.wikidata.wdtk.dumpfiles.DumpContentType;
 import org.wikidata.wdtk.dumpfiles.MwDumpFile;
 import org.wikidata.wdtk.testing.MockDirectoryManager;
 import org.wikidata.wdtk.testing.MockWebResourceFetcher;
 import org.wikidata.wdtk.util.CompressionType;
 
+import static org.junit.Assert.*;
+
 public class WmfOnlineStandardDumpFileTest {
 
 	MockWebResourceFetcher wrf;
 	MockDirectoryManager dm;
 
-	@BeforeEach
+	@Before
 	public void setUp() throws IOException {
 		dm = new MockDirectoryManager(
 				Paths.get(System.getProperty("user.dir")), true, false);
@@ -138,7 +134,7 @@ public class WmfOnlineStandardDumpFileTest {
 		assertEquals(DumpContentType.FULL, dump.getDumpContentType());
 	}
 
-	@Test
+	@Test(expected = IOException.class)
 	public void downloadNoRevisionId() throws IOException {
 		wrf.setWebResourceContents(
 				"http://dumps.wikimedia.org/wikidatawiki/20140210/wikidatawiki-20140210-pages-meta-current.xml.bz2",
@@ -148,10 +144,10 @@ public class WmfOnlineStandardDumpFileTest {
 				"/wikidatawiki-20140210-md5sums.txt", this.getClass());
 		MwDumpFile dump = new WmfOnlineStandardDumpFile("20140210",
 				"wikidatawiki", wrf, dm, DumpContentType.FULL);
-		assertThrows(IOException.class, () -> dump.getDumpFileReader());
+		dump.getDumpFileReader();
 	}
 
-	@Test
+	@Test(expected = IOException.class)
 	public void downloadNoMd5sum() throws IOException {
 		wrf.setWebResourceContents(
 				"http://dumps.wikimedia.org/wikidatawiki/20140210/wikidatawiki-20140210-pages-meta-current.xml.bz2",
@@ -161,10 +157,10 @@ public class WmfOnlineStandardDumpFileTest {
 				"/wikidatawiki-20140210-index.html", this.getClass());
 		MwDumpFile dump = new WmfOnlineStandardDumpFile("20140210",
 				"wikidatawiki", wrf, dm, DumpContentType.FULL);
-		assertThrows(IOException.class, () -> dump.getDumpFileReader());
+		dump.getDumpFileReader();
 	}
 
-	@Test
+	@Test(expected = IOException.class)
 	public void downloadNoDumpFile() throws IOException {
 		wrf.setWebResourceContentsFromResource(
 				"http://dumps.wikimedia.org/wikidatawiki/20140210/",
@@ -174,7 +170,7 @@ public class WmfOnlineStandardDumpFileTest {
 				"/wikidatawiki-20140210-md5sums.txt", this.getClass());
 		MwDumpFile dump = new WmfOnlineStandardDumpFile("20140210",
 				"wikidatawiki", wrf, dm, DumpContentType.CURRENT);
-		assertThrows(IOException.class, () -> dump.getDumpFileReader());
+		dump.getDumpFileReader();
 	}
 
 }

--- a/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/MockPropertyRegister.java
+++ b/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/MockPropertyRegister.java
@@ -20,11 +20,10 @@
 
 package org.wikidata.wdtk.rdf;
 
-import static org.junit.jupiter.api.Assertions.fail;
-
 import java.util.HashMap;
 import java.util.Map;
 
+import org.junit.Assert;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
@@ -51,7 +50,7 @@ public class MockPropertyRegister extends PropertyRegister {
 
 	@Override
 	protected void fetchPropertyInformation(PropertyIdValue startProperty) {
-		fail("Please add " + startProperty
+		Assert.fail("Please add " + startProperty
 				+ "to the datatypes and uriPatterns map.");
 	}
 

--- a/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/PropertyRegisterTest.java
+++ b/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/PropertyRegisterTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.rdf;
+
 /*
  * #%L
  * Wikidata Toolkit RDF
@@ -18,11 +20,9 @@
  * #L%
  */
 
-package org.wikidata.wdtk.rdf;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -32,8 +32,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.hamcrest.core.IsIterableContaining;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.hamcrest.MockitoHamcrest;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
@@ -59,7 +59,7 @@ public class PropertyRegisterTest {
 	final TestObjectFactory objectFactory = new TestObjectFactory();
 	final DataObjectFactory dataObjectFactory = new DataObjectFactoryImpl();
 
-	@BeforeEach
+	@Before
 	public void setUp() throws MediaWikiApiErrorException, IOException {
 		Map<String, EntityDocument> mockResult = new HashMap<>();
 		List<StatementGroup> mockStatementGroups = new ArrayList<>();
@@ -193,8 +193,8 @@ public class PropertyRegisterTest {
 		// Check twice to test fast failing on retry
 		assertNull(this.propertyRegister.getPropertyType(dataObjectFactory
 				.getPropertyIdValue("P10000", this.siteIri)));
-		assertEquals(smallestBefore, this.propertyRegister.smallestUnfetchedPropertyIdNumber,
-				"no requests should be made if the property is known to be missing");
+		assertEquals("no requests should be made if the property is known to be missing",
+				smallestBefore, this.propertyRegister.smallestUnfetchedPropertyIdNumber);
 	}
 
 	@Test

--- a/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/RdfConverterTest.java
+++ b/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/RdfConverterTest.java
@@ -20,8 +20,8 @@
 
 package org.wikidata.wdtk.rdf;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -38,9 +38,9 @@ import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.StatementBuilder;
 import org.wikidata.wdtk.datamodel.implementation.DataObjectFactoryImpl;
@@ -73,7 +73,7 @@ public class RdfConverterTest {
 	final TestObjectFactory objectFactory = new TestObjectFactory();
 	final DataObjectFactory dataObjectFactory = new DataObjectFactoryImpl();
 
-	@BeforeEach
+	@Before
 	public void setUp() {
 		this.out = new ByteArrayOutputStream();
 		this.rdfWriter = new RdfWriter(RDFFormat.TURTLE, out);
@@ -306,7 +306,7 @@ public class RdfConverterTest {
 				.getResourceFromFile("InterPropertyLinks.rdf")), model);
 	}
 
-	@AfterEach
+	@After
 	public void clear() throws RDFHandlerException, IOException {
 		this.out.close();
 	}

--- a/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/RdfSerializerTest.java
+++ b/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/RdfSerializerTest.java
@@ -20,7 +20,7 @@
 
 package org.wikidata.wdtk.rdf;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -30,8 +30,8 @@ import org.eclipse.rdf4j.model.util.Models;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.implementation.SitesImpl;
 
 public class RdfSerializerTest {
@@ -42,7 +42,7 @@ public class RdfSerializerTest {
 
 	RdfSerializer rdfSerializer;
 
-	@BeforeEach
+	@Before
 	public void setUp() {
 		this.out = new ByteArrayOutputStream();
 		this.rdfSerializer = new RdfSerializer(RDFFormat.TURTLE, this.out,

--- a/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/values/ValueRdfConverterTest.java
+++ b/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/values/ValueRdfConverterTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.rdf.values;
+
 /*
  * #%L
  * Wikidata Toolkit RDF
@@ -18,15 +20,15 @@
  * #L%
  */
 
-package org.wikidata.wdtk.rdf.values;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 
+import org.junit.Before;
+import org.junit.Test;
 import org.eclipse.rdf4j.model.BNode;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.Resource;
@@ -34,8 +36,6 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.eclipse.rdf4j.rio.RDFParseException;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.implementation.DataObjectFactoryImpl;
 import org.wikidata.wdtk.datamodel.implementation.UnsupportedEntityIdValueImpl;
@@ -62,7 +62,7 @@ public class ValueRdfConverterTest {
 
 	DataObjectFactory objectFactory = new DataObjectFactoryImpl();
 
-	@BeforeEach
+	@Before
 	public void setUp() {
 		this.out = new ByteArrayOutputStream();
 		this.rdfWriter = new RdfWriter(RDFFormat.TURTLE, this.out);

--- a/wdtk-storage/src/test/java/org/wikidata/wdtk/storage/datastructures/BitVectorImplTest.java
+++ b/wdtk-storage/src/test/java/org/wikidata/wdtk/storage/datastructures/BitVectorImplTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.storage.datastructures;
+
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -18,15 +20,8 @@
  * #L%
  */
 
-package org.wikidata.wdtk.storage.datastructures;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import org.junit.jupiter.api.Test;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Test class for {@link BitVectorImpl}.
@@ -46,33 +41,33 @@ public class BitVectorImplTest {
 	 *            another bit vector
 	 */
 	void assertEqualsForBitVector(BitVector bv0, BitVector bv1) {
-		assertEquals(bv0, bv0);
-		assertEquals(bv0, bv1);
-		assertEquals(bv1, bv0);
-		assertEquals(bv0.hashCode(), bv1.hashCode());
+		Assert.assertEquals(bv0, bv0);
+		Assert.assertEquals(bv0, bv1);
+		Assert.assertEquals(bv1, bv0);
+		Assert.assertEquals(bv0.hashCode(), bv1.hashCode());
 	}
 
 	@Test
 	public void testAdd() {
 		BitVectorImpl bv = new BitVectorImpl();
-		assertEquals(0, bv.size());
+		Assert.assertEquals(0, bv.size());
 
 		bv.addBit(true);
-		assertEquals(1, bv.size());
-		assertTrue(bv.getBit(0));
+		Assert.assertEquals(1, bv.size());
+		Assert.assertTrue(bv.getBit(0));
 
 		bv.addBit(false);
-		assertEquals(2, bv.size());
-		assertFalse(bv.getBit(1));
+		Assert.assertEquals(2, bv.size());
+		Assert.assertFalse(bv.getBit(1));
 
 		bv.addBit(false);
-		assertEquals(3, bv.size());
-		assertFalse(bv.getBit(2));
+		Assert.assertEquals(3, bv.size());
+		Assert.assertFalse(bv.getBit(2));
 
 		for (int i = 3; i < 0x1000; i++) {
 			boolean value = (i % 3) == 0;
 			bv.addBit(value);
-			assertEquals(value, bv.getBit(i));
+			Assert.assertEquals(value, bv.getBit(i));
 		}
 	}
 
@@ -90,8 +85,8 @@ public class BitVectorImplTest {
 	public void testEqualityAndCopyConstructor() {
 		int aLargeNumber = 0x100000;
 		BitVectorImpl bv0 = new BitVectorImpl();
-		assertEquals(bv0, bv0);
-		assertNotEquals(bv0, new Object());
+		Assert.assertEquals(bv0, bv0);
+		Assert.assertNotEquals(bv0, new Object());
 		BitVectorImpl bv1 = new BitVectorImpl();
 
 		PseudorandomBooleanGenerator generator = new PseudorandomBooleanGenerator(
@@ -109,12 +104,12 @@ public class BitVectorImplTest {
 		bv1.setBit(0x12345, false);
 		bv2.setBit(0x12345, true);
 
-		assertNotEquals(bv1, bv2);
-		assertNotEquals(bv2, bv1);
+		Assert.assertNotEquals(bv1, bv2);
+		Assert.assertNotEquals(bv2, bv1);
 
 		RankedBitVectorImpl bv3 = new RankedBitVectorImpl(bv2);
-		assertNotEquals(bv1, bv3);
-		assertNotEquals(bv3, bv1);
+		Assert.assertNotEquals(bv1, bv3);
+		Assert.assertNotEquals(bv3, bv1);
 	}
 
 	@Test
@@ -122,28 +117,28 @@ public class BitVectorImplTest {
 		long word = 0;
 
 		for (byte i = 0; i < 0x40; i++) {
-			assertFalse(BitVectorImpl.getBitInWord(i, word));
+			Assert.assertFalse(BitVectorImpl.getBitInWord(i, word));
 		}
 
 		word = 0x0810F;
 
-		assertTrue(BitVectorImpl.getBitInWord((byte) 0, word));
-		assertTrue(BitVectorImpl.getBitInWord((byte) 1, word));
-		assertTrue(BitVectorImpl.getBitInWord((byte) 2, word));
-		assertTrue(BitVectorImpl.getBitInWord((byte) 3, word));
-		assertFalse(BitVectorImpl.getBitInWord((byte) 4, word));
-		assertFalse(BitVectorImpl.getBitInWord((byte) 5, word));
-		assertFalse(BitVectorImpl.getBitInWord((byte) 6, word));
-		assertFalse(BitVectorImpl.getBitInWord((byte) 7, word));
-		assertTrue(BitVectorImpl.getBitInWord((byte) 8, word));
-		assertFalse(BitVectorImpl.getBitInWord((byte) 9, word));
-		assertFalse(BitVectorImpl.getBitInWord((byte) 10, word));
-		assertFalse(BitVectorImpl.getBitInWord((byte) 11, word));
-		assertFalse(BitVectorImpl.getBitInWord((byte) 12, word));
-		assertFalse(BitVectorImpl.getBitInWord((byte) 13, word));
-		assertFalse(BitVectorImpl.getBitInWord((byte) 14, word));
-		assertTrue(BitVectorImpl.getBitInWord((byte) 15, word));
-		assertFalse(BitVectorImpl.getBitInWord((byte) 16, word));
+		Assert.assertTrue(BitVectorImpl.getBitInWord((byte) 0, word));
+		Assert.assertTrue(BitVectorImpl.getBitInWord((byte) 1, word));
+		Assert.assertTrue(BitVectorImpl.getBitInWord((byte) 2, word));
+		Assert.assertTrue(BitVectorImpl.getBitInWord((byte) 3, word));
+		Assert.assertFalse(BitVectorImpl.getBitInWord((byte) 4, word));
+		Assert.assertFalse(BitVectorImpl.getBitInWord((byte) 5, word));
+		Assert.assertFalse(BitVectorImpl.getBitInWord((byte) 6, word));
+		Assert.assertFalse(BitVectorImpl.getBitInWord((byte) 7, word));
+		Assert.assertTrue(BitVectorImpl.getBitInWord((byte) 8, word));
+		Assert.assertFalse(BitVectorImpl.getBitInWord((byte) 9, word));
+		Assert.assertFalse(BitVectorImpl.getBitInWord((byte) 10, word));
+		Assert.assertFalse(BitVectorImpl.getBitInWord((byte) 11, word));
+		Assert.assertFalse(BitVectorImpl.getBitInWord((byte) 12, word));
+		Assert.assertFalse(BitVectorImpl.getBitInWord((byte) 13, word));
+		Assert.assertFalse(BitVectorImpl.getBitInWord((byte) 14, word));
+		Assert.assertTrue(BitVectorImpl.getBitInWord((byte) 15, word));
+		Assert.assertFalse(BitVectorImpl.getBitInWord((byte) 16, word));
 
 	}
 
@@ -151,66 +146,66 @@ public class BitVectorImplTest {
 	public void testHashCode() {
 		{
 			BitVectorImpl bv = new BitVectorImpl();
-			assertEquals(0, bv.hashCode());
+			Assert.assertEquals(0, bv.hashCode());
 
 			bv.addBit(false);
-			assertEquals(1, bv.hashCode());
+			Assert.assertEquals(1, bv.hashCode());
 		}
 		{
 			BitVectorImpl bv = new BitVectorImpl();
-			assertEquals(0, bv.hashCode());
+			Assert.assertEquals(0, bv.hashCode());
 
 			bv.addBit(true);
-			assertEquals(0x20, bv.hashCode());
+			Assert.assertEquals(0x20, bv.hashCode());
 		}
 	}
 
 	@Test
 	public void testGetOutOfRange() {
-		assertFalse(new BitVectorImpl().getBit(1));
-		assertFalse(new BitVectorImpl().getBit(Long.MAX_VALUE));
+		Assert.assertFalse(new BitVectorImpl().getBit(1));
+		Assert.assertFalse(new BitVectorImpl().getBit(Long.MAX_VALUE));
 	}
 
 	@Test
 	public void testSetOutOfRange() {
 		BitVectorImpl bv = new BitVectorImpl();
-		assertEquals(0, bv.size());
+		Assert.assertEquals(0, bv.size());
 		bv.setBit(41, true);
-		assertEquals(42, bv.size());
-		assertFalse(bv.getBit(40));
-		assertTrue(bv.getBit(41));
-		assertFalse(bv.getBit(42));
-		assertFalse(bv.getBit(43));
+		Assert.assertEquals(42, bv.size());
+		Assert.assertFalse(bv.getBit(40));
+		Assert.assertTrue(bv.getBit(41));
+		Assert.assertFalse(bv.getBit(42));
+		Assert.assertFalse(bv.getBit(43));
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testInvalidInitialSize() {
-		assertThrows(IllegalArgumentException.class, () -> new BitVectorImpl(-1));
+		new BitVectorImpl(-1);
 	}
 
-	@Test
+	@Test(expected = IndexOutOfBoundsException.class)
 	public void testInvalidPositionSizeGet00() {
-		assertThrows(IndexOutOfBoundsException.class, () -> new BitVectorImpl().getBit(-1));
+		(new BitVectorImpl()).getBit(-1);
 	}
 
-	@Test
+	@Test(expected = IndexOutOfBoundsException.class)
 	public void testInvalidPositionSizeGet01() {
-		assertThrows(IndexOutOfBoundsException.class, () -> BitVectorImpl.getBitInWord((byte) -1, 0));
+		BitVectorImpl.getBitInWord((byte) -1, 0);
 	}
 
-	@Test
+	@Test(expected = IndexOutOfBoundsException.class)
 	public void testInvalidPositionSizeGet02() {
-		assertThrows(IndexOutOfBoundsException.class, () -> BitVectorImpl.getBitInWord((byte) 0x40, 0));
+		BitVectorImpl.getBitInWord((byte) 0x40, 0);
 	}
 
-	@Test
+	@Test(expected = IndexOutOfBoundsException.class)
 	public void testInvalidPositionSizeSet00() {
-		assertThrows(IndexOutOfBoundsException.class, () -> BitVectorImpl.setBitInWord((byte) -1, true, 0));
+		BitVectorImpl.setBitInWord((byte) -1, true, 0);
 	}
 
-	@Test
+	@Test(expected = IndexOutOfBoundsException.class)
 	public void testInvalidPositionSizeSet01() {
-		assertThrows(IndexOutOfBoundsException.class, () -> BitVectorImpl.setBitInWord((byte) 0x40, false, 0));
+		BitVectorImpl.setBitInWord((byte) 0x40, false, 0);
 	}
 
 	@Test
@@ -222,7 +217,7 @@ public class BitVectorImplTest {
 		}
 
 		for (byte i = 0; i < 0x40; i++) {
-			assertTrue(BitVectorImpl.getBitInWord(i, word));
+			Assert.assertTrue(BitVectorImpl.getBitInWord(i, word));
 		}
 
 		for (byte i = 0; i < 0x40; i++) {
@@ -230,25 +225,25 @@ public class BitVectorImplTest {
 		}
 
 		for (byte i = 0; i < 0x40; i++) {
-			assertFalse(BitVectorImpl.getBitInWord(i, word));
+			Assert.assertFalse(BitVectorImpl.getBitInWord(i, word));
 		}
 
 		word = 0x0362;
 		for (byte i = 0; i < 0x40; i++) {
 			boolean value = BitVectorImpl.getBitInWord(i, word);
 			word = BitVectorImpl.setBitInWord(i, value, word);
-			assertEquals(value, BitVectorImpl.getBitInWord(i, word));
+			Assert.assertEquals(value, BitVectorImpl.getBitInWord(i, word));
 
 			value = !value;
 			word = BitVectorImpl.setBitInWord(i, value, word);
-			assertEquals(value, BitVectorImpl.getBitInWord(i, word));
+			Assert.assertEquals(value, BitVectorImpl.getBitInWord(i, word));
 
 			value = !value;
 			word = BitVectorImpl.setBitInWord(i, value, word);
-			assertEquals(value, BitVectorImpl.getBitInWord(i, word));
+			Assert.assertEquals(value, BitVectorImpl.getBitInWord(i, word));
 		}
 
-		assertEquals(0x0362, word);
+		Assert.assertEquals(0x0362, word);
 
 	}
 
@@ -256,18 +251,18 @@ public class BitVectorImplTest {
 	public void testSize() {
 		{
 			BitVectorImpl bv = new BitVectorImpl(0x100);
-			assertEquals(0x100, bv.size());
+			Assert.assertEquals(0x100, bv.size());
 			bv.addBit(false);
 			bv.addBit(true);
-			assertEquals(0x102, bv.size());
+			Assert.assertEquals(0x102, bv.size());
 		}
 
 		{
 			BitVectorImpl bv = new BitVectorImpl();
-			assertEquals(0, bv.size());
+			Assert.assertEquals(0, bv.size());
 			for (int i = 0; i < 0x300; i++) {
 				bv.addBit((i % 5) == 0);
-				assertEquals(i + 1, bv.size());
+				Assert.assertEquals(i + 1, bv.size());
 			}
 		}
 	}
@@ -279,39 +274,39 @@ public class BitVectorImplTest {
 			boolean value = (i % 3) == 0;
 			bv.addBit(value);
 		}
-		assertEquals("1001001001001001", bv.toString());
+		Assert.assertEquals("1001001001001001", bv.toString());
 
 		for (int i = 0; i < 0x10; i++) {
 			boolean value = (i % 2) == 0;
 			bv.addBit(value);
 		}
-		assertEquals("10010010010010011010101010101010", bv.toString());
+		Assert.assertEquals("10010010010010011010101010101010", bv.toString());
 
 		for (int i = 0; i < 0x20; i++) {
 			bv.setBit(i, bv.getBit(i));
 		}
-		assertEquals("10010010010010011010101010101010", bv.toString());
+		Assert.assertEquals("10010010010010011010101010101010", bv.toString());
 
 		for (int i = 0; i < 0x20; i++) {
 			bv.setBit(i, !bv.getBit(i));
 		}
-		assertEquals("01101101101101100101010101010101", bv.toString());
+		Assert.assertEquals("01101101101101100101010101010101", bv.toString());
 
 	}
 
 	@Test
 	public void testWordToString() {
 		long word = 0;
-		assertEquals(
+		Assert.assertEquals(
 				"0000000000000000000000000000000000000000000000000000000000000000",
 				BitVectorImpl.wordToString(word));
 		word = -1;
-		assertEquals(
+		Assert.assertEquals(
 				"1111111111111111111111111111111111111111111111111111111111111111",
 				BitVectorImpl.wordToString(word));
 
 		word = 0x362;
-		assertEquals(
+		Assert.assertEquals(
 				"0100011011000000000000000000000000000000000000000000000000000000",
 				BitVectorImpl.wordToString(word));
 	}

--- a/wdtk-storage/src/test/java/org/wikidata/wdtk/storage/datastructures/BitVectorIteratorTest.java
+++ b/wdtk-storage/src/test/java/org/wikidata/wdtk/storage/datastructures/BitVectorIteratorTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.storage.datastructures;
+
 /*
  * #%L
  * Wikidata Toolkit Storage
@@ -18,18 +20,12 @@
  * #L%
  */
 
-package org.wikidata.wdtk.storage.datastructures;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Test class for {@link BitVectorIterator}.
@@ -42,17 +38,17 @@ public class BitVectorIteratorTest {
 	@Test
 	public void testHashCode() {
 		Iterator<Boolean> it = (new BitVectorImpl()).iterator();
-		assertEquals(0, it.hashCode());
+		Assert.assertEquals(0, it.hashCode());
 	}
 
-	@Test
+	@Test(expected = NoSuchElementException.class)
 	public void testNoSuchElementException() {
-		assertThrows(NoSuchElementException.class, () -> new BitVectorImpl().iterator().next());
+		new BitVectorImpl().iterator().next();
 	}
 
-	@Test
+	@Test(expected = UnsupportedOperationException.class)
 	public void testUnsupportedOperationException() {
-		assertThrows(UnsupportedOperationException.class, () -> new BitVectorImpl().iterator().remove());
+		new BitVectorImpl().iterator().remove();
 	}
 
 	@Test
@@ -61,9 +57,9 @@ public class BitVectorIteratorTest {
 		BitVectorImpl bv1 = new BitVectorImpl();
 
 		Iterator<Boolean> it = bv0.iterator();
-		assertEquals(it, it);
-		assertEquals(bv0.iterator(), bv1.iterator());
-		assertNotEquals(bv0.iterator(), Collections.emptyIterator());
+		Assert.assertEquals(it, it);
+		Assert.assertEquals(bv0.iterator(), bv1.iterator());
+		Assert.assertNotEquals(bv0.iterator(), Collections.emptyIterator());
 
 		PseudorandomBooleanGenerator generator0 = new PseudorandomBooleanGenerator(
 				0x1234);
@@ -78,13 +74,13 @@ public class BitVectorIteratorTest {
 		int i = 0;
 		for (boolean value : bv0) {
 			boolean expectedValue = generator1.getPseudorandomBoolean();
-			assertEquals(expectedValue, value);
+			Assert.assertEquals(expectedValue, value);
 			i++;
 		}
 
-		assertEquals(i, 0x1000);
-		assertEquals(bv0.iterator(), bv1.iterator());
-		assertNotEquals(bv0.iterator(), (new BitVectorImpl()).iterator());
+		Assert.assertEquals(i, 0x1000);
+		Assert.assertEquals(bv0.iterator(), bv1.iterator());
+		Assert.assertNotEquals(bv0.iterator(), (new BitVectorImpl()).iterator());
 	}
 
 	@Test
@@ -98,12 +94,12 @@ public class BitVectorIteratorTest {
 
 			{
 				Iterator<Boolean> it = bv.iterator();
-				assertTrue(it.hasNext());
+				Assert.assertTrue(it.hasNext());
 				int i = 0;
 				while (it.hasNext()) {
 					boolean expectedValue = ((i % 3) == 0);
 					boolean value = it.next();
-					assertEquals(expectedValue, value);
+					Assert.assertEquals(expectedValue, value);
 					i++;
 				}
 			}
@@ -120,7 +116,7 @@ public class BitVectorIteratorTest {
 				int i = 0;
 				for (boolean value : bv) {
 					boolean expectedValue = (i % 7) == 0;
-					assertEquals(expectedValue, value);
+					Assert.assertEquals(expectedValue, value);
 					i++;
 				}
 			}

--- a/wdtk-storage/src/test/java/org/wikidata/wdtk/storage/datastructures/RankedBitVectorImplTest.java
+++ b/wdtk-storage/src/test/java/org/wikidata/wdtk/storage/datastructures/RankedBitVectorImplTest.java
@@ -20,15 +20,10 @@
 
 package org.wikidata.wdtk.storage.datastructures;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.util.Iterator;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Assert;
+import org.junit.Test;
 
 /**
  * Test class for {@link RankedBitVectorImpl}.
@@ -63,11 +58,11 @@ public class RankedBitVectorImplTest {
 	void assertCorrectCount(RankedBitVector bv, long position) {
 		long expectedCountBitsFalse = countBits(bv, false, position);
 		long computedCountBitsFalse = bv.countBits(false, position);
-		assertEquals(expectedCountBitsFalse, computedCountBitsFalse);
+		Assert.assertEquals(expectedCountBitsFalse, computedCountBitsFalse);
 
 		long expectedCountBitsTrue = countBits(bv, true, position);
 		long computedCountBitsTrue = bv.countBits(true, position);
-		assertEquals(expectedCountBitsTrue, computedCountBitsTrue);
+		Assert.assertEquals(expectedCountBitsTrue, computedCountBitsTrue);
 	}
 
 	/**
@@ -96,12 +91,12 @@ public class RankedBitVectorImplTest {
 	void assertCorrectFindPosition(RankedBitVector bv, long nOccurrences) {
 		long expectedFindPositionFalse = findPosition(bv, false, nOccurrences);
 		long computedFindPositionFalse = bv.findPosition(false, nOccurrences);
-		assertEquals(expectedFindPositionFalse,
+		Assert.assertEquals(expectedFindPositionFalse,
 				computedFindPositionFalse);
 
 		long expectedFindPositionTrue = findPosition(bv, true, nOccurrences);
 		long computedFindPositionTrue = bv.findPosition(true, nOccurrences);
-		assertEquals(expectedFindPositionTrue, computedFindPositionTrue);
+		Assert.assertEquals(expectedFindPositionTrue, computedFindPositionTrue);
 	}
 
 	/**
@@ -114,10 +109,10 @@ public class RankedBitVectorImplTest {
 	 *            another bit vector
 	 */
 	void assertEqualsForBitVector(RankedBitVector bv0, RankedBitVector bv1) {
-		assertEquals(bv0, bv0);
-		assertEquals(bv0, bv1);
-		assertEquals(bv1, bv0);
-		assertEquals(bv0.hashCode(), bv1.hashCode());
+		Assert.assertEquals(bv0, bv0);
+		Assert.assertEquals(bv0, bv1);
+		Assert.assertEquals(bv1, bv0);
+		Assert.assertEquals(bv0.hashCode(), bv1.hashCode());
 	}
 
 	/**
@@ -175,24 +170,24 @@ public class RankedBitVectorImplTest {
 	@Test
 	public void testAdd() {
 		RankedBitVectorImpl bv = new RankedBitVectorImpl();
-		assertEquals(0, bv.size());
+		Assert.assertEquals(0, bv.size());
 
 		bv.addBit(true);
-		assertEquals(1, bv.size());
-		assertTrue(bv.getBit(0));
+		Assert.assertEquals(1, bv.size());
+		Assert.assertTrue(bv.getBit(0));
 
 		bv.addBit(false);
-		assertEquals(2, bv.size());
-		assertFalse(bv.getBit(1));
+		Assert.assertEquals(2, bv.size());
+		Assert.assertFalse(bv.getBit(1));
 
 		bv.addBit(false);
-		assertEquals(3, bv.size());
-		assertFalse(bv.getBit(2));
+		Assert.assertEquals(3, bv.size());
+		Assert.assertFalse(bv.getBit(2));
 
 		for (int i = 3; i < 0x1000; i++) {
 			boolean value = (i % 3) == 0;
 			bv.addBit(value);
-			assertEquals(value, bv.getBit(i));
+			Assert.assertEquals(value, bv.getBit(i));
 			assertCorrectCount(bv, i);
 		}
 	}
@@ -219,11 +214,11 @@ public class RankedBitVectorImplTest {
 	@Test
 	public void testEmptyBitVector() {
 		RankedBitVectorImpl bv0 = new RankedBitVectorImpl();
-		assertEquals(0, bv0.size());
+		Assert.assertEquals(0, bv0.size());
 		assertCorrectCount(bv0);
 		assertCorrectFindPosition(bv0);
-		assertNotEquals(bv0, new Object());
-		assertEquals(bv0, new BitVectorImpl());
+		Assert.assertNotEquals(bv0, new Object());
+		Assert.assertEquals(bv0, new BitVectorImpl());
 
 		RankedBitVector bv1 = new RankedBitVectorImpl();
 		RankedBitVectorImpl bv2 = new RankedBitVectorImpl(0);
@@ -261,12 +256,12 @@ public class RankedBitVectorImplTest {
 	}
 
 	void testFindPositionWithBitVector(RankedBitVectorImpl bv) {
-		assertEquals(0, bv.size());
+		Assert.assertEquals(0, bv.size());
 
 		bv.addBit(true);
 
-		assertEquals(RankedBitVector.NOT_FOUND, bv.findPosition(true, 0));
-		assertEquals(0, bv.findPosition(true, 1));
+		Assert.assertEquals(RankedBitVector.NOT_FOUND, bv.findPosition(true, 0));
+		Assert.assertEquals(0, bv.findPosition(true, 1));
 
 		bv.addBit(true);
 		bv.addBit(false);
@@ -276,50 +271,50 @@ public class RankedBitVectorImplTest {
 		bv.addBit(false);
 		bv.addBit(true);
 
-		assertEquals(RankedBitVector.NOT_FOUND,
+		Assert.assertEquals(RankedBitVector.NOT_FOUND,
 				bv.findPosition(false, 0));
-		assertEquals(RankedBitVector.NOT_FOUND, bv.findPosition(true, 0));
-		assertEquals(0, bv.findPosition(true, 1));
-		assertEquals(1, bv.findPosition(true, 2));
-		assertEquals(2, bv.findPosition(false, 1));
-		assertEquals(3, bv.findPosition(true, 3));
-		assertEquals(4, bv.findPosition(false, 2));
-		assertEquals(5, bv.findPosition(false, 3));
-		assertEquals(6, bv.findPosition(false, 4));
-		assertEquals(7, bv.findPosition(true, 4));
-		assertEquals(RankedBitVector.NOT_FOUND,
+		Assert.assertEquals(RankedBitVector.NOT_FOUND, bv.findPosition(true, 0));
+		Assert.assertEquals(0, bv.findPosition(true, 1));
+		Assert.assertEquals(1, bv.findPosition(true, 2));
+		Assert.assertEquals(2, bv.findPosition(false, 1));
+		Assert.assertEquals(3, bv.findPosition(true, 3));
+		Assert.assertEquals(4, bv.findPosition(false, 2));
+		Assert.assertEquals(5, bv.findPosition(false, 3));
+		Assert.assertEquals(6, bv.findPosition(false, 4));
+		Assert.assertEquals(7, bv.findPosition(true, 4));
+		Assert.assertEquals(RankedBitVector.NOT_FOUND,
 				bv.findPosition(false, 5));
-		assertEquals(RankedBitVector.NOT_FOUND, bv.findPosition(true, 5));
+		Assert.assertEquals(RankedBitVector.NOT_FOUND, bv.findPosition(true, 5));
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testInvalidInitialSizes0() {
-		assertThrows(IllegalArgumentException.class, () -> new RankedBitVectorImpl(1, 0, 0x40));
+		new RankedBitVectorImpl(1, 0, 0x40);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testInvalidInitialSizes1() {
-		assertThrows(IllegalArgumentException.class, () -> new RankedBitVectorImpl(1, 2, 0x3F));
+		new RankedBitVectorImpl(1, 2, 0x3F);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testInvalidInitialSizes2() {
-		assertThrows(IllegalArgumentException.class, () -> new CountBitsArray(new BitVectorImpl(), 0));
+		new CountBitsArray(new BitVectorImpl(), 0);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testInvalidInitialSizes3() {
-		assertThrows(IllegalArgumentException.class, () -> new FindPositionArray(0, new BitVectorImpl(), true));
+		new FindPositionArray(0, new BitVectorImpl(), true);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testInvalidInitialSizes4() {
-		assertThrows(IllegalArgumentException.class, () -> new FindPositionArray(new BitVectorImpl(), true, 0x3F));
+		new FindPositionArray(new BitVectorImpl(), true, 0x3F);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testInvalidInitialSizes5() {
-		assertThrows(IllegalArgumentException.class, () -> new RankedBitVectorImpl(-1));
+		new RankedBitVectorImpl(-1);
 	}
 
 	@Test
@@ -327,25 +322,25 @@ public class RankedBitVectorImplTest {
 		RankedBitVectorImpl bv = new RankedBitVectorImpl(new BitVectorImpl());
 		PseudorandomBooleanGenerator generator = new PseudorandomBooleanGenerator(
 				0x7531);
-		assertEquals(0, bv.size());
+		Assert.assertEquals(0, bv.size());
 		for (int i = 0; i < 0x300; i++) {
 			bv.addBit(generator.getPseudorandomBoolean());
 		}
 		Iterator<Boolean> it = bv.iterator();
 		for (int i = 0; i < 0x300; i++) {
 			boolean value = it.next();
-			assertEquals(bv.getBit(i), value);
+			Assert.assertEquals(bv.getBit(i), value);
 		}
-		assertFalse(it.hasNext());
+		Assert.assertFalse(it.hasNext());
 	}
 
 	@Test
 	public void testSize0() {
 		RankedBitVectorImpl bv = new RankedBitVectorImpl(0x100);
-		assertEquals(0x100, bv.size());
+		Assert.assertEquals(0x100, bv.size());
 		bv.addBit(false);
 		bv.addBit(true);
-		assertEquals(0x102, bv.size());
+		Assert.assertEquals(0x102, bv.size());
 		assertCorrectCount(bv);
 		assertCorrectFindPosition(bv);
 	}
@@ -353,10 +348,10 @@ public class RankedBitVectorImplTest {
 	@Test
 	public void testSize1() {
 		RankedBitVectorImpl bv = new RankedBitVectorImpl();
-		assertEquals(0, bv.size());
+		Assert.assertEquals(0, bv.size());
 		for (int i = 0; i < 0x300; i++) {
 			bv.addBit((i % 5) == 0);
-			assertEquals(i + 1, bv.size());
+			Assert.assertEquals(i + 1, bv.size());
 		}
 		assertCorrectCount(bv);
 		assertCorrectFindPosition(bv);
@@ -369,7 +364,7 @@ public class RankedBitVectorImplTest {
 			boolean value = (i % 3) == 0;
 			bv.addBit(value);
 		}
-		assertEquals("1001001001001001", bv.toString());
+		Assert.assertEquals("1001001001001001", bv.toString());
 		assertCorrectCount(bv);
 		assertCorrectFindPosition(bv);
 
@@ -377,21 +372,21 @@ public class RankedBitVectorImplTest {
 			boolean value = (i % 2) == 0;
 			bv.addBit(value);
 		}
-		assertEquals("10010010010010011010101010101010", bv.toString());
+		Assert.assertEquals("10010010010010011010101010101010", bv.toString());
 		assertCorrectCount(bv);
 		assertCorrectFindPosition(bv);
 
 		for (int i = 0; i < 0x20; i++) {
 			bv.setBit(i, bv.getBit(i));
 		}
-		assertEquals("10010010010010011010101010101010", bv.toString());
+		Assert.assertEquals("10010010010010011010101010101010", bv.toString());
 		assertCorrectCount(bv);
 		assertCorrectFindPosition(bv);
 
 		for (int i = 0; i < 0x20; i++) {
 			bv.setBit(i, !bv.getBit(i));
 		}
-		assertEquals("01101101101101100101010101010101", bv.toString());
+		Assert.assertEquals("01101101101101100101010101010101", bv.toString());
 		assertCorrectCount(bv);
 		assertCorrectFindPosition(bv);
 	}
@@ -409,13 +404,13 @@ public class RankedBitVectorImplTest {
 		bv.addBit(true);
 
 		CountBitsArray cba = new CountBitsArray(bv, 2);
-		assertEquals("[1, 3, 3, 4]", cba.toString());
+		Assert.assertEquals("[1, 3, 3, 4]", cba.toString());
 
 		FindPositionArray fpa = new FindPositionArray(2, bv, false);
-		assertEquals("[-1, 4, 6]", fpa.toString());
+		Assert.assertEquals("[-1, 4, 6]", fpa.toString());
 
-		assertEquals(RankedBitVector.NOT_FOUND, fpa.findPosition(0));
-		assertEquals(4, fpa.findPosition(2));
+		Assert.assertEquals(RankedBitVector.NOT_FOUND, fpa.findPosition(0));
+		Assert.assertEquals(4, fpa.findPosition(2));
 	}
 
 	@Test

--- a/wdtk-testing/src/test/java/org/wikidata/wdtk/testing/MockDirectoryManagerTest.java
+++ b/wdtk-testing/src/test/java/org/wikidata/wdtk/testing/MockDirectoryManagerTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.testing;
+
 /*
  * #%L
  * Wikidata Toolkit Dump File Handling
@@ -18,14 +20,6 @@
  * #L%
  */
 
-package org.wikidata.wdtk.testing;
-
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.BufferedWriter;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -38,17 +32,19 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashSet;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 import org.wikidata.wdtk.util.CompressionType;
 import org.wikidata.wdtk.util.DirectoryManager;
+
+import static org.junit.Assert.*;
 
 public class MockDirectoryManagerTest {
 
 	MockDirectoryManager mdm;
 	Path basePath;
 
-	@BeforeEach
+	@Before
 	public void setUp() throws Exception {
 		basePath = Paths.get(System.getProperty("user.dir"));
 		mdm = new MockDirectoryManager(basePath, true, false);
@@ -69,10 +65,10 @@ public class MockDirectoryManagerTest {
 		assertTrue(mdm.hasSubdirectory("newdir"));
 	}
 
-	@Test
+	@Test(expected = IOException.class)
 	public void subdirectoryManagerConflict() throws IOException {
 		DirectoryManager submdm = mdm.getSubdirectoryManager("dir2");
-		assertThrows(IOException.class, () -> submdm.getSubdirectoryManager("test.txt"));
+		submdm.getSubdirectoryManager("test.txt");
 	}
 
 	@Test
@@ -187,52 +183,52 @@ public class MockDirectoryManagerTest {
 		assertTrue(exception);
 	}
 
-	@Test
+	@Test(expected = FileAlreadyExistsException.class)
 	public void createFileConflict() throws IOException {
 		DirectoryManager submdm = mdm.getSubdirectoryManager("dir2");
-		assertThrows(FileAlreadyExistsException.class, () -> submdm.createFile("test.txt", "New contents"));
+		submdm.createFile("test.txt", "New contents");
 	}
 
-	@Test
+	@Test(expected = FileNotFoundException.class)
 	public void fileNotFound() throws IOException {
-		assertThrows(FileNotFoundException.class, () -> mdm.getInputStreamForFile("test.txt", CompressionType.NONE));
+		mdm.getInputStreamForFile("test.txt", CompressionType.NONE);
 	}
 
-	@Test
+	@Test(expected = IOException.class)
 	public void createFileFromStringReadOnly() throws IOException {
 		DirectoryManager mdmReadOnly = new MockDirectoryManager(basePath,
 				false, true);
-		assertThrows(IOException.class, () -> mdmReadOnly.createFile("newfile.txt", "New contents"));
+		mdmReadOnly.createFile("newfile.txt", "New contents");
 	}
 
-	@Test
+	@Test(expected = IOException.class)
 	public void createFileFromInputStreamReadOnly() throws IOException {
 		DirectoryManager mdmReadOnly = new MockDirectoryManager(basePath,
 				false, true);
-		assertThrows(IOException.class, () -> mdmReadOnly.createFile("newfile.txt",
-				MockStringContentFactory.newMockInputStream("content")));
+		mdmReadOnly.createFile("newfile.txt",
+				MockStringContentFactory.newMockInputStream("content"));
 	}
 
-	@Test
+	@Test(expected = IOException.class)
 	public void createFileFromInputStreamAtomicReadOnly() throws IOException {
 		DirectoryManager mdmReadOnly = new MockDirectoryManager(basePath,
 				false, true);
-		assertThrows(IOException.class, () -> mdmReadOnly.createFileAtomic("newfile.txt",
-				MockStringContentFactory.newMockInputStream("content")));
+		mdmReadOnly.createFileAtomic("newfile.txt",
+				MockStringContentFactory.newMockInputStream("content"));
 	}
 
-	@Test
+	@Test(expected = IOException.class)
 	public void getOutputStreamReadOnly() throws IOException {
 		DirectoryManager mdmReadOnly = new MockDirectoryManager(basePath,
 				false, true);
-		assertThrows(IOException.class, () -> mdmReadOnly.getOutputStreamForFile("newfile.txt"));
+		mdmReadOnly.getOutputStreamForFile("newfile.txt");
 	}
 
-	@Test
+	@Test(expected = IOException.class)
 	public void openInNonexistingDirectoryReadOnly() throws IOException {
 		DirectoryManager mdmReadOnly = new MockDirectoryManager(basePath,
 				false, true);
-		assertThrows(IOException.class, () -> mdmReadOnly.getSubdirectoryManager("doesNotExist"));
+		mdmReadOnly.getSubdirectoryManager("doesNotExist");
 	}
 
 }

--- a/wdtk-testing/src/test/java/org/wikidata/wdtk/testing/MockWebResourceFetcherTest.java
+++ b/wdtk-testing/src/test/java/org/wikidata/wdtk/testing/MockWebResourceFetcherTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.testing;
+
 /*
  * #%L
  * Wikidata Toolkit Dump File Handling
@@ -18,23 +20,20 @@
  * #L%
  */
 
-package org.wikidata.wdtk.testing;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 
 public class MockWebResourceFetcherTest {
 
 	MockWebResourceFetcher mwrf;
 
-	@BeforeEach
+	@Before
 	public void setUp() throws Exception {
 		mwrf = new MockWebResourceFetcher();
 		mwrf.setWebResourceContents("http://example.com/test.html",
@@ -74,9 +73,9 @@ public class MockWebResourceFetcherTest {
 		assertTrue(exception);
 	}
 
-	@Test
-	public void readOnlyMockedUrls() {
-		assertThrows(IOException.class, () -> mwrf.getInputStreamForUrl("http://not-mocked.com"));
+	@Test(expected = IOException.class)
+	public void readOnlyMockedUrls() throws IOException {
+		mwrf.getInputStreamForUrl("http://not-mocked.com");
 	}
 
 }

--- a/wdtk-util/src/test/java/org/wikidata/wdtk/util/DirectoryManagerFactoryTest.java
+++ b/wdtk-util/src/test/java/org/wikidata/wdtk/util/DirectoryManagerFactoryTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.util;
+
 /*
  * #%L
  * Wikidata Toolkit Utilities
@@ -18,11 +20,8 @@
  * #L%
  */
 
-package org.wikidata.wdtk.util;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -31,8 +30,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 
 public class DirectoryManagerFactoryTest {
 
@@ -84,7 +83,7 @@ public class DirectoryManagerFactoryTest {
 		}
 	}
 
-	@BeforeEach
+	@Before
 	public void setup() throws IOException {
 		DirectoryManagerFactory
 				.setDirectoryManagerClass(DirectoryManagerImpl.class);
@@ -112,17 +111,17 @@ public class DirectoryManagerFactoryTest {
 		assertEquals(path, dmi.directory);
 	}
 
-	@Test
-	public void createDirectoryManagerNoConstructor() {
+	@Test(expected = RuntimeException.class)
+	public void createDirectoryManagerNoConstructor() throws IOException {
 		DirectoryManagerFactory
 				.setDirectoryManagerClass(TestDirectoryManager.class);
-		assertThrows(RuntimeException.class, () -> DirectoryManagerFactory.createDirectoryManager("/", true));
+		DirectoryManagerFactory.createDirectoryManager("/", true);
 	}
 
-	@Test
-	public void createDirectoryManagerIoException() {
-		assertThrows(IOException.class, () -> DirectoryManagerFactory.createDirectoryManager(
-				"/nonexisting-directory/123456789/hopefully", true));
+	@Test(expected = IOException.class)
+	public void createDirectoryManagerIoException() throws IOException {
+		DirectoryManagerFactory.createDirectoryManager(
+				"/nonexisting-directory/123456789/hopefully", true);
 	}
 
 }

--- a/wdtk-util/src/test/java/org/wikidata/wdtk/util/DirectoryManagerTest.java
+++ b/wdtk-util/src/test/java/org/wikidata/wdtk/util/DirectoryManagerTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.util;
+
 /*
  * #%L
  * Wikidata Toolkit Utilities
@@ -18,10 +20,7 @@
  * #L%
  */
 
-package org.wikidata.wdtk.util;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertEquals;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
@@ -36,8 +35,8 @@ import java.nio.file.Paths;
 
 import org.apache.commons.compress.compressors.bzip2.BZip2CompressorOutputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 
 /**
  * Test for directory manager implementation. We can only test the read-only
@@ -50,7 +49,7 @@ public class DirectoryManagerTest {
 
 	DirectoryManagerImpl dm;
 
-	@BeforeEach
+	@Before
 	public void setUp() throws Exception {
 		Path path = Paths.get(System.getProperty("user.dir"));
 		dm = new DirectoryManagerImpl(path, true);
@@ -62,33 +61,33 @@ public class DirectoryManagerTest {
 				dm.toString());
 	}
 
-	@Test
+	@Test(expected = IOException.class)
 	public void MissingSubdirectoryReadOnly() throws IOException {
-		assertThrows(IOException.class, () -> dm.getSubdirectoryManager("1 2 3 not a subdirectory that exists in the test system, hopefully"));
+		dm.getSubdirectoryManager("1 2 3 not a subdirectory that exists in the test system, hopefully");
 	}
 
-	@Test
+	@Test(expected = IOException.class)
 	public void OutputStreamReadOnly() throws IOException {
-		assertThrows(IOException.class, () -> dm.getOutputStreamForFile("file.txt"));
+		dm.getOutputStreamForFile("file.txt");
 	}
 
-	@Test
+	@Test(expected = IOException.class)
 	public void NoCreateFileStringReadOnly() throws IOException {
-		assertThrows(IOException.class, () -> dm.createFile("new-test-file.txt", "new contents"));
+		dm.createFile("new-test-file.txt", "new contents");
 	}
 
-	@Test
+	@Test(expected = IOException.class)
 	public void NoCreateFileInputStreamReadOnly() throws IOException {
 		ByteArrayInputStream in = new ByteArrayInputStream(
 				"new contents".getBytes(StandardCharsets.UTF_8));
-		assertThrows(IOException.class, () -> dm.createFile("new-test-file.txt", in));
+		dm.createFile("new-test-file.txt", in);
 	}
 
-	@Test
+	@Test(expected = IOException.class)
 	public void NoCreateFileAtomicInputStreamReadOnly() throws IOException {
 		ByteArrayInputStream in = new ByteArrayInputStream(
 				"new contents".getBytes(StandardCharsets.UTF_8));
-		assertThrows(IOException.class, () -> dm.createFileAtomic("new-test-file.txt", in));
+		dm.createFileAtomic("new-test-file.txt", in);
 	}
 
 	@Test

--- a/wdtk-util/src/test/java/org/wikidata/wdtk/util/NestedIteratorTest.java
+++ b/wdtk-util/src/test/java/org/wikidata/wdtk/util/NestedIteratorTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.util;
+
 /*
  * #%L
  * Wikidata Toolkit Utilities
@@ -18,19 +20,14 @@
  * #L%
  */
 
-package org.wikidata.wdtk.util;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
 
 public class NestedIteratorTest {
 
@@ -65,25 +62,25 @@ public class NestedIteratorTest {
 		assertFalse(nestedIterator.hasNext());
 	}
 
-	@Test
+	@Test(expected = UnsupportedOperationException.class)
 	public void removeNotSupported() {
 		NestedIterator<String> nestedIterator = new NestedIterator<>(
 				Collections.singletonList(Collections.singletonList("Test")));
-		assertThrows(UnsupportedOperationException.class, () -> nestedIterator.remove());
+		nestedIterator.remove();
 	}
 
-	@Test
+	@Test(expected = NoSuchElementException.class)
 	public void iterateBeyondInnerList() {
 		NestedIterator<String> nestedIterator = new NestedIterator<>(
 				Collections.singletonList(Collections.emptyList()));
-		assertThrows(NoSuchElementException.class, () -> nestedIterator.next());
+		nestedIterator.next();
 	}
 
-	@Test
+	@Test(expected = NoSuchElementException.class)
 	public void iterateBeyondOuterList() {
 		NestedIterator<String> nestedIterator = new NestedIterator<>(
 				Collections.emptyList());
-		assertThrows(NoSuchElementException.class, () -> nestedIterator.next());
+		nestedIterator.next();
 	}
 
 }

--- a/wdtk-util/src/test/java/org/wikidata/wdtk/util/TimerTest.java
+++ b/wdtk-util/src/test/java/org/wikidata/wdtk/util/TimerTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.util;
+
 /*
  * #%L
  * Wikidata Toolkit utilities
@@ -18,18 +20,13 @@
  * #L%
  */
 
-package org.wikidata.wdtk.util;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.*;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
 import java.util.Random;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class TimerTest {
 
@@ -82,22 +79,22 @@ public class TimerTest {
 		long wallTime1 = System.nanoTime();
 		timer.start();
 		doDummyComputation();
-		assertTrue(timer.isRunning(), "Timer should be running");
+		assertTrue("Timer should be running", timer.isRunning());
 		timer.stop();
 		cpuTime1 = tmxb.getThreadCpuTime(threadId) - cpuTime1;
 		wallTime1 = System.nanoTime() - wallTime1;
 		assertTrue(
+				"Unrealistic CPU time: " + timer.getTotalCpuTime()
+						+ " should be closer to " + cpuTime1,
 				(cpuTime1 - TimerTest.TIME_TOLERANCE) <= timer
 						.getTotalCpuTime()
-						&& timer.getTotalCpuTime() <= cpuTime1,
-				"Unrealistic CPU time: " + timer.getTotalCpuTime()
-						+ " should be closer to " + cpuTime1);
+						&& timer.getTotalCpuTime() <= cpuTime1);
 		assertTrue(
+				"Unrealistic wall time: " + timer.getTotalWallTime()
+						+ " should be closer to " + wallTime1,
 				(wallTime1 - 2 * TimerTest.TIME_TOLERANCE) <= timer
 						.getTotalWallTime()
-						&& timer.getTotalWallTime() <= wallTime1,
-				"Unrealistic wall time: " + timer.getTotalWallTime()
-						+ " should be closer to " + wallTime1);
+						&& timer.getTotalWallTime() <= wallTime1);
 
 		long cpuTime2 = tmxb.getThreadCpuTime(threadId);
 		long wallTime2 = System.nanoTime();
@@ -107,17 +104,17 @@ public class TimerTest {
 		cpuTime1 += tmxb.getThreadCpuTime(threadId) - cpuTime2;
 		wallTime1 += System.nanoTime() - wallTime2;
 		assertTrue(
+				"Unrealistic total CPU time: " + timer.getTotalCpuTime()
+						+ " should be closer to " + cpuTime1,
 				(cpuTime1 - 2 * TimerTest.TIME_TOLERANCE) <= timer
 						.getTotalCpuTime()
-						&& timer.getTotalCpuTime() <= cpuTime1,
-				"Unrealistic total CPU time: " + timer.getTotalCpuTime()
-						+ " should be closer to " + cpuTime1);
+						&& timer.getTotalCpuTime() <= cpuTime1);
 		assertTrue(
+				"Unrealistic total wall time: " + timer.getTotalWallTime()
+						+ " should be closer to " + wallTime1,
 				(wallTime1 - 4 * TimerTest.TIME_TOLERANCE) <= timer
 						.getTotalWallTime()
-						&& timer.getTotalWallTime() <= wallTime1,
-				"Unrealistic total wall time: " + timer.getTotalWallTime()
-						+ " should be closer to " + wallTime1);
+						&& timer.getTotalWallTime() <= wallTime1);
 
 		assertEquals(timer.getTotalCpuTime() / 2, timer.getAvgCpuTime());
 		assertEquals(timer.getTotalWallTime() / 2, timer.getAvgWallTime());
@@ -125,7 +122,7 @@ public class TimerTest {
 		timer.reset();
 		assertEquals(timer.getTotalCpuTime(), 0);
 		assertEquals(timer.getTotalWallTime(), 0);
-		assertFalse(timer.isRunning(), "Timer should not be running");
+		assertFalse("Timer should not be running", timer.isRunning());
 	}
 
 	@Test
@@ -166,22 +163,22 @@ public class TimerTest {
 		Timer.stopNamedTimer("test timer", Timer.RECORD_WALLTIME);
 		Timer.stopNamedTimer("test timer", Timer.RECORD_ALL, 0);
 
-		assertTrue(timerA1.getTotalCpuTime() > 0,
-				"Named timer should have measured a non-zero CPU time.");
-		assertTrue(timerA1.getTotalWallTime() > 0,
-				"Named timer should have measured a non-zero wall time.");
+		assertTrue("Named timer should have measured a non-zero CPU time.",
+				timerA1.getTotalCpuTime() > 0);
+		assertTrue("Named timer should have measured a non-zero wall time.",
+				timerA1.getTotalWallTime() > 0);
 		assertTrue(
-				timerCpu.getTotalCpuTime() > 0,
-				"Timer for CPU time should have measured a non-zero CPU time.");
-		assertEquals(0, timerCpu.getTotalWallTime(), "Timer for CPU time should not have measured a wall time.");
-		assertEquals(0, timerWall.getTotalCpuTime(), "Timer for wall time should not have measured a CPU time.");
+				"Timer for CPU time should have measured a non-zero CPU time.",
+				timerCpu.getTotalCpuTime() > 0);
+		assertEquals("Timer for CPU time should not have measured a wall time.", 0, timerCpu.getTotalWallTime());
+		assertEquals("Timer for wall time should not have measured a CPU time.", 0, timerWall.getTotalCpuTime());
 		assertTrue(
-				timerWall.getTotalWallTime() > 0,
-				"Timer for wall time should have measured a non-zero wall time.");
-		assertEquals(0, timerNoThread.getTotalCpuTime(), "Timer without threadId should not have measured a CPU time.");
+				"Timer for wall time should have measured a non-zero wall time.",
+				timerWall.getTotalWallTime() > 0);
+		assertEquals("Timer without threadId should not have measured a CPU time.", 0, timerNoThread.getTotalCpuTime());
 		assertTrue(
-				timerNoThread.getTotalWallTime() > 0,
-				"Timer without threadId should have measured a non-zero wall time.");
+				"Timer without threadId should have measured a non-zero wall time.",
+				timerNoThread.getTotalWallTime() > 0);
 
 		// Testing total timer creation:
 		Timer totalTimer1 = Timer.getNamedTotalTimer("test timer");
@@ -223,14 +220,14 @@ public class TimerTest {
 		Timer.resetNamedTimer("test timer", Timer.RECORD_WALLTIME);
 		Timer.resetNamedTimer("test timer", Timer.RECORD_ALL, 0);
 
-		assertEquals(0, timerA1.getTotalCpuTime(), "Named timer should have reset CPU time.");
-		assertEquals(0, timerA1.getTotalWallTime(), "Named timer should have reset wall time.");
-		assertEquals(0, timerCpu.getTotalCpuTime(), "Timer for CPU time should have reset CPU time.");
-		assertEquals(0, timerCpu.getTotalWallTime(), "Timer for CPU time should have reset wall time.");
-		assertEquals(0, timerWall.getTotalCpuTime(), "Timer for wall time should have reset CPU time.");
-		assertEquals(0, timerWall.getTotalWallTime(), "Timer for wall time should have reset wall time.");
-		assertEquals(0, timerNoThread.getTotalCpuTime(), "Timer without threadId should have reset CPU time.");
-		assertEquals(0, timerNoThread.getTotalWallTime(), "Timer without threadId should have reset wall time.");
+		assertEquals("Named timer should have reset CPU time.", 0, timerA1.getTotalCpuTime());
+		assertEquals("Named timer should have reset wall time.", 0, timerA1.getTotalWallTime());
+		assertEquals("Timer for CPU time should have reset CPU time.", 0, timerCpu.getTotalCpuTime());
+		assertEquals("Timer for CPU time should have reset wall time.", 0, timerCpu.getTotalWallTime());
+		assertEquals("Timer for wall time should have reset CPU time.", 0, timerWall.getTotalCpuTime());
+		assertEquals("Timer for wall time should have reset wall time.", 0, timerWall.getTotalWallTime());
+		assertEquals("Timer without threadId should have reset CPU time.", 0, timerNoThread.getTotalCpuTime());
+		assertEquals("Timer without threadId should have reset wall time.", 0, timerNoThread.getTotalWallTime());
 
 		// Testing unregistered timer stop (does not create one):
 		assertEquals(Timer.stopNamedTimer("unknown name"), -1);
@@ -264,7 +261,7 @@ public class TimerTest {
 		doDummyComputation();
 		timer.stop();
 
-		assertTrue(timer.getTotalCpuTime() > 0,
-				"Timer should have measured a CPU time.");
+		assertTrue("Timer should have measured a CPU time.",
+				timer.getTotalCpuTime() > 0);
 	}
 }

--- a/wdtk-util/src/test/java/org/wikidata/wdtk/util/WebResourceFetcherTest.java
+++ b/wdtk-util/src/test/java/org/wikidata/wdtk/util/WebResourceFetcherTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.util;
+
 /*
  * #%L
  * Wikidata Toolkit Utilities
@@ -18,22 +20,20 @@
  * #L%
  */
 
-package org.wikidata.wdtk.util;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.net.InetSocketAddress;
 import java.net.Proxy;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class WebResourceFetcherTest {
 
 	@Test
 	public void testSetUserAgent() {
 		WebResourceFetcherImpl.setUserAgent("My user agent");
-		assertEquals(WebResourceFetcherImpl.getUserAgent(), "My user agent");
+		assertEquals("My user agent", WebResourceFetcherImpl.getUserAgent());
 	}
 
 	@Test

--- a/wdtk-wikibaseapi/pom.xml
+++ b/wdtk-wikibaseapi/pom.xml
@@ -39,7 +39,7 @@
 		</dependency>
 		<dependency>
 			<groupId>com.squareup.okhttp3</groupId>
-			<artifactId>mockwebserver3-junit5</artifactId>
+			<artifactId>mockwebserver</artifactId>
 			<version>${okhttpVersion}</version>
 			<scope>test</scope>
 		</dependency>

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnectionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnectionTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.wikibaseapi;
+
 /*
  * #%L
  * Wikidata Toolkit Wikibase API
@@ -18,15 +20,9 @@
  * #L%
  */
 
-package org.wikidata.wdtk.wikibaseapi;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.FileWriter;
@@ -43,10 +39,15 @@ import java.util.StringTokenizer;
 import java.util.TreeSet;
 
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Before;
+import org.junit.Test;
+
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.wikidata.wdtk.testing.MockStringContentFactory;
 import org.wikidata.wdtk.wikibaseapi.apierrors.AssertUserFailedException;
 import org.wikidata.wdtk.wikibaseapi.apierrors.MaxlagErrorException;
@@ -55,10 +56,7 @@ import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import mockwebserver3.Dispatcher;
-import mockwebserver3.MockResponse;
-import mockwebserver3.MockWebServer;
-import mockwebserver3.RecordedRequest;
+import static org.junit.Assert.*;
 
 public class BasicApiConnectionTest {
 
@@ -88,7 +86,7 @@ public class BasicApiConnectionTest {
 				.setBody(body);
 	}
 
-	@BeforeAll
+	@BeforeClass
 	public static void init() throws Exception {
 		Dispatcher dispatcher = new Dispatcher() {
 
@@ -137,12 +135,12 @@ public class BasicApiConnectionTest {
 		server.start();
 	}
 
-	@AfterAll
+	@AfterClass
 	public static void finish() throws IOException {
 		server.shutdown();
 	}
 
-	@BeforeEach
+	@Before
 	public void setUp() {
 		connection = new BasicApiConnection(server.url("/w/api.php").toString());
 	}
@@ -218,10 +216,10 @@ public class BasicApiConnectionTest {
 		assertFalse(connection.loggedIn);
 	}
 
-	@Test
+	@Test(expected = LoginFailedException.class)
 	public void loginUserErrors() throws LoginFailedException {
 		// This will fail because the user is not known
-		assertThrows(LoginFailedException.class, () -> connection.login("username1", "password1"));
+		connection.login("username1", "password1");
 	}
 
 	@Test
@@ -273,13 +271,13 @@ public class BasicApiConnectionTest {
 		assertEquals(expectedWarnings, warnings);
 	}
 
-	@Test
+	@Test(expected = MediaWikiApiErrorException.class)
 	public void testErrors() throws IOException,
 			MediaWikiApiErrorException {
 		JsonNode root;
 		URL path = this.getClass().getResource("/error.json");
 		root = mapper.readTree(path.openStream());
-		assertThrows(MediaWikiApiErrorException.class, () -> connection.checkErrors(root));
+		connection.checkErrors(root);
 	}
 	
 	@Test
@@ -343,13 +341,13 @@ public class BasicApiConnectionTest {
 		}
 	}
 
-	@Test
+	@Test(expected = AssertUserFailedException.class)
 	public void testCheckCredentials() throws IOException, MediaWikiApiErrorException, LoginFailedException {
 		// we first login successfully
 		connection.login("username", "password");
 		assertTrue(connection.isLoggedIn());
 		// after a while, the credentials expire
-		assertThrows(AssertUserFailedException.class, () -> connection.checkCredentials());
+		connection.checkCredentials();
 	}
 
 	/**
@@ -395,8 +393,8 @@ public class BasicApiConnectionTest {
 		assertEquals("{\"entities\":{\"Q8\":{\"pageid\":134,\"ns\":0,\"title\":\"Q8\",\"lastrevid\":1174289176,\"modified\":\"2020-05-05T12:39:07Z\",\"type\":\"item\",\"id\":\"Q8\"}},\"success\":1}", mapper.writeValueAsString(root));
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testUnsupportedMethod() throws IOException, MediaWikiApiErrorException {
-		assertThrows(IllegalArgumentException.class, () -> connection.sendJsonRequest("PUT", new HashMap<>()));
+		connection.sendJsonRequest("PUT", new HashMap<>());
 	}
 }

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/OAuthApiConnectionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/OAuthApiConnectionTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.wikibaseapi;
+
 /*
  * #%L
  * Wikidata Toolkit Wikibase API
@@ -18,33 +20,26 @@
  * #L%
  */
 
-package org.wikidata.wdtk.wikibaseapi;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.io.IOException;
-import java.util.Collections;
-
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.Collections;
 
-import mockwebserver3.Dispatcher;
-import mockwebserver3.MockResponse;
-import mockwebserver3.MockWebServer;
-import mockwebserver3.RecordedRequest;
+import static org.junit.Assert.*;
 
 public class OAuthApiConnectionTest {
 
@@ -79,7 +74,7 @@ public class OAuthApiConnectionTest {
             "\"connectTimeout\":-1," +
             "\"readTimeout\":-1}";
 
-    @BeforeAll
+    @BeforeClass
     public static void init() throws IOException {
         Dispatcher dispatcher = new Dispatcher() {
 
@@ -105,12 +100,12 @@ public class OAuthApiConnectionTest {
         server.start();
     }
 
-    @AfterAll
+    @AfterClass
     public static void finish() throws IOException {
         server.shutdown();
     }
 
-    @BeforeEach
+    @Before
     public void setUp() {
         connection = new OAuthApiConnection(server.url("/w/api.php").toString(),
                 CONSUMER_KEY, CONSUMER_SECRET, ACCESS_TOKEN, ACCESS_SECRET);
@@ -160,10 +155,10 @@ public class OAuthApiConnectionTest {
     public void testDeserialize() throws IOException {
         OAuthApiConnection newConnection = mapper.readValue(LOGGED_IN_SERIALIZED, OAuthApiConnection.class);
         assertTrue(newConnection.isLoggedIn());
-        assertEquals(newConnection.getConsumerKey(), CONSUMER_KEY);
-        assertEquals(newConnection.getConsumerSecret(), CONSUMER_SECRET);
-        assertEquals(newConnection.getAccessToken(), ACCESS_TOKEN);
-        assertEquals(newConnection.getAccessSecret(), ACCESS_SECRET);
+        assertEquals(CONSUMER_KEY, newConnection.getConsumerKey());
+        assertEquals(CONSUMER_SECRET, newConnection.getConsumerSecret());
+        assertEquals(ACCESS_TOKEN, newConnection.getAccessToken());
+        assertEquals(ACCESS_SECRET, newConnection.getAccessSecret());
         assertEquals(server.url("/w/api.php").toString(), newConnection.getApiBaseUrl());
         assertEquals("foo", newConnection.getCurrentUser());
         assertEquals(-1, connection.getConnectTimeout());
@@ -175,10 +170,10 @@ public class OAuthApiConnectionTest {
     public void testDeserializeNotLogin() throws IOException {
         OAuthApiConnection connection = mapper.readValue(NOT_LOGGED_IN_SERIALIZED, OAuthApiConnection.class);
         assertFalse(connection.isLoggedIn());
-        assertNull(connection.getConsumerKey(), CONSUMER_KEY);
-        assertNull(connection.getConsumerSecret(), CONSUMER_SECRET);
-        assertNull(connection.getAccessToken(), ACCESS_TOKEN);
-        assertNull(connection.getAccessSecret(), ACCESS_SECRET);
+        assertNull(CONSUMER_KEY, connection.getConsumerKey());
+        assertNull(CONSUMER_SECRET, connection.getConsumerSecret());
+        assertNull(ACCESS_TOKEN, connection.getAccessToken());
+        assertNull(ACCESS_SECRET, connection.getAccessSecret());
         assertEquals(server.url("/w/api.php").toString(), connection.getApiBaseUrl());
         assertEquals(-1, connection.getConnectTimeout());
         assertEquals(-1, connection.getReadTimeout());

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/StatementUpdateTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/StatementUpdateTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.wikibaseapi;
+
 /*
  * #%L
  * Wikidata Toolkit Wikibase API
@@ -18,23 +20,21 @@
  * #L%
  */
 
-package org.wikidata.wdtk.wikibaseapi;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.ItemDocumentBuilder;
-import org.wikidata.wdtk.datamodel.helpers.JsonSerializer;
 import org.wikidata.wdtk.datamodel.helpers.ReferenceBuilder;
 import org.wikidata.wdtk.datamodel.helpers.StatementBuilder;
+import org.wikidata.wdtk.datamodel.helpers.JsonSerializer;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdateTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdateTest.java
@@ -20,15 +20,15 @@
 
 package org.wikidata.wdtk.wikibaseapi;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.ItemDocumentBuilder;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WbEditingActionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WbEditingActionTest.java
@@ -1,3 +1,7 @@
+package org.wikidata.wdtk.wikibaseapi;
+
+import static org.junit.Assert.assertEquals;
+
 /*
  * #%L
  * Wikidata Toolkit Wikibase API
@@ -18,17 +22,15 @@
  * #L%
  */
 
-package org.wikidata.wdtk.wikibaseapi;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.Assert.assertNull;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
+import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
 import org.wikidata.wdtk.util.CompressionType;
 import org.wikidata.wdtk.wikibaseapi.apierrors.MaxlagErrorException;
 import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
@@ -36,18 +38,19 @@ import org.wikidata.wdtk.wikibaseapi.apierrors.TokenErrorException;
 
 public class WbEditingActionTest {
 
-	@Test
+	@Test(expected = IOException.class)
 	public void testOffineErrors() throws IOException,
 			MediaWikiApiErrorException {
 		MockBasicApiConnection con = new MockBasicApiConnection();
 		WbEditingAction weea = new WbEditingAction(con,
 				Datamodel.SITE_WIKIDATA);
 
-		assertThrows(IOException.class, () -> weea.wbEditEntity("Q42", null, null, null,
-				"{}", true, false, 0, null, null));
+		EntityDocument result = weea.wbEditEntity("Q42", null, null, null,
+				"{}", true, false, 0, null, null);
+		assertNull(result);
 	}
 
-	@Test
+	@Test(expected = TokenErrorException.class)
 	public void testApiErrorGettingToken() throws IOException,
 			MediaWikiApiErrorException {
 		MockBasicApiConnection con = new MockBasicApiConnection();
@@ -73,10 +76,10 @@ public class WbEditingActionTest {
 
 		WbEditingAction weea = new WbEditingAction(con,
 				Datamodel.SITE_WIKIDATA);
-		assertThrows(TokenErrorException.class, () -> weea.wbEditEntity("Q42", null, null, null, "{}", false, false, 0, null, null));
+		weea.wbEditEntity("Q42", null, null, null, "{}", false, false, 0, null, null);
 	}
 
-	@Test
+	@Test(expected = TokenErrorException.class)
 	public void testNoTokenInReponse() throws IOException,
 			MediaWikiApiErrorException {
 		MockBasicApiConnection con = new MockBasicApiConnection();
@@ -102,10 +105,10 @@ public class WbEditingActionTest {
 		WbEditingAction weea = new WbEditingAction(con,
 				Datamodel.SITE_WIKIDATA);
 
-		assertThrows(TokenErrorException.class, () -> weea.wbEditEntity("Q42", null, null, null, "{}", false, false, 0, null, null));
+		weea.wbEditEntity("Q42", null, null, null, "{}", false, false, 0, null, null);
 	}
 
-	@Test
+	@Test(expected = MaxlagErrorException.class)
 	public void testApiErrorMaxLag() throws IOException,
 			MediaWikiApiErrorException {
 		MockBasicApiConnection con = new MockBasicApiConnection();
@@ -131,64 +134,64 @@ public class WbEditingActionTest {
 		WbEditingAction weea = new WbEditingAction(con,
 				Datamodel.SITE_WIKIDATA);
 		weea.setMaxLagFirstWaitTime(0); // speed up the test ...
-		assertThrows(MaxlagErrorException.class, () -> weea.wbEditEntity("Q42", null, null, null, "{}", false, false, 0, null, null));
+		weea.wbEditEntity("Q42", null, null, null, "{}", false, false, 0, null, null);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testIdAndSite() throws IOException, MediaWikiApiErrorException {
 		WbEditingAction weea = new WbEditingAction(
 				new MockBasicApiConnection(), Datamodel.SITE_WIKIDATA);
-		assertThrows(IllegalArgumentException.class, () -> weea.wbEditEntity("Q1234", "enwiki", null, null, "{}", false, false, 0,
-				null, null));
+		weea.wbEditEntity("Q1234", "enwiki", null, null, "{}", false, false, 0,
+				null, null);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testIdAndTitle() throws IOException, MediaWikiApiErrorException {
 		WbEditingAction weea = new WbEditingAction(
 				new MockBasicApiConnection(), Datamodel.SITE_WIKIDATA);
-		assertThrows(IllegalArgumentException.class, () -> weea.wbEditEntity("Q1234", null, "Title", null, "{}", false, false, 0,
-				null, null));
+		weea.wbEditEntity("Q1234", null, "Title", null, "{}", false, false, 0,
+				null, null);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testTitleNoSite() throws IOException,
 			MediaWikiApiErrorException {
 		WbEditingAction weea = new WbEditingAction(
 				new MockBasicApiConnection(), Datamodel.SITE_WIKIDATA);
-		assertThrows(IllegalArgumentException.class, () -> weea.wbEditEntity(null, null, "Title", null, "{}", false, false, 0,
-				null, null));
+		weea.wbEditEntity(null, null, "Title", null, "{}", false, false, 0,
+				null, null);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testNewAndId() throws IOException, MediaWikiApiErrorException {
 		WbEditingAction weea = new WbEditingAction(
 				new MockBasicApiConnection(), Datamodel.SITE_WIKIDATA);
-		assertThrows(IllegalArgumentException.class, () -> weea.wbEditEntity("Q1234", null, null, "item", "{}", false, false, 0,
-				null, null));
+		weea.wbEditEntity("Q1234", null, null, "item", "{}", false, false, 0,
+				null, null);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testNewAndSite() throws IOException, MediaWikiApiErrorException {
 		WbEditingAction weea = new WbEditingAction(
 				new MockBasicApiConnection(), Datamodel.SITE_WIKIDATA);
-		assertThrows(IllegalArgumentException.class, () -> weea.wbEditEntity(null, "enwiki", null, "item", "{}", false, false, 0,
-				null, null));
+		weea.wbEditEntity(null, "enwiki", null, "item", "{}", false, false, 0,
+				null, null);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testNewAndTitle() throws IOException,
 			MediaWikiApiErrorException {
 		WbEditingAction weea = new WbEditingAction(
 				new MockBasicApiConnection(), Datamodel.SITE_WIKIDATA);
-		assertThrows(IllegalArgumentException.class, () -> weea.wbEditEntity(null, null, "Title", "item", "{}", false, false, 0,
-				null, null));
+		weea.wbEditEntity(null, null, "Title", "item", "{}", false, false, 0,
+				null, null);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testNoTask() throws IOException, MediaWikiApiErrorException {
 		WbEditingAction weea = new WbEditingAction(
 				new MockBasicApiConnection(), Datamodel.SITE_WIKIDATA);
-		assertThrows(IllegalArgumentException.class, () -> weea.wbEditEntity(null, null, null, null, "{}", false, false, 0, null, null));
+		weea.wbEditEntity(null, null, null, null, "{}", false, false, 0, null, null);
 	}
 	
 	@Test

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WbGetEntitiesActionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WbGetEntitiesActionTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.wikibaseapi;
+
 /*
  * #%L
  * Wikidata Toolkit Wikibase API
@@ -18,18 +20,15 @@
  * #L%
  */
 
-package org.wikidata.wdtk.wikibaseapi;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
 import org.wikidata.wdtk.util.CompressionType;
@@ -40,7 +39,7 @@ public class WbGetEntitiesActionTest {
 	MockBasicApiConnection con;
 	WbGetEntitiesAction action;
 
-	@BeforeEach
+	@Before
 	public void setUp() throws Exception {
 
 		this.con = new MockBasicApiConnection();
@@ -123,31 +122,31 @@ public class WbGetEntitiesActionTest {
 		assertEquals(result1, result2);
 	}
 
-	@Test
+	@Test(expected = IOException.class)
 	public void testWbGetEntitiesIoError() throws MediaWikiApiErrorException, IOException {
 		WbGetEntitiesActionData properties = new WbGetEntitiesActionData();
 		properties.ids = "Q6|Q42|notmocked";
-		assertThrows(IOException.class, () -> action.wbGetEntities(properties));
+		action.wbGetEntities(properties);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testIdsAndTitles() throws MediaWikiApiErrorException, IOException {
-		assertThrows(IllegalArgumentException.class, () -> action.wbGetEntities("Q42", null, "Tim Berners Lee", null, null, null));
+		action.wbGetEntities("Q42", null, "Tim Berners Lee", null, null, null);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testIdsAndSites() throws MediaWikiApiErrorException, IOException {
-		assertThrows(IllegalArgumentException.class, () -> action.wbGetEntities("Q42", "enwiki", null, null, null, null));
+		action.wbGetEntities("Q42", "enwiki", null, null, null, null);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testTitlesNoSites() throws MediaWikiApiErrorException, IOException {
-		assertThrows(IllegalArgumentException.class, () -> action.wbGetEntities(null, null, "Tim Berners Lee", null, null, null));
+		action.wbGetEntities(null, null, "Tim Berners Lee", null, null, null);
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void testNoTitlesOrIds() throws MediaWikiApiErrorException, IOException {
-		assertThrows(IllegalArgumentException.class, () -> action.wbGetEntities(null, "enwiki", null, null, null, null));
+		action.wbGetEntities(null, "enwiki", null, null, null, null);
 	}
 	
 	// for https://github.com/Wikidata/Wikidata-Toolkit/issues/643

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesActionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesActionTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.wikibaseapi;
+
 /*
  * #%L
  * Wikidata Toolkit Wikibase API
@@ -18,11 +20,8 @@
  * #L%
  */
 
-package org.wikidata.wdtk.wikibaseapi;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -30,8 +29,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.util.CompressionType;
 import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
@@ -41,7 +40,7 @@ public class WbSearchEntitiesActionTest {
     MockBasicApiConnection con;
     WbSearchEntitiesAction action;
 
-    @BeforeEach
+    @Before
     public void setUp() throws Exception {
 
         this.con = new MockBasicApiConnection();
@@ -95,13 +94,13 @@ public class WbSearchEntitiesActionTest {
         assertTrue(results.isEmpty());
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testIdsAndTitles() throws MediaWikiApiErrorException, IOException {
-        assertThrows(IllegalArgumentException.class, () -> action.wbSearchEntities(null, "en", null, null, null, null));
+        action.wbSearchEntities(null, "en", null, null, null, null);
     }
 
-    @Test
+    @Test(expected = IllegalArgumentException.class)
     public void testIdsAndSites() throws MediaWikiApiErrorException, IOException {
-        assertThrows(IllegalArgumentException.class, () -> action.wbSearchEntities("abc", null, null, null, null, null));
+        action.wbSearchEntities("abc", null, null, null, null, null);
     }
 }

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditorTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditorTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.wikibaseapi;
+
 /*
  * #%L
  * Wikidata Toolkit Wikibase API
@@ -18,12 +20,6 @@
  * #L%
  */
 
-package org.wikidata.wdtk.wikibaseapi;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
@@ -42,8 +38,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.AliasUpdateBuilder;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.FormUpdateBuilder;
@@ -76,6 +72,8 @@ import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
 import org.wikidata.wdtk.wikibaseapi.apierrors.TagsApplyNotAllowedException;
 import org.wikidata.wdtk.wikibaseapi.apierrors.TokenErrorException;
 
+import static org.junit.Assert.*;
+
 public class WikibaseDataEditorTest {
 
 	MockBasicApiConnection con;
@@ -84,7 +82,7 @@ public class WikibaseDataEditorTest {
 	static final String TEST_GUID = "427C0317-BA8C-95B0-16C8-1A1B5FAC1081";
 	MockGuidGenerator guids = new MockGuidGenerator(TEST_GUID);
 
-	@BeforeEach
+	@Before
 	public void setUp() throws IOException {
 		this.con = new MockBasicApiConnection();
 		Map<String, String> params = new HashMap<>();
@@ -225,7 +223,7 @@ public class WikibaseDataEditorTest {
 		assertEquals(-1, wde.getRemainingEdits());
 	}
 
-	@Test
+	@Test(expected = TokenErrorException.class)
 	public void testCreateItemBadToken() throws IOException,
 			MediaWikiApiErrorException {
 		WikibaseDataEditor wde = new WikibaseDataEditor(this.con,
@@ -246,7 +244,7 @@ public class WikibaseDataEditorTest {
 		this.con.setWebResourceFromPath(params, this.getClass(),
 				"/error-badtoken.json", CompressionType.NONE);
 
-		assertThrows(TokenErrorException.class, () -> wde.createItemDocument(itemDocument, "My summary", null));
+		wde.createItemDocument(itemDocument, "My summary", null);
 	}
 
 	@Test
@@ -317,7 +315,7 @@ public class WikibaseDataEditorTest {
 		assertEquals(expectedResultDocument, result);
 	}
 
-	@Test
+	@Test(expected = IOException.class)
 	public void testCreateItemBadEntityDocumentJson() throws IOException,
 			MediaWikiApiErrorException {
 		// Test what happens if the API returns JSON without an actual entity
@@ -340,10 +338,10 @@ public class WikibaseDataEditorTest {
 		params.put("data", data);
 		con.setWebResource(params, expectedResult);
 
-		assertThrows(IOException.class, () -> wde.createItemDocument(itemDocument, "My summary", null));
+		wde.createItemDocument(itemDocument, "My summary", null);
 	}
 
-	@Test
+	@Test(expected = IOException.class)
 	public void testCreateItemMissingEntityDocumentJson() throws IOException,
 			MediaWikiApiErrorException {
 		WikibaseDataEditor wde = new WikibaseDataEditor(this.con,
@@ -364,7 +362,7 @@ public class WikibaseDataEditorTest {
 		params.put("data", data);
 		con.setWebResource(params, expectedResult);
 
-		assertThrows(IOException.class, () -> wde.createItemDocument(itemDocument, "My summary", null));
+		wde.createItemDocument(itemDocument, "My summary", null);
 	}
 
 	@Test
@@ -841,9 +839,9 @@ public class WikibaseDataEditorTest {
 		assertEquals(expectedResultDocument, result);
 	}
 	
-	@Test
 	@Deprecated
 	@SuppressWarnings("deprecation")
+	@Test(expected = TagsApplyNotAllowedException.class)
 	public void testApplyInvalidTag() throws MediaWikiApiErrorException, IOException {
 		WikibaseDataEditor wde = new WikibaseDataEditor(this.con,
 				Datamodel.SITE_WIKIDATA);
@@ -874,10 +872,10 @@ public class WikibaseDataEditorTest {
 				+ "\"servedby\":\"mw1276\"}";
 		con.setWebResource(params, expectedResult);
 
-		assertThrows(TagsApplyNotAllowedException.class, () -> wde.updateTermsStatements(itemDocument, Collections.<MonolingualTextValue>emptyList(),
+		wde.updateTermsStatements(itemDocument, Collections.<MonolingualTextValue>emptyList(),
 				Collections.singletonList(description),	Collections.<MonolingualTextValue>emptyList(),
 				Collections.<MonolingualTextValue>emptyList(), Collections.<Statement>emptyList(),
-				Collections.<Statement>emptyList(), "testing tags", Collections.singletonList("tag_which_does_not_exist")));
+				Collections.<Statement>emptyList(), "testing tags", Collections.singletonList("tag_which_does_not_exist"));
 	}
 
 	private WbEditingAction mockEntityUpdate(EntityUpdate update) throws MediaWikiApiErrorException, IOException {

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataFetcherTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataFetcherTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.wikibaseapi;
+
 /*
  * #%L
  * Wikidata Toolkit Wikibase API
@@ -18,25 +20,11 @@
  * #L%
  */
 
-package org.wikidata.wdtk.wikibaseapi;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.Before;
+import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoIdValue;
@@ -44,12 +32,14 @@ import org.wikidata.wdtk.util.CompressionType;
 import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
 import org.wikidata.wdtk.wikibaseapi.apierrors.NoSuchEntityErrorException;
 
+import static org.junit.Assert.*;
+
 public class WikibaseDataFetcherTest {
 
 	MockBasicApiConnection con;
 	WikibaseDataFetcher wdf;
 
-	@BeforeEach
+	@Before
 	public void setUp() {
 		con = new MockBasicApiConnection();
 		wdf = new WikibaseDataFetcher(con, Datamodel.SITE_WIKIDATA);
@@ -102,7 +92,7 @@ public class WikibaseDataFetcherTest {
 		assertNull(result);
 	}
 
-	@Test
+	@Test(expected = NoSuchEntityErrorException.class)
 	public void testWbGetEntitiesError() throws IOException,
 			MediaWikiApiErrorException {
 		Map<String, String> parameters = new HashMap<>();
@@ -111,7 +101,7 @@ public class WikibaseDataFetcherTest {
 		// We use the mock answer as for a multi request; no problem
 		con.setWebResourceFromPath(parameters, getClass(),
 				"/wbgetentities-bogus.json", CompressionType.NONE);
-		assertThrows(NoSuchEntityErrorException.class, () -> wdf.getEntityDocuments("bogus"));
+		wdf.getEntityDocuments("bogus");
 	}
 
 	@Test

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/apierrors/MediaWikiApiErrorHandlerTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/apierrors/MediaWikiApiErrorHandlerTest.java
@@ -1,3 +1,5 @@
+package org.wikidata.wdtk.wikibaseapi.apierrors;
+
 /*
  * #%L
  * Wikidata Toolkit Wikibase API
@@ -18,12 +20,9 @@
  * #L%
  */
 
-package org.wikidata.wdtk.wikibaseapi.apierrors;
+import static org.junit.Assert.assertEquals;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-import org.junit.jupiter.api.Test;
+import org.junit.Test;
 
 public class MediaWikiApiErrorHandlerTest {
 
@@ -43,35 +42,35 @@ public class MediaWikiApiErrorHandlerTest {
 		assertEquals("some message", message);
 	}
 
-	@Test
+	@Test(expected = TokenErrorException.class)
 	public void testNoTokenError() throws MediaWikiApiErrorException {
-		assertThrows(TokenErrorException.class, () -> MediaWikiApiErrorHandler.throwMediaWikiApiErrorException(
-				MediaWikiApiErrorHandler.ERROR_NO_TOKEN, "some message"));
+		MediaWikiApiErrorHandler.throwMediaWikiApiErrorException(
+				MediaWikiApiErrorHandler.ERROR_NO_TOKEN, "some message");
 	}
 
-	@Test
+	@Test(expected = TokenErrorException.class)
 	public void testBadTokenError() throws MediaWikiApiErrorException {
-		assertThrows(TokenErrorException.class, () -> MediaWikiApiErrorHandler.throwMediaWikiApiErrorException(
-				MediaWikiApiErrorHandler.ERROR_INVALID_TOKEN, "some message"));
+		MediaWikiApiErrorHandler.throwMediaWikiApiErrorException(
+				MediaWikiApiErrorHandler.ERROR_INVALID_TOKEN, "some message");
 	}
 
-	@Test
+	@Test(expected = EditConflictErrorException.class)
 	public void testEditConflictError() throws MediaWikiApiErrorException {
-		assertThrows(EditConflictErrorException.class, () -> MediaWikiApiErrorHandler.throwMediaWikiApiErrorException(
-				MediaWikiApiErrorHandler.ERROR_EDIT_CONFLICT, "some message"));
+		MediaWikiApiErrorHandler.throwMediaWikiApiErrorException(
+				MediaWikiApiErrorHandler.ERROR_EDIT_CONFLICT, "some message");
 	}
 
-	@Test
+	@Test(expected = NoSuchEntityErrorException.class)
 	public void testNoSuchEntityError() throws MediaWikiApiErrorException {
-		assertThrows(NoSuchEntityErrorException.class, () -> MediaWikiApiErrorHandler.throwMediaWikiApiErrorException(
-				MediaWikiApiErrorHandler.ERROR_NO_SUCH_ENTITY, "some message"));
+		MediaWikiApiErrorHandler.throwMediaWikiApiErrorException(
+				MediaWikiApiErrorHandler.ERROR_NO_SUCH_ENTITY, "some message");
 	}
 
-	@Test
+	@Test(expected = MaxlagErrorException.class)
 	public void testMaxlagError() throws MediaWikiApiErrorException {
-		assertThrows(MaxlagErrorException.class, () -> MediaWikiApiErrorHandler.throwMediaWikiApiErrorException(
+		MediaWikiApiErrorHandler.throwMediaWikiApiErrorException(
 				MediaWikiApiErrorHandler.ERROR_MAXLAG,
-				"Waiting for 10.64.16.27: 2 seconds lagged"));
+				"Waiting for 10.64.16.27: 2 seconds lagged");
 	}
 
 }


### PR DESCRIPTION
Upgrading to JUnit5 requires upgrading OkHTTP to a newer version, but our okhttp-signpost dependency still relies on an earlier version. This means that at the moment we depend on two different versions of the same library, causing #600.

This closes #600.

This reverts commit 522abd40ce8fdd407f97580cbe190e28c2593c28.

This is a temporary workaround. We should then consider:
* whether we can upgrade okhttp-signpost to OkHTTP 5 (the maintainer looks responsive)
* or whether there are alternatives to okhttp-signpost which use more recent versions of OkHTTP

Also, I propose we only migrate to OkHTTP 5 once we have a stable release of that library (so that we do not depend on an alpha version as currently).