### PR TITLE
Fix deserialization of unknown property datatypes

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Equality.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Equality.java
@@ -86,7 +86,8 @@ public class Equality {
 			return true;
 		}
 		return o2 instanceof DatatypeIdValue
-			&& o1.getIri().equals(((DatatypeIdValue) o2).getIri());
+			&& o1.getIri().equals(((DatatypeIdValue) o2).getIri())
+			&& o1.getJsonString().equals(((DatatypeIdValue) o2).getJsonString());
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ToString.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/ToString.java
@@ -122,7 +122,7 @@ public class ToString {
 	 * @return a string representation of the object
 	 */
 	public static String toString(DatatypeIdValue o) {
-		return o.getIri();
+		return o.getIri() + " (" + o.getJsonString() + ")";
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImpl.java
@@ -113,6 +113,11 @@ public class DataObjectFactoryImpl implements DataObjectFactory {
 	}
 
 	@Override
+	public DatatypeIdValue getDatatypeIdValue(String id, String jsonString) {
+		return new DatatypeIdImpl(id, jsonString);
+	}
+
+	@Override
 	public TimeValue getTimeValue(long year, byte month, byte day, byte hour,
 			byte minute, byte second, byte precision, int beforeTolerance,
 			int afterTolerance, int timezoneOffset, String calendarModel) {

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImpl.java
@@ -108,7 +108,7 @@ public class PropertyDocumentImpl extends TermedStatementDocumentImpl
 			@JsonProperty("lastrevid") long revisionId,
 			@JacksonInject("siteIri") String siteIri) {
         super(jsonId, labels, descriptions, aliases, claims, revisionId, siteIri);
-        this.datatype = new DatatypeIdImpl(DatatypeIdImpl.getDatatypeIriFromJsonDatatype(datatype));
+        this.datatype = new DatatypeIdImpl(DatatypeIdImpl.getDatatypeIriFromJsonDatatype(datatype), datatype);
     }
 
     /**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DataObjectFactory.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DataObjectFactory.java
@@ -142,6 +142,20 @@ public interface DataObjectFactory {
 	DatatypeIdValue getDatatypeIdValue(String id);
 
 	/**
+	 * Creates a {@link DatatypeIdValue}. The datatype IRI is usually one of the
+	 * constants defined in {@link DatatypeIdValue}, but this is not enforced,
+	 * since there might be extensions that provide additional types. The JSON
+	 * string is its representation in the JSON serialization of properties.
+	 *
+	 * @param id
+	 *            the IRI string that identifies the datatype
+	 * @param jsonString
+	 * 			  the JSON representation of this datatype
+	 * @return a {@link DatatypeIdValue} corresponding to the input
+	 */
+	DatatypeIdValue getDatatypeIdValue(String id, String jsonString);
+
+	/**
 	 * Creates a {@link TimeValue}.
 	 *
 	 * @param year

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DatatypeIdValue.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/DatatypeIdValue.java
@@ -108,4 +108,9 @@ public interface DatatypeIdValue {
 	 * @return String with the IRI
 	 */
 	String getIri();
+
+	/**
+	 * The string identifying this datatype in the JSON serialization of a property.
+	 */
+    String getJsonString();
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/DataObjectFactoryImplTest.java
@@ -82,6 +82,13 @@ public class DataObjectFactoryImplTest {
 	}
 
 	@Test
+	public final void testGetDatatypeIdWithJsonString() {
+		DatatypeIdValue o1 = new DatatypeIdImpl(DatatypeIdValue.DT_STRING, DatatypeIdImpl.JSON_DT_STRING);
+		DatatypeIdValue o2 = factory.getDatatypeIdValue(DatatypeIdValue.DT_STRING, DatatypeIdImpl.JSON_DT_STRING);
+		assertEquals(o1, o2);
+	}
+
+	@Test
 	public final void testGetTimeValue() {
 		TimeValue o1 = new TimeValueImpl(2007, (byte) 5, (byte) 12,
 				(byte) 10, (byte) 45, (byte) 0, TimeValue.PREC_DAY, 0, 1, 60,

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/DatatypeIdImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/DatatypeIdImplTest.java
@@ -30,6 +30,7 @@ public class DatatypeIdImplTest {
 	private final DatatypeIdImpl d1 = new DatatypeIdImpl(DatatypeIdValue.DT_ITEM);
 	private final DatatypeIdImpl d2 = new DatatypeIdImpl("http://wikiba.se/ontology#WikibaseItem");
 	private final DatatypeIdImpl d3 = new DatatypeIdImpl(DatatypeIdValue.DT_TIME);
+	private final DatatypeIdImpl d4 = new DatatypeIdImpl("http://wikiba.se/ontology#SomeUnknownDatatype", "some-unknownDatatype");
 
 	@Test(expected = NullPointerException.class)
 	public void datatypeIdNotNull() {
@@ -48,6 +49,19 @@ public class DatatypeIdImplTest {
 	@Test
 	public void hashBasedOnContent() {
 		assertEquals(d1.hashCode(), d2.hashCode());
+	}
+
+	@Test
+	public void doNotChokeOnUnknownDatatypes() {
+		// for issue https://github.com/Wikidata/Wikidata-Toolkit/issues/716
+		assertEquals("some-unknownDatatype", d4.getJsonString());
+		assertEquals("http://wikiba.se/ontology#SomeUnknownDatatype", d4.getIri());
+	}
+
+	@Test
+	public void testDeserializeUnknownJsonDatatype() {
+		// for issue https://github.com/Wikidata/Wikidata-Toolkit/issues/716
+		assertEquals("http://wikiba.se/ontology#LocalMedia", DatatypeIdImpl.getDatatypeIriFromJsonDatatype("localMedia"));
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImplTest.java
@@ -61,6 +61,7 @@ public class PropertyDocumentImplTest {
 			statementGroups, datatypeId, 1234);
 
 	private final String JSON_PROPERTY = "{\"type\":\"property\",\"id\":\"P2\",\"labels\":{\"en\":{\"language\":\"en\",\"value\":\"label\"}},\"descriptions\":{\"fr\":{\"language\":\"fr\",\"value\":\"des\"}},\"aliases\":{\"de\":[{\"language\":\"de\",\"value\":\"alias\"}]},\"claims\":{\"P42\":[{\"rank\":\"normal\",\"id\":\"MyId\",\"mainsnak\":{\"property\":\"P42\",\"snaktype\":\"somevalue\"},\"type\":\"statement\"}]},\"datatype\":\"wikibase-item\",\"lastrevid\":1234}";
+	private final String JSON_PROPERTY_WITH_UNKNOWN_DATATYPE = "{\"type\":\"property\",\"id\":\"P2\",\"labels\":{\"en\":{\"language\":\"en\",\"value\":\"label\"}},\"descriptions\":{},\"aliases\":{},\"claims\":{},\"datatype\":\"some-unknownDatatype\",\"lastrevid\":1234}";
 
 	@Test
 	public void fieldsAreCorrect() {
@@ -107,7 +108,7 @@ public class PropertyDocumentImplTest {
 				Collections.emptyList(), datatypeId, 1234);
 		PropertyDocument pdDiffDatatype = new PropertyDocumentImpl(pid,
 				labelList, descList, aliasList,
-				statementGroups, new DatatypeIdImpl("string"), 1234);
+				statementGroups, new DatatypeIdImpl(DatatypeIdValue.DT_STRING), 1234);
 		PropertyDocument pdDiffRevisions = new PropertyDocumentImpl(pid,
 				labelList, descList, aliasList,
 				statementGroups, datatypeId, 1235);
@@ -246,6 +247,12 @@ public class PropertyDocumentImplTest {
 	@Test
 	public void testPropertyToJava() throws IOException {
 		assertEquals(pd1, mapper.readValue(JSON_PROPERTY, PropertyDocumentImpl.class));
+	}
+
+	@Test
+	public void testPropertyToJavaWithUnknownDatatype() throws JsonProcessingException {
+		PropertyDocumentImpl pd = mapper.readValue(JSON_PROPERTY_WITH_UNKNOWN_DATATYPE, PropertyDocumentImpl.class);
+		assertEquals("some-unknownDatatype", pd.getJsonDatatype());
 	}
         
         @Test


### PR DESCRIPTION
Closes #716.

Because the translation between the IRI and JSON datatypes is unreliable, we need
to remember the JSON datatype as well as the IRI, so that we are able to reliably
deserialize and re-serialize properties with custom datatypes. See more discussion in #716.