### PR TITLE
Fix online dump downloads for the various modes and Closes #869

### DIFF
--- a/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/wmf/WmfDumpFile.java
+++ b/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/wmf/WmfDumpFile.java
@@ -53,7 +53,7 @@ public abstract class WmfDumpFile implements MwDumpFile {
 		WmfDumpFile.WEB_DIRECTORY.put(DumpContentType.CURRENT, "");
 		WmfDumpFile.WEB_DIRECTORY.put(DumpContentType.FULL, "");
 		WmfDumpFile.WEB_DIRECTORY.put(DumpContentType.SITES, "");
-		WmfDumpFile.WEB_DIRECTORY.put(DumpContentType.JSON, "other/");
+		WmfDumpFile.WEB_DIRECTORY.put(DumpContentType.JSON, "");
 	}
 
 	/**
@@ -68,7 +68,7 @@ public abstract class WmfDumpFile implements MwDumpFile {
 		WmfDumpFile.POSTFIXES.put(DumpContentType.FULL,
 				"-pages-meta-history.xml.bz2");
 		WmfDumpFile.POSTFIXES.put(DumpContentType.SITES, "-sites.sql.gz");
-		WmfDumpFile.POSTFIXES.put(DumpContentType.JSON, ".json.gz");
+		WmfDumpFile.POSTFIXES.put(DumpContentType.JSON, "-all.json.gz");
 	}
 
 	/**
@@ -172,7 +172,7 @@ public abstract class WmfDumpFile implements MwDumpFile {
 			if ("wikidatawiki".equals(projectName)) {
 				return WmfDumpFile.DUMP_SITE_BASE_URL
 						+ WmfDumpFile.WEB_DIRECTORY.get(dumpContentType)
-						+ "wikidata" + "/";
+						+ projectName + "/entities/";
 			} else {
 				throw new RuntimeException(
 						"Wikimedia Foundation uses non-systematic directory names for this type of dump file."
@@ -253,7 +253,7 @@ public abstract class WmfDumpFile implements MwDumpFile {
 	public static String getDumpFileName(DumpContentType dumpContentType,
 			String projectName, String dateStamp) {
 		if (dumpContentType == DumpContentType.JSON) {
-			return dateStamp + WmfDumpFile.getDumpFilePostfix(dumpContentType);
+			return "wikidata-" + dateStamp + WmfDumpFile.getDumpFilePostfix(dumpContentType);
 		} else {
 			return projectName + "-" + dateStamp
 					+ WmfDumpFile.getDumpFilePostfix(dumpContentType);

--- a/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/wmf/WmfOnlineDailyDumpFile.java
+++ b/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/wmf/WmfOnlineDailyDumpFile.java
@@ -137,7 +137,7 @@ class WmfOnlineDailyDumpFile extends WmfDumpFile {
 					new InputStreamReader(in, StandardCharsets.UTF_8));
 			String inputLine = bufferedReader.readLine();
 			bufferedReader.close();
-			result = "done".equals(inputLine);
+			result = inputLine.startsWith("done");
 		} catch (IOException e) { // file not found or not readable
 			result = false;
 		}

--- a/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/JsonDumpFileProcessingTest.java
+++ b/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/JsonDumpFileProcessingTest.java
@@ -169,7 +169,7 @@ public class JsonDumpFileProcessingTest {
 		Path dumpFilePath = dmPath.resolve("dumpfiles").resolve("wikidatawiki");
 		Path thisDumpPath = dumpFilePath.resolve(dumpContentType.toString()
 				.toLowerCase() + "-" + dateStamp);
-		Path filePath = thisDumpPath.resolve(dateStamp + WmfDumpFile.getDumpFilePostfix(dumpContentType));
+		Path filePath = thisDumpPath.resolve("wikidata-" + dateStamp + WmfDumpFile.getDumpFilePostfix(dumpContentType));
 		dm.setFileContents(filePath, MockStringContentFactory.getStringFromUrl(resourceUrl),
 				WmfDumpFile.getDumpFileCompressionType(filePath.toString()));
 	}

--- a/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/wmf/WmfDumpFileManagerTest.java
+++ b/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/wmf/WmfDumpFileManagerTest.java
@@ -186,6 +186,21 @@ public class WmfDumpFileManagerTest {
 	}
 
 	@Test
+	public void findMostRecentJsonDump() throws IOException {
+		WebResourceFetcherImpl onlineWrf = new WebResourceFetcherImpl();
+		WmfDumpFileManager dumpFileManager = new WmfDumpFileManager(
+				"wikidatawiki", dm, onlineWrf);
+
+		MwDumpFile dumpFile = dumpFileManager
+				.findMostRecentDump(DumpContentType.JSON);
+
+		assertTrue(dumpFile != null);
+		assertTrue("Dumpfile " + dumpFile
+						+ " should be online.",
+						dumpFile instanceof JsonOnlineDumpFile);
+	}
+
+	@Test
 	public void getAllCurrentDumps() throws IOException {
 		wrf.setWebResourceContentsFromResource(
 				"https://dumps.wikimedia.org/wikidatawiki/",

--- a/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/wmf/WmfDumpFileManagerTest.java
+++ b/wdtk-dumpfiles/src/test/java/org/wikidata/wdtk/dumpfiles/wmf/WmfDumpFileManagerTest.java
@@ -38,6 +38,7 @@ import org.wikidata.wdtk.dumpfiles.MwDumpFileProcessor;
 import org.wikidata.wdtk.testing.MockDirectoryManager;
 import org.wikidata.wdtk.testing.MockStringContentFactory;
 import org.wikidata.wdtk.testing.MockWebResourceFetcher;
+import org.wikidata.wdtk.util.WebResourceFetcherImpl;
 
 public class WmfDumpFileManagerTest {
 
@@ -61,7 +62,8 @@ public class WmfDumpFileManagerTest {
 			try {
 				result = result
 						+ MockStringContentFactory
-								.getStringFromInputStream(inputStream) + "\n";
+								.getStringFromInputStream(inputStream)
+						+ "\n";
 			} catch (IOException e) {
 				throw new RuntimeException(e);
 			}
@@ -146,9 +148,7 @@ public class WmfDumpFileManagerTest {
 
 	@Test
 	public void getAllJsonDumps() throws IOException {
-		wrf.setWebResourceContentsFromResource(
-				"https://dumps.wikimedia.org/other/wikidata/",
-				"/other-wikidata-index.html", this.getClass());
+		WebResourceFetcherImpl onlineWrf = new WebResourceFetcherImpl();
 
 		setLocalDump("20141110", DumpContentType.JSON, true);
 		setLocalDump("20150105", DumpContentType.CURRENT, true);
@@ -156,23 +156,24 @@ public class WmfDumpFileManagerTest {
 		setLocalDump("nodate", DumpContentType.JSON, true);
 
 		WmfDumpFileManager dumpFileManager = new WmfDumpFileManager(
-				"wikidatawiki", dm, wrf);
+				"wikidatawiki", dm, onlineWrf);
 
 		List<? extends MwDumpFile> dumpFiles = dumpFileManager
 				.findAllDumps(DumpContentType.JSON);
 
-		String[] dumpDates = { "20150112", "20150105", "20141229", "20141222",
-				"20141215", "20141210", "20141201", "20141124", "20141117",
-				"20141110" };
-		boolean[] dumpIsLocal = { false, false, false, false, false, false,
-				true, false, false, true };
+		String[] localDumpDates = { "20141201", "20141110" };
 
-		assertEquals(dumpFiles.size(), dumpDates.length);
+		assertTrue(localDumpDates.length < dumpFiles.size());
 		for (int i = 0; i < dumpFiles.size(); i++) {
 			assertEquals(dumpFiles.get(i).getDumpContentType(),
 					DumpContentType.JSON);
-			assertEquals(dumpFiles.get(i).getDateStamp(), dumpDates[i]);
-			if (dumpIsLocal[i]) {
+			boolean shouldBeLocal = false;
+			for (String localDumpDate : localDumpDates) {
+				if (localDumpDate.equals(dumpFiles.get(i).getDateStamp())) {
+					shouldBeLocal = true;
+				}
+			}
+			if (shouldBeLocal) {
 				assertTrue(
 						"Dumpfile " + dumpFiles.get(i) + " should be local.",
 						dumpFiles.get(i) instanceof WmfLocalDumpFile);


### PR DESCRIPTION
It seems that there were changes in the way dumps are structured for wikidata making the way dump files were automatically downloaded not functional anymore.

Here are the fixes implemented, and the reasoning behind it :
DAILY : update the check for an available dump as status.txt now indicated "done:all". See : https://dumps.wikimedia.org/other/incr/wikidatawiki/20240419/status.txt I put startsWith but it might be preferable to check for done:all equality ? I don't know the various possible values but this version should work at least most of the time (compared to none right now).
JSON : The JSON dumps are currently downloaded from this folder : https://dumps.wikimedia.org/other/wikidata/ It is a bit of a mess including both full and incremental (?) dumps. I switch it to use https://dumps.wikimedia.org/wikidatawiki/entities/ (which seems to be equivalent to https://dumps.wikimedia.org/other/wikibase/wikidatawiki/, I don't know if anyone has any insight into which link should be preferred). Moreover, not all shown dates feature the full json dump so I added a check that the file is actually there (I have not found a status.txt or equivalent for the entitity dump)
SITES : Nothing done, haven't tested it but the file it is looking for is still there so it probably still works.
CURRENT / FULL : Both of these look for a -pages-meta-current.xml.bz2 / -pages-meta-history.xml.bz2 inside a dump (like https://dumps.wikimedia.org/wikidatawiki/20240401/). However these files do not seem to be there. Nevertheless, parts of these file ARE present (of form https://dumps.wikimedia.org/wikidatawiki/20240401/wikidatawiki-20240401-pages-meta-current1.xml-p1p441397.bz2 for example) but not the united file. If anyone knows why the full file isn't there I could try to fix the issue
