### PR TITLE
Fix fetching mids of multiple non-existent files.

### DIFF
--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/MediaInfoIdQueryAction.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/MediaInfoIdQueryAction.java
@@ -100,7 +100,7 @@ public class MediaInfoIdQueryAction {
 			Map.Entry<String, JsonNode> page = iterator.next();
 			String pageId = page.getKey();
 			String title = page.getValue().get("title").textValue();
-			if (!"-1".equals(pageId)) { // "-1" means not found
+			if (!pageId.startsWith("-")) { // negative keys such as "-1", "-2", ... mean not found
 				midMap.put(title, Datamodel.makeMediaInfoIdValue("M" + pageId, siteIri));
 			}
 		}

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataFetcherTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataFetcherTest.java
@@ -268,6 +268,21 @@ public class WikibaseDataFetcherTest {
 	}
 
 	@Test
+	public void testGetMediaInfoIdNotFoundTwice() throws IOException, MediaWikiApiErrorException {
+		Map<String, String> parameters = new HashMap<>();
+		parameters.put("action", "query");
+		parameters.put("format", "json");
+		parameters.put("titles", "File:Not Found|File:Not Found Either");
+		con.setWebResourceFromPath(parameters, getClass(),
+				"/query-Not Found twice.json", CompressionType.NONE);
+
+		Map<String, MediaInfoIdValue> result = wdf.getMediaInfoIdsByFileName("Not Found", "Not Found Either");
+		assertEquals(result.size(), 2);
+		assertNull(result.get("Not Found"));
+		assertNull(result.get("Not Found Either"));
+	}
+
+	@Test
 	public void testWbGetVirtualMediaInfoEntityFromTitle() throws IOException, MediaWikiApiErrorException {
 		Map<String, String> parameters = new HashMap<>();
 		this.setStandardParameters(parameters);

--- a/wdtk-wikibaseapi/src/test/resources/query-Not Found twice.json
+++ b/wdtk-wikibaseapi/src/test/resources/query-Not Found twice.json
@@ -1,0 +1,17 @@
+{
+  "batchcomplete": "",
+  "query": {
+    "pages": {
+      "-1": {
+        "ns": 6,
+        "title": "File:Not Found",
+        "missing": ""
+      },
+      "-2": {
+        "ns": 6,
+        "title": "File:Not Found Either",
+        "missing": ""
+      }
+    }
+  }
+}


### PR DESCRIPTION
Closes #745.

I would release this immediately after merge as this is the source of an important bug in OpenRefine.