### PR TITLE
Refactored implementation and Design smells

### DIFF
--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/CopyUtils.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/CopyUtils.java
@@ -24,8 +24,6 @@ import java.util.Collection;
  */
 
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/CopyUtils.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/CopyUtils.java
@@ -1,5 +1,8 @@
 package org.wikidata.wdtk.datamodel.helpers;
 
+import java.util.ArrayList;
+import java.util.Collection;
+
 /*-
  * #%L
  * Wikidata Toolkit Data Model
@@ -21,9 +24,13 @@ package org.wikidata.wdtk.datamodel.helpers;
  */
 
 import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.stream.Collectors;
 
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
+import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
 
 /**
  * Utility class for copying various data model elements.
@@ -40,5 +47,24 @@ public class CopyUtils {
         return ids.stream()
                 .map(converter::copy)
                 .collect(Collectors.toList());
+    }
+
+    public static List<MonolingualTextValue> copyMonoLingualTextValues(
+        Collection<MonolingualTextValue> monoLingualTextValues, 
+        DatamodelConverter converter
+    ) 
+    {
+        return monoLingualTextValues.stream()
+            .map(converter::copy)
+            .collect(Collectors.toList());
+    }
+
+    public static List<StatementGroup> copyStatementGroups(
+        List<StatementGroup> statementGroups, 
+        DatamodelConverter converter
+    ) {
+        return statementGroups.stream()
+            .map(converter::copy)
+            .collect(Collectors.toList());
     }
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/CopyUtils.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/CopyUtils.java
@@ -1,0 +1,44 @@
+package org.wikidata.wdtk.datamodel.helpers;
+
+/*-
+ * #%L
+ * Wikidata Toolkit Data Model
+ * %%
+ * Copyright (C) 2014 - 2024 Wikidata Toolkit Developers
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
+
+/**
+ * Utility class for copying various data model elements.
+ */
+public class CopyUtils {
+
+    /**
+     * Copies a list of {@link ItemIdValue}.
+     *
+     * @param ids list of item IDs to copy
+     * @return a new list of copied item IDs
+     */
+    public static List<ItemIdValue> copyItemIds(List<ItemIdValue> ids, DatamodelConverter converter) {
+        return ids.stream()
+                .map(converter::copy)
+                .collect(Collectors.toList());
+    }
+}

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverter.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverter.java
@@ -463,7 +463,7 @@ public class DatamodelConverter implements SnakVisitor<Snak>,
         return dataObjectFactory.getFormDocument(
                 copy(object.getEntityId()),
                 copyMonoLingualTextValues(object.getRepresentations().values()),
-                CopyUtils.copyItemIds(object.getGrammaticalFeatures(), this),
+                copyItemIds(object.getGrammaticalFeatures()),
                 copyStatementGroups(object.getStatementGroups()),
                 object.getRevisionId());
     }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverter.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverter.java
@@ -78,8 +78,7 @@ import org.wikidata.wdtk.datamodel.interfaces.ValueVisitor;
 public class DatamodelConverter implements SnakVisitor<Snak>,
 		ValueVisitor<Value> {
 
-	static final Logger logger = LoggerFactory
-			.getLogger(DatamodelConverter.class);
+	private  final Logger logger;
 
 	/**
 	 * The factory to use for copying.
@@ -94,6 +93,7 @@ public class DatamodelConverter implements SnakVisitor<Snak>,
 	 */
 	public DatamodelConverter(DataObjectFactory dataObjectFactory) {
 		this.dataObjectFactory = dataObjectFactory;
+		this.logger = LoggerFactory.getLogger(getClass());
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverter.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverter.java
@@ -678,9 +678,7 @@ public class DatamodelConverter implements SnakVisitor<Snak>,
 	 * @return
 	 */
     private List<ItemIdValue> copyItemIds(List<ItemIdValue> ids) {
-        return ids.stream()
-                .map(id -> copy(id))
-                .collect(Collectors.toList());
+        return CopyUtils.copyItemIds(ids, this);
     }
     
     /**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverter.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/DatamodelConverter.java
@@ -463,7 +463,7 @@ public class DatamodelConverter implements SnakVisitor<Snak>,
         return dataObjectFactory.getFormDocument(
                 copy(object.getEntityId()),
                 copyMonoLingualTextValues(object.getRepresentations().values()),
-                copyItemIds(object.getGrammaticalFeatures()),
+                CopyUtils.copyItemIds(object.getGrammaticalFeatures(), this),
                 copyStatementGroups(object.getStatementGroups()),
                 object.getRevisionId());
     }
@@ -634,11 +634,7 @@ public class DatamodelConverter implements SnakVisitor<Snak>,
 	 * @return the copied object
 	 */
 	private List<StatementGroup> copyStatementGroups(List<StatementGroup> statementGroups) {
-		List<StatementGroup> result = new ArrayList<>(statementGroups.size());
-		for (StatementGroup statementGroup : statementGroups) {
-			result.add(copy(statementGroup));
-		}
-		return result;
+		return CopyUtils.copyStatementGroups(statementGroups, this);
 	}
 
 	/**
@@ -649,11 +645,7 @@ public class DatamodelConverter implements SnakVisitor<Snak>,
 	 * @return the copied object
 	 */
 	private List<MonolingualTextValue> copyMonoLingualTextValues(Collection<MonolingualTextValue> monoLingualTextValues) {
-		List<MonolingualTextValue> result = new ArrayList<>(monoLingualTextValues.size());
-		for (MonolingualTextValue mtv : monoLingualTextValues) {
-			result.add(copy(mtv));
-		}
-		return result;
+		return CopyUtils.copyMonoLingualTextValues(monoLingualTextValues, this);
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Hash.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/Hash.java
@@ -332,8 +332,7 @@ public class Hash {
 	 * @return the hash code of the object
 	 */
 	public static int hashCode(PropertyDocument o) {
-		int result;
-		result = hashCodeForTermedDocument(o);
+		int result = o.hashCodeForTermedDocument();
 		result = PRIME * result + o.getStatementGroups().hashCode();
 		result = PRIME * result + o.getDatatype().hashCode();
 		return result;
@@ -348,8 +347,7 @@ public class Hash {
 	 * @return the hash code of the object
 	 */
 	public static int hashCode(ItemDocument o) {
-		int result;
-		result = hashCodeForTermedDocument(o);
+		int result = o.hashCodeForTermedDocument();
 		result = PRIME * result + o.getStatementGroups().hashCode();
 		result = PRIME * result + o.getSiteLinks().hashCode();
 		return result;
@@ -418,23 +416,6 @@ public class Hash {
 		int result;
 		result = o.getLabels().hashCode();
 		result = PRIME * result + o.getStatementGroups().hashCode();
-		return result;
-	}
-
-	/**
-	 * Returns a hash code for the given object.
-	 *
-	 * @see java.lang.Object#hashCode()
-	 * @param o
-	 *            the object to create a hash for
-	 * @return the hash code of the object
-	 */
-	private static int hashCodeForTermedDocument(TermedDocument o) {
-		int result;
-		result = o.getAliases().hashCode();
-		result = PRIME * result + o.getDescriptions().hashCode();
-		result = PRIME * result + o.getLabels().hashCode();
-		result = PRIME * result + Long.hashCode(o.getRevisionId());
 		return result;
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilder.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LexemeUpdateBuilder.java
@@ -410,13 +410,19 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 	 */
 	public LexemeUpdateBuilder append(LexemeUpdate update) {
 		super.append(update);
-		if (update.getLanguage().isPresent()) {
-			setLanguage(update.getLanguage().get());
-		}
-		if (update.getLexicalCategory().isPresent()) {
-			setLexicalCategory(update.getLexicalCategory().get());
-		}
+		updateLanguageAndCategory(update);
 		updateLemmas(update.getLemmas());
+		updateSenses(update);
+		updateForms(update);
+		return this;
+	}
+	
+	private void updateLanguageAndCategory(LexemeUpdate update) {
+		update.getLanguage().ifPresent(this::setLanguage);
+		update.getLexicalCategory().ifPresent(this::setLexicalCategory);
+	}
+	
+	private void updateSenses(LexemeUpdate update) {
 		for (SenseDocument sense : update.getAddedSenses()) {
 			addSense(sense);
 		}
@@ -426,6 +432,9 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 		for (SenseIdValue senseId : update.getRemovedSenses()) {
 			removeSense(senseId);
 		}
+	}
+	
+	private void updateForms(LexemeUpdate update) {
 		for (FormDocument form : update.getAddedForms()) {
 			addForm(form);
 		}
@@ -435,7 +444,6 @@ public class LexemeUpdateBuilder extends StatementDocumentUpdateBuilder {
 		for (FormIdValue formId : update.getRemovedForms()) {
 			removeForm(formId);
 		}
-		return this;
 	}
 
 	@Override

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TimeValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TimeValueImpl.java
@@ -212,33 +212,50 @@ public class TimeValueImpl extends ValueImpl implements TimeValue {
 
 	@Override
 	public TimeValue toGregorian() {
-		// already in Gregorian calendar
-		if (this.getPreferredCalendarModel().equals(TimeValue.CM_GREGORIAN_PRO)) {
+		if (isAlreadyGregorian()) {
 			return this;
 		}
 
-		// convert Julian
-		if (this.getPreferredCalendarModel().equals(TimeValue.CM_JULIAN_PRO)
-				&& this.getPrecision() >= TimeValue.PREC_DAY
-				&& this.value.year > Integer.MIN_VALUE && this.value.year < Integer.MAX_VALUE
-		) {
-			try {
-				final JulianDate julian = JulianDate.of((int) this.value.year, this.value.month, this.value.day);
-				final LocalDate date = LocalDate.from(julian);
-				return new TimeValueImpl(
-						date.getYear(), (byte) date.getMonth().getValue(), (byte) date.getDayOfMonth(),
-						this.value.hour, this.value.minute, this.value.second,
-						(byte) this.value.precision, this.value.before, this.value.after,
-						this.value.timezone, TimeValue.CM_GREGORIAN_PRO
-				);
-			} catch(DateTimeException e) {
-				return null;
-			}
-
+		if (isJulianCalendar() && isPrecisionAtLeastDay() && isYearWithinValidRange()) {
+			return convertJulianToGregorian();
 		}
 
 		return null;
 	}
+
+	// Helper methods to decompose the complex condition
+	private boolean isAlreadyGregorian() {
+		return this.getPreferredCalendarModel().equals(TimeValue.CM_GREGORIAN_PRO);
+	}
+
+	private boolean isJulianCalendar() {
+		return this.getPreferredCalendarModel().equals(TimeValue.CM_JULIAN_PRO);
+	}
+
+	private boolean isPrecisionAtLeastDay() {
+		return this.getPrecision() >= TimeValue.PREC_DAY;
+	}
+
+	private boolean isYearWithinValidRange() {
+		return this.value.year > Integer.MIN_VALUE && this.value.year < Integer.MAX_VALUE;
+	}
+
+	// Conversion logic remains unchanged
+	private TimeValue convertJulianToGregorian() {
+		try {
+			JulianDate julian = JulianDate.of((int) this.value.year, this.value.month, this.value.day);
+			LocalDate date = LocalDate.from(julian);
+			return new TimeValueImpl(
+					date.getYear(), (byte) date.getMonth().getValue(), (byte) date.getDayOfMonth(),
+					this.value.hour, this.value.minute, this.value.second,
+					(byte) this.value.precision, this.value.before, this.value.after,
+					this.value.timezone, TimeValue.CM_GREGORIAN_PRO
+			);
+		} catch (DateTimeException e) {
+			return null;
+		}
+	}
+
 
 	/**
 	 * Helper object that represents the JSON object structure of the value.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/TermedDocument.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/interfaces/TermedDocument.java
@@ -22,6 +22,7 @@ package org.wikidata.wdtk.datamodel.interfaces;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Interface for EntityDocuments that can be described by terms in several
@@ -91,4 +92,13 @@ public interface TermedDocument extends LabeledDocument {
 	 * 		contain should all match the supplied language.
 	 */
 	TermedDocument withAliases(String language, List<MonolingualTextValue> aliases);
+
+	 /**
+     * Calculates hash code for this TermedDocument.
+     *
+     * @return the hash code of the object
+     */
+    default int hashCodeForTermedDocument() {
+        return Objects.hash(getAliases(), getDescriptions(), getLabels(), getRevisionId());
+    }
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemIdValueImplTest.java
@@ -45,7 +45,7 @@ public class ItemIdValueImplTest {
 	private final ItemIdValueImpl item4 = new ItemIdValueImpl("Q42", "http://www.example.org/entity/");
 	private final String JSON_ITEM_ID_VALUE = "{\"type\":\"wikibase-entityid\",\"value\":{\"entity-type\":\"item\",\"numeric-id\":42,\"id\":\"Q42\"}}";
 	private final String JSON_ITEM_ID_VALUE_WITHOUT_ID = "{\"type\":\"wikibase-entityid\",\"value\":{\"entity-type\":\"item\",\"numeric-id\":\"42\"}}";
-	private final String JSON_ITEM_ID_VALUE_WITHOUT_NUMERICAL_ID = "{\"type\":\"wikibase-entityid\",\"value\":{\"id\":\"Q42\"}}";
+	private final String JSON_ITEM_ID_NO_NUMERIC = "{\"type\":\"wikibase-entityid\",\"value\":{\"id\":\"Q42\"}}";
 	private final String JSON_ITEM_ID_VALUE_WRONG_ID = "{\"type\":\"wikibase-entityid\",\"value\":{\"id\":\"W42\"}}";
 	private final String JSON_ITEM_ID_VALUE_UNSUPPORTED_TYPE = "{\"type\":\"wikibase-entityid\",\"value\":{\"entity-type\":\"foo\",\"numeric-id\":42,\"id\":\"F42\"}}";
 	private final String JSON_ITEM_ID_VALUE_UNSUPPORTED_NO_ID = "{\"type\":\"wikibase-entityid\",\"value\":{}}";
@@ -128,7 +128,7 @@ public class ItemIdValueImplTest {
 
 	@Test
 	public void testToJavaWithoutNumericalId() throws IOException {
-		assertEquals(item1, mapper.readValue(JSON_ITEM_ID_VALUE_WITHOUT_NUMERICAL_ID, ValueImpl.class));
+		assertEquals(item1, mapper.readValue(JSON_ITEM_ID_NO_NUMERIC, ValueImpl.class));
 	}
 	
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeIdValueImplTest.java
@@ -43,7 +43,7 @@ public class LexemeIdValueImplTest {
 	private final LexemeIdValueImpl lexeme3 = new LexemeIdValueImpl("L57", "http://www.wikidata.org/entity/");
 	private final LexemeIdValueImpl lexeme4 = new LexemeIdValueImpl("L42", "http://www.example.org/entity/");
 	private final String JSON_LEXEME_ID_VALUE = "{\"type\":\"wikibase-entityid\",\"value\":{\"entity-type\":\"lexeme\",\"numeric-id\":42,\"id\":\"L42\"}}";
-	private final String JSON_LEXEME_ID_VALUE_WITHOUT_NUMERICAL_ID = "{\"type\":\"wikibase-entityid\",\"value\":{\"id\":\"L42\"}}";
+	private final String JSON_LEXEME_ID_NO_NUMERIC = "{\"type\":\"wikibase-entityid\",\"value\":{\"id\":\"L42\"}}";
 
 	@Test
 	public void entityTypeIsLexeme() {
@@ -118,7 +118,7 @@ public class LexemeIdValueImplTest {
 
 	@Test
 	public void testToJavaWithoutNumericalID() throws IOException {
-		assertEquals(lexeme1, mapper.readValue(JSON_LEXEME_ID_VALUE_WITHOUT_NUMERICAL_ID, ValueImpl.class));
+		assertEquals(lexeme1, mapper.readValue(JSON_LEXEME_ID_NO_NUMERIC, ValueImpl.class));
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoIdValueImplTest.java
@@ -41,7 +41,7 @@ public class MediaInfoIdValueImplTest {
 	private final MediaInfoIdValueImpl mediaInfo3 = new MediaInfoIdValueImpl("M57", "http://commons.wikimedia.org/entity/");
 	private final MediaInfoIdValueImpl mediaInfo4 = new MediaInfoIdValueImpl("M42", "http://www.example.org/entity/");
 	private final String JSON_MEDIA_INFO_ID_VALUE = "{\"type\":\"wikibase-entityid\",\"value\":{\"entity-type\":\"mediainfo\",\"numeric-id\":42,\"id\":\"M42\"}}";
-	private final String JSON_MEDIA_INFO_ID_VALUE_WITHOUT_NUMERICAL_ID = "{\"type\":\"wikibase-entityid\",\"value\":{\"id\":\"M42\"}}";
+	private final String MEDIA_INFO_ID_NO_NUMERIC = "{\"type\":\"wikibase-entityid\",\"value\":{\"id\":\"M42\"}}";
 
 	@Test
 	public void entityTypeIsMediaInfo() {
@@ -116,7 +116,7 @@ public class MediaInfoIdValueImplTest {
 
 	@Test
 	public void testToJavaWithoutNumericalID() throws IOException {
-		assertEquals(mediaInfo1, mapper.readValue(JSON_MEDIA_INFO_ID_VALUE_WITHOUT_NUMERICAL_ID, ValueImpl.class));
+		assertEquals(mediaInfo1, mapper.readValue(MEDIA_INFO_ID_NO_NUMERIC, ValueImpl.class));
 	}
 
 	@Test

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyIdValueImplTest.java
@@ -40,7 +40,7 @@ public class PropertyIdValueImplTest {
 	private final PropertyIdValueImpl prop3 = new PropertyIdValueImpl("P57",	 "http://www.wikidata.org/entity/");
 	private final PropertyIdValueImpl prop4 = new PropertyIdValueImpl("P42", "http://www.example.org/entity/");
 	private final String JSON_PROPERTY_ID_VALUE = "{\"type\":\"wikibase-entityid\",\"value\":{\"entity-type\":\"property\",\"numeric-id\":42,\"id\":\"P42\"}}";
-	private final String JSON_PROPERTY_ID_VALUE_WITHOUT_NUMERICAL_ID = "{\"type\":\"wikibase-entityid\",\"value\":{\"id\":\"P42\"}}";
+	private final String JSON_PROPERTY_ID_NO_NUMERIC = "{\"type\":\"wikibase-entityid\",\"value\":{\"id\":\"P42\"}}";
 
 	@Test
 	public void entityTypeIsProperty() {
@@ -101,7 +101,7 @@ public class PropertyIdValueImplTest {
 
 	@Test
 	public void testToJavaWithoutNumericalID() throws IOException {
-		assertEquals(prop1, mapper.readValue(JSON_PROPERTY_ID_VALUE_WITHOUT_NUMERICAL_ID, ValueImpl.class));
+		assertEquals(prop1, mapper.readValue(JSON_PROPERTY_ID_NO_NUMERIC, ValueImpl.class));
 	}
 
 	@Test


### PR DESCRIPTION
The following implementation smells has been refactored:

- Complex conditional
- Complex Method
- Long Identifier

The following design refactorings have been made:

- Extract Class (Moved copy methods in DatamodelConverter to new class CopyUtils)
- Pull-up method (Moved hashCodeForTermedDocument in hash class to TermedDocument interface)
- Move field (Moved Logger initialization into constructor in DatamodelConverter class to make it more cohesive)




