### PR TITLE
chore!: Update to Jackson 3 + Java 17 new baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 11, 17, 21 ]
+        java: [ 17, 21, 25 ]
 
     steps:
       - uses: actions/checkout@v5
@@ -26,7 +26,7 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-${{ matrix.java }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-${{ matrix.java }}-m2
-      - run: mvn --batch-mode --update-snapshots -Dgpg.skip=true jacoco:prepare-agent verify jacoco:report
+      - run: mvn --batch-mode --no-transfer-progress --update-snapshots -Dgpg.skip=true -Dstyle.color=always jacoco:prepare-agent verify jacoco:report
       - uses: codecov/codecov-action@v5
         with:
           file: ./**/target/site/jacoco/jacoco.xml

--- a/pom.xml
+++ b/pom.xml
@@ -72,8 +72,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<jacksonVersion>2.20.1</jacksonVersion>
-		<okhttpVersion>5.3.0</okhttpVersion>
+		<jacksonVersion>3.0.2</jacksonVersion>
+		<okhttpVersion>5.3.2</okhttpVersion>
 	</properties>
 
 	<dependencyManagement>
@@ -109,7 +109,7 @@
 			<dependency>
 				<groupId>org.apache.commons</groupId>
 				<artifactId>commons-lang3</artifactId>
-				<version>3.19.0</version>
+				<version>3.20.0</version>
 			</dependency>
 			<dependency>
 				<groupId>org.apache.commons</groupId>
@@ -117,11 +117,11 @@
 				<version>1.28.0</version>
 			</dependency>
 			<dependency>
-				<groupId>com.fasterxml.jackson</groupId>
+				<groupId>tools.jackson</groupId>
 				<artifactId>jackson-bom</artifactId>
 				<version>${jacksonVersion}</version>
-                                <scope>import</scope>
-                                <type>pom</type>
+				<scope>import</scope>
+				<type>pom</type>
 			</dependency>
 			<dependency>
 				<groupId>org.threeten</groupId>
@@ -262,8 +262,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.14.1</version>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/wdtk-datamodel/pom.xml
+++ b/wdtk-datamodel/pom.xml
@@ -32,16 +32,12 @@
 			<artifactId>jackson-annotations</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
+			<groupId>tools.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>com.fasterxml.jackson.core</groupId>
+			<groupId>tools.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>com.fasterxml.jackson.datatype</groupId>
-			<artifactId>jackson-datatype-jdk8</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.threeten</groupId>

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/DatamodelMapper.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/DatamodelMapper.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,38 +19,34 @@
  */
 package org.wikidata.wdtk.datamodel.helpers;
 
-import com.fasterxml.jackson.databind.InjectableValues;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.InjectableValues;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
- * Same as Jackson's celebrated ObjectMapper, except
+ * Same as Jackson's celebrated JsonMapper, except
  * that we add injections necessary to fill fields not
  * represented in JSON.
- * 
+ *
  * @author antonin
  *
  */
-public class DatamodelMapper extends ObjectMapper {
+public class DatamodelMapper extends JsonMapper {
 
 	private static final long serialVersionUID = -236841297410109272L;
-	
+
 	/**
 	 * Constructs a mapper with the given siteIri. This IRI
 	 * will be used to fill all the siteIris of the entity ids
 	 * contained in the payloads.
-	 * 
+	 *
 	 * @param siteIri
 	 * 		the ambient IRI of the Wikibase site
 	 */
 	public DatamodelMapper(String siteIri) {
-		super();
-		InjectableValues injection = new InjectableValues.Std()
-				.addValue("siteIri", siteIri);
-		this.setInjectableValues(injection);
-		/*
-		 * Support for Optional properties.
-		 */
-		registerModule(new Jdk8Module());
+		super(JsonMapper.builder()
+				.enable(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT)
+				.disable(DeserializationFeature.FAIL_ON_NULL_FOR_PRIMITIVES)
+				.injectableValues(new InjectableValues.Std().addValue("siteIri", siteIri)));
 	}
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/JsonDeserializer.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/JsonDeserializer.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -33,18 +33,17 @@ import org.wikidata.wdtk.datamodel.interfaces.LexemeDocument;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectReader;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.ObjectReader;
 
 /**
  * Helper to deserialize datamodel objects from their
  * JSON representation.
- * 
+ *
  * We accept empty arrays as empty maps since there has
  * been a confusion in the past between the two:
  * https://phabricator.wikimedia.org/T138104
- * 
+ *
  * @author Antonin Delpeuch
  */
 public class JsonDeserializer {
@@ -55,81 +54,75 @@ public class JsonDeserializer {
 	private ObjectReader lexemeReader;
 	private ObjectReader mediaInfoReader;
 	private ObjectReader entityRedirectReader;
-	
+
 	/**
-	 * Constructs a new JSON deserializer for the 
+	 * Constructs a new JSON deserializer for the
 	 * designated site.
-	 * 
+	 *
 	 * @param siteIri
 	 * 		Root IRI of the site to deserialize for
 	 */
 	public JsonDeserializer(String siteIri) {
 		DatamodelMapper mapper = new DatamodelMapper(siteIri);
-		entityDocumentReader = mapper.readerFor(EntityDocumentImpl.class)
-				.with(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT);
-		itemReader = mapper.readerFor(ItemDocumentImpl.class)
-				.with(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT);
-		propertyReader = mapper.readerFor(PropertyDocumentImpl.class)
-				.with(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT);
-		lexemeReader = mapper.readerFor(LexemeDocumentImpl.class)
-				.with(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT);
-		mediaInfoReader = mapper.readerFor(MediaInfoDocumentImpl.class)
-				.with(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT);
-		entityRedirectReader = mapper.readerFor(EntityRedirectDocumentImpl.class)
-				.with(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT);
+		entityDocumentReader = mapper.readerFor(EntityDocumentImpl.class);
+		itemReader = mapper.readerFor(ItemDocumentImpl.class);
+		propertyReader = mapper.readerFor(PropertyDocumentImpl.class);
+		lexemeReader = mapper.readerFor(LexemeDocumentImpl.class);
+		mediaInfoReader = mapper.readerFor(MediaInfoDocumentImpl.class);
+		entityRedirectReader = mapper.readerFor(EntityRedirectDocumentImpl.class);
 	}
-	
+
 	/**
 	 * Deserializes a JSON string into an {@link ItemDocument}.
-	 * @throws JsonProcessingException 
+	 * @throws JacksonException
 			if the JSON payload is invalid
 	 */
-	public ItemDocument deserializeItemDocument(String json) throws JsonProcessingException {
+	public ItemDocument deserializeItemDocument(String json) {
 		return itemReader.readValue(json);
 	}
-	
+
 	/**
 	 * Deserializes a JSON string into a {@link PropertyDocument}.
-	 * @throws JsonProcessingException 
+	 * @throws JacksonException
 			if the JSON payload is invalid
 	 */
-	public PropertyDocument deserializePropertyDocument(String json) throws JsonProcessingException {
+	public PropertyDocument deserializePropertyDocument(String json) {
 		return propertyReader.readValue(json);
 	}
 
 	/**
 	 * Deserializes a JSON string into a {@link LexemeDocument}.
-	 * @throws JsonProcessingException 
+	 * @throws JacksonException
 			if the JSON payload is invalid
 	 */
-	public LexemeDocument deserializeLexemeDocument(String json) throws JsonProcessingException {
+	public LexemeDocument deserializeLexemeDocument(String json) {
 		return lexemeReader.readValue(json);
 	}
-	
+
 	/**
 	 * Deserializes a JSON string into a {@link MediaInfoDocument}.
-	 * @throws JsonProcessingException 
+	 * @throws JacksonException
 			if the JSON payload is invalid
 	 */
-	public MediaInfoDocument deserializeMediaInfoDocument(String json) throws JsonProcessingException {
+	public MediaInfoDocument deserializeMediaInfoDocument(String json) {
 		return mediaInfoReader.readValue(json);
 	}
-	
+
 	/**
 	 * Deserializes a JSON string into a {@link EntityDocument}.
-	 * @throws JsonProcessingException 
+	 * @throws JacksonException
 			if the JSON payload is invalid
 	 */
-	public EntityDocument deserializeEntityDocument(String json) throws JsonProcessingException {
+	public EntityDocument deserializeEntityDocument(String json) {
 		return entityDocumentReader.readValue(json);
 	}
 
 	/**
 	 * Deserializes a JSON string into a {@link EntityRedirectDocument}.
-	 * @throws JsonProcessingException
-	if the JSON payload is invalid
+	 * @throws JacksonException
+	        if the JSON payload is invalid
 	 */
-	public EntityRedirectDocument deserializeEntityRedirectDocument(String json) throws JsonProcessingException {
+	public EntityRedirectDocument deserializeEntityRedirectDocument(String json) {
 		return entityRedirectReader.readValue(json);
 	}
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/JsonSerializer.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/JsonSerializer.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,10 +35,9 @@ import org.wikidata.wdtk.datamodel.interfaces.MediaInfoDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import tools.jackson.core.JacksonException;
+import tools.jackson.core.StreamWriteFeature;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * This class implements {@link EntityDocumentDumpProcessor} to provide a
@@ -70,14 +69,7 @@ public class JsonSerializer implements EntityDocumentDumpProcessor {
 	/**
 	 * Object mapper that is used to serialize JSON.
 	 */
-	protected static final ObjectMapper mapper = new ObjectMapper();
-	static {
-		mapper.configure(JsonGenerator.Feature.AUTO_CLOSE_TARGET, false);
-		/*
-		 * Support for Optional properties.
-		 */
-		mapper.registerModule(new Jdk8Module());
-	}
+	protected static final JsonMapper mapper = JsonMapper.builder().disable(StreamWriteFeature.AUTO_CLOSE_TARGET).build();
 
 	/**
 	 * Counter for the number of documents serialized so far.
@@ -185,9 +177,9 @@ public class JsonSerializer implements EntityDocumentDumpProcessor {
 	 * @param entityDocument
 	 *            object to serialize
 	 * @return JSON serialization
-	 * @throws JsonProcessingException if the object cannot be serialized
+	 * @throws JacksonException if the object cannot be serialized
 	 */
-	public static String getJsonString(EntityDocument entityDocument) throws JsonProcessingException {
+	public static String getJsonString(EntityDocument entityDocument) {
 		return mapper.writeValueAsString(entityDocument);
 	}
 
@@ -198,9 +190,9 @@ public class JsonSerializer implements EntityDocumentDumpProcessor {
 	 * @param itemDocument
 	 *            object to serialize
 	 * @return JSON serialization
-	 * @throws JsonProcessingException if the object cannot be serialized
+	 * @throws JacksonException if the object cannot be serialized
 	 */
-	public static String getJsonString(ItemDocument itemDocument) throws JsonProcessingException {
+	public static String getJsonString(ItemDocument itemDocument) {
 		return mapper.writeValueAsString(itemDocument);
 	}
 
@@ -211,9 +203,9 @@ public class JsonSerializer implements EntityDocumentDumpProcessor {
 	 * @param propertyDocument
 	 *            object to serialize
 	 * @return JSON serialization
-	 * @throws JsonProcessingException if the object cannot be serialized
+	 * @throws JacksonException if the object cannot be serialized
 	 */
-	public static String getJsonString(PropertyDocument propertyDocument) throws JsonProcessingException {
+	public static String getJsonString(PropertyDocument propertyDocument) {
 		return mapper.writeValueAsString(propertyDocument);
 	}
 
@@ -224,9 +216,9 @@ public class JsonSerializer implements EntityDocumentDumpProcessor {
 	 * @param mediaInfoDocument
 	 *            object to serialize
 	 * @return JSON serialization
-	 * @throws JsonProcessingException if the object cannot be serialized
+	 * @throws JacksonException if the object cannot be serialized
 	 */
-	public static String getJsonString(MediaInfoDocument mediaInfoDocument) throws JsonProcessingException {
+	public static String getJsonString(MediaInfoDocument mediaInfoDocument) {
 		return mapper.writeValueAsString(mediaInfoDocument);
 	}
 
@@ -237,9 +229,9 @@ public class JsonSerializer implements EntityDocumentDumpProcessor {
 	 * @param statement
 	 *            object to serialize
 	 * @return JSON serialization
-	 * @throws JsonProcessingException if the object cannot be serialized
+	 * @throws JacksonException if the object cannot be serialized
 	 */
-	public static String getJsonString(Statement statement) throws JsonProcessingException {
+	public static String getJsonString(Statement statement) {
 		return mapper.writeValueAsString(statement);
 	}
 
@@ -250,9 +242,9 @@ public class JsonSerializer implements EntityDocumentDumpProcessor {
 	 * @param update
 	 *            object to serialize
 	 * @return JSON serialization
-	 * @throws JsonProcessingException if the object cannot be serialized
+	 * @throws JacksonException if the object cannot be serialized
 	 */
-	public static String getJsonString(EntityUpdate update) throws JsonProcessingException {
+	public static String getJsonString(EntityUpdate update) {
 		return mapper.writeValueAsString(update);
 	}
 

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LexemeDeserializer.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/helpers/LexemeDeserializer.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.helpers;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,25 +20,17 @@ package org.wikidata.wdtk.datamodel.helpers;
  * #L%
  */
 
-import com.fasterxml.jackson.core.JacksonException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import com.fasterxml.jackson.databind.exc.InvalidFormatException;
-import com.fasterxml.jackson.databind.node.NullNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.databind.type.TypeFactory;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.deser.std.StdDeserializer;
+import tools.jackson.databind.node.ObjectNode;
+import tools.jackson.databind.type.TypeFactory;
 import org.wikidata.wdtk.datamodel.implementation.*;
 import org.wikidata.wdtk.datamodel.interfaces.FormDocument;
-import org.wikidata.wdtk.datamodel.interfaces.LexemeDocument;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 import org.wikidata.wdtk.datamodel.interfaces.SenseDocument;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -56,16 +48,17 @@ public class LexemeDeserializer extends StdDeserializer<LexemeDocumentImpl> {
     }
 
     @Override
-    public LexemeDocumentImpl deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JacksonException {
-        JsonNode node = jsonParser.getCodec().readTree(jsonParser);
+	public LexemeDocumentImpl deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) {
+		JsonNode node = jsonParser.objectReadContext().readTree(jsonParser);
         if (! (node instanceof ObjectNode)) {
-            throw new IOException("Deserializing a lexeme can only be done from a JSON object");
+        	deserializationContext.reportInputMismatch(LexemeDocumentImpl.class,
+        			"Deserializing a lexeme can only be done from a JSON object");
         }
         ObjectNode object = (ObjectNode) node;
 
-        String jsonId = object.get("id").asText();
-        String lexicalCategory = object.get("lexicalCategory").asText();
-        String language = object.get("language").asText();
+        String jsonId = object.get("id").asString();
+        String lexicalCategory = object.get("lexicalCategory").asString();
+        String language = object.get("language").asString();
         TypeFactory typeFactory = deserializationContext.getTypeFactory();
 
         JsonNode lemmas1 = object.get("lemmas");
@@ -107,7 +100,7 @@ public class LexemeDeserializer extends StdDeserializer<LexemeDocumentImpl> {
         if (object.has("lastrevid")) {
             lastrevid = object.get("lastrevid").asLong();
         }
-        String siteIri = (String) deserializationContext.findInjectableValue("siteIri", null , null);
+        String siteIri = (String) deserializationContext.findInjectableValue("siteIri", null , null, null, null);
         return new LexemeDocumentImpl(
                 jsonId,
                 lexicalCategory,

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/EntityDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/EntityDocumentImpl.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,7 +23,9 @@ package org.wikidata.wdtk.datamodel.implementation;
 import com.fasterxml.jackson.annotation.*;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
-import org.apache.commons.lang3.Validate;
+
+import java.util.Objects;
+
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocument;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 
@@ -111,7 +113,7 @@ public abstract class EntityDocumentImpl implements EntityDocument {
 	 * 		the id of the last revision of this document
 	 */
 	EntityDocumentImpl(EntityIdValue id, long revisionId) {
-		Validate.notNull(id);
+		Objects.requireNonNull(id);
 		this.entityId = id.getId();
 		this.siteIri = id.getSiteIri();
 		this.revisionId = revisionId;
@@ -124,10 +126,8 @@ public abstract class EntityDocumentImpl implements EntityDocument {
 			@JsonProperty("id") String jsonId,
 			@JsonProperty("lastrevid") long revisionId,
 			@JacksonInject("siteIri") String siteIri) {
-		Validate.notNull(jsonId);
-		this.entityId = jsonId;
-		Validate.notNull(siteIri);
-		this.siteIri = siteIri;
+		this.entityId = Objects.requireNonNull(jsonId);
+		this.siteIri = Objects.requireNonNull(siteIri);
 		this.revisionId = revisionId;
 	}
 
@@ -151,7 +151,7 @@ public abstract class EntityDocumentImpl implements EntityDocument {
 	public String getSiteIri() {
 		return this.siteIri;
 	}
-	
+
 	private static class NonZeroFilter {
 		@Override
 		public boolean equals(Object other) {

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/EntityRedirectDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/EntityRedirectDocumentImpl.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,6 +24,9 @@ import com.fasterxml.jackson.annotation.JacksonInject;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
 import org.apache.commons.lang3.Validate;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
@@ -54,9 +57,8 @@ public class EntityRedirectDocumentImpl implements EntityRedirectDocument  {
 	 * 		the id of the last revision of this document
 	 */
 	EntityRedirectDocumentImpl(EntityIdValue id, EntityIdValue targetId, long revisionId) {
-		Validate.notNull(id);
-		this.entityId = id;
-		Validate.notNull(targetId);
+		this.entityId = Objects.requireNonNull(id);
+		Objects.requireNonNull(targetId);
 		Validate.isTrue(id.getEntityType().equals(targetId.getEntityType()), "You could only do redirects between entities of the same type");
 		this.targetId = targetId;
 		this.revisionId = revisionId;
@@ -72,7 +74,7 @@ public class EntityRedirectDocumentImpl implements EntityRedirectDocument  {
 			@JsonProperty("lastrevid") long revisionId,
 			@JacksonInject("siteIri") String siteIri) {
 		this.entityId = EntityIdValueImpl.fromId(jsonId, siteIri);
-		Validate.notNull(jsonTargetId);
+		Objects.requireNonNull(jsonTargetId);
 		this.targetId = EntityIdValueImpl.fromId(jsonTargetId, siteIri);
 		Validate.isTrue(getEntityId().getEntityType().equals(targetId.getEntityType()), "You could only do redirects between entities of the same type");
 		this.revisionId = revisionId;

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/FormDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/FormDocumentImpl.java
@@ -21,7 +21,7 @@ package org.wikidata.wdtk.datamodel.implementation;
  */
 
 import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/FormIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/FormIdValueImpl.java
@@ -1,8 +1,7 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
 import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.apache.commons.lang3.Validate;
+import tools.jackson.databind.annotation.JsonDeserialize;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;
@@ -11,6 +10,7 @@ import org.wikidata.wdtk.datamodel.interfaces.FormIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.LexemeIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ValueVisitor;
 
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 /*
@@ -22,9 +22,9 @@ import java.util.regex.Pattern;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -68,8 +68,7 @@ public class FormIdValueImpl extends ValueImpl implements FormIdValue {
 			throw new IllegalArgumentException("The string " + id + " is not a valid form id");
 		}
 		this.id = id;
-		Validate.notNull(siteIri);
-		this.siteIri = siteIri;
+		this.siteIri = Objects.requireNonNull(siteIri);
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/GlobeCoordinatesValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/GlobeCoordinatesValueImpl.java
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Jackson implementation of {@link GlobeCoordinatesValue}.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImpl.java
@@ -41,7 +41,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Jackson implementation of {@link ItemDocument}.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ItemIdValueImpl.java
@@ -1,7 +1,7 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
 import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/LexemeDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/LexemeDocumentImpl.java
@@ -21,7 +21,7 @@ package org.wikidata.wdtk.datamodel.implementation;
  */
 
 import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 import org.apache.commons.lang3.Validate;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/LexemeIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/LexemeIdValueImpl.java
@@ -1,7 +1,7 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
 import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoDocumentImpl.java
@@ -21,7 +21,7 @@ package org.wikidata.wdtk.datamodel.implementation;
  */
 
 import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoIdValueImpl.java
@@ -1,7 +1,7 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
 import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/MonolingualTextValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/MonolingualTextValueImpl.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Jackson implementation of {@link MonolingualTextValue}. Java attributes are

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImpl.java
@@ -39,7 +39,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Jackson implementation of {@link PropertyDocument}.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/PropertyIdValueImpl.java
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Jackson implementation of {@link PropertyIdValue}.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/QuantityValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/QuantityValueImpl.java
@@ -21,7 +21,7 @@ package org.wikidata.wdtk.datamodel.implementation;
  */
 
 import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 import org.apache.commons.lang3.Validate;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SenseDocumentImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SenseDocumentImpl.java
@@ -21,7 +21,7 @@ package org.wikidata.wdtk.datamodel.implementation;
  */
 
 import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SenseIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SenseIdValueImpl.java
@@ -1,8 +1,7 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
 import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import org.apache.commons.lang3.Validate;
+import tools.jackson.databind.annotation.JsonDeserialize;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;
@@ -11,6 +10,7 @@ import org.wikidata.wdtk.datamodel.interfaces.SenseIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.LexemeIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.ValueVisitor;
 
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 /*
@@ -22,9 +22,9 @@ import java.util.regex.Pattern;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -68,8 +68,7 @@ public class SenseIdValueImpl extends ValueImpl implements SenseIdValue {
 			throw new IllegalArgumentException("The string " + id + " is not a valid form id");
 		}
 		this.id = id;
-		Validate.notNull(siteIri);
-		this.siteIri = siteIri;
+		this.siteIri = Objects.requireNonNull(siteIri);
 	}
 
 	/**

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SiteLinkImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SiteLinkImpl.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,7 +21,6 @@ package org.wikidata.wdtk.datamodel.implementation;
  */
 
 import com.fasterxml.jackson.annotation.*;
-import org.apache.commons.lang3.Validate;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;
@@ -33,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Jackson implementation of {@link SiteLink}.
@@ -50,7 +50,7 @@ public class SiteLinkImpl implements SiteLink {
 
 	/**
 	 * Constructor.
-	 * 
+	 *
 	 * @param title
 	 * 		the title of the page on the target site
 	 * @param site
@@ -63,10 +63,8 @@ public class SiteLinkImpl implements SiteLink {
 			String title,
 			String site,
 			List<ItemIdValue> badges) {
-		Validate.notNull(title);
-		this.title = title;
-		Validate.notNull(site);
-		this.site = site;
+		this.title = Objects.requireNonNull(title);
+		this.site = Objects.requireNonNull(site);
 		this.badges = (badges == null) ? Collections.emptyList() : badges;
 		this.badges.sort(Comparator.comparing(EntityIdValue::getId));
 	}
@@ -89,10 +87,8 @@ public class SiteLinkImpl implements SiteLink {
 			@JsonProperty("badges") List<String> badges,
 			@JacksonInject("siteIri") String siteIri
 	) {
-		Validate.notNull(title);
-		this.title = title;
-		Validate.notNull(site);
-		this.site = site;
+		this.title = Objects.requireNonNull(title);
+		this.site = Objects.requireNonNull(site);
 		this.badges = (badges == null || badges.isEmpty())
 			? Collections.emptyList()
 			: constructBadges(badges, siteIri);

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SnakImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/SnakImpl.java
@@ -1,7 +1,5 @@
 package org.wikidata.wdtk.datamodel.implementation;
 
-import org.apache.commons.lang3.Validate;
-
 /*
  * #%L
  * Wikidata Toolkit Data Model
@@ -11,9 +9,9 @@ import org.apache.commons.lang3.Validate;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,6 +19,8 @@ import org.apache.commons.lang3.Validate;
  * limitations under the License.
  * #L%
  */
+
+import java.util.Objects;
 
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.Snak;
@@ -64,27 +64,26 @@ public abstract class SnakImpl implements Snak {
 	 * The property used by this snak.
 	 */
 	private final PropertyIdValue property;
-	
+
 	/**
 	 * Constructor.
 	 */
 	public SnakImpl(PropertyIdValue property) {
-		Validate.notNull(property);
-		this.property = property;
+		this.property = Objects.requireNonNull(property);
 	}
 
 	/**
 	 * Constructor. Creates an empty object that can be populated during JSON
 	 * deserialization. Should only be used by Jackson for this very purpose.
-	 * 
+	 *
 	 * This is not marked as JsonCreator because only concrete subclasses will
 	 * be deserialized directly.
 	 */
 	protected SnakImpl(
 			String id,
 			String siteIri) {
-		Validate.notNull(id);
-		Validate.notNull(siteIri);
+		Objects.requireNonNull(id);
+		Objects.requireNonNull(siteIri);
 		this.property = new PropertyIdValueImpl(id, siteIri);
 	}
 
@@ -104,7 +103,7 @@ public abstract class SnakImpl implements Snak {
 	public PropertyIdValue getPropertyId() {
 		return property;
 	}
-	
+
 	@JsonProperty("snaktype")
 	public abstract String getSnakType();
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StatementImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StatementImpl.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -21,14 +21,14 @@ package org.wikidata.wdtk.datamodel.implementation;
  */
 
 import com.fasterxml.jackson.annotation.*;
-import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonSerializer;
-import com.fasterxml.jackson.databind.SerializerProvider;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonParser;
+import tools.jackson.databind.DeserializationContext;
+import tools.jackson.databind.SerializationContext;
+import tools.jackson.databind.ValueDeserializer;
+import tools.jackson.databind.ValueSerializer;
+import tools.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonSerialize;
 import org.apache.commons.lang3.Validate;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
@@ -36,7 +36,6 @@ import org.wikidata.wdtk.datamodel.helpers.ToString;
 import org.wikidata.wdtk.datamodel.interfaces.*;
 import org.wikidata.wdtk.util.NestedIterator;
 
-import java.io.IOException;
 import java.util.*;
 
 /**
@@ -117,9 +116,7 @@ public class StatementImpl implements Statement {
 		}
 
 		this.references = (references == null) ? Collections.emptyList() : references;
-		Validate.notNull(subjectId);
-
-		this.subjectId = subjectId;
+		this.subjectId = Objects.requireNonNull(subjectId);
 	}
 
 	public StatementImpl(
@@ -138,8 +135,7 @@ public class StatementImpl implements Statement {
 		this.qualifiers = (qualifiers == null) ? Collections.emptyMap() : qualifiers;
 		this.qualifiersOrder = (qualifiersOrder == null) ? Collections.emptyList() : qualifiersOrder;
 		this.references = (references == null) ? Collections.emptyList() : references;
-		Validate.notNull(subjectId);
-		this.subjectId = subjectId;
+		this.subjectId = Objects.requireNonNull(subjectId);
 	}
 
 	/**
@@ -251,7 +247,7 @@ public class StatementImpl implements Statement {
 				getReferences(),
 				getSubject());
 	}
-	
+
 	@Override
 	public int hashCode() {
 		return Hash.hashCode(this);
@@ -335,10 +331,10 @@ public class StatementImpl implements Statement {
 	 * necessary since Java enumerations are in upper case but the Json counterpart
 	 * is in lower case.
 	 */
-	static class StatementRankSerializer extends JsonSerializer<StatementRank> {
+	static class StatementRankSerializer extends ValueSerializer<StatementRank> {
 
 		@Override
-		public void serialize(StatementRank value, JsonGenerator jgen, SerializerProvider provider) throws IOException {
+		public void serialize(StatementRank value, JsonGenerator jgen, SerializationContext provider) {
 			jgen.writeString(value.name().toLowerCase());
 
 		}
@@ -349,11 +345,11 @@ public class StatementImpl implements Statement {
 	 * necessary since Java enumerations are in upper case but the Json counterpart
 	 * is in lower case.
 	 */
-	static class StatementRankDeserializer extends JsonDeserializer<StatementRank> {
+	static class StatementRankDeserializer extends ValueDeserializer<StatementRank> {
 
 		@Override
-		public StatementRank deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
-			return StatementRank.valueOf(jp.getText().toUpperCase());
+		public StatementRank deserialize(JsonParser jp, DeserializationContext ctxt) {
+			return StatementRank.valueOf(jp.getString().toUpperCase());
 		}
 	}
 }

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StringValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/StringValueImpl.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /*
  * #%L

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TimeValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/TimeValueImpl.java
@@ -36,7 +36,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Jackson implementation of {@link TimeValue}.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueImpl.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,9 +22,9 @@ package org.wikidata.wdtk.datamodel.implementation;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.Validate;
 import org.wikidata.wdtk.datamodel.helpers.Equality;
 import org.wikidata.wdtk.datamodel.helpers.Hash;
 import org.wikidata.wdtk.datamodel.helpers.ToString;
@@ -39,8 +39,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Represents a entity id value of an unsupported type.
@@ -49,12 +49,12 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
  * back to its original representation.
  * This avoids parsing failures on documents containing
  * these values.
- * 
+ *
  * @author Antonin Delpeuch
  */
 @JsonDeserialize()
 public class UnsupportedEntityIdValueImpl extends ValueImpl implements UnsupportedEntityIdValue {
-	
+
 	private final JacksonIdValue value;
 	private final String siteIri;
 
@@ -73,41 +73,40 @@ public class UnsupportedEntityIdValueImpl extends ValueImpl implements Unsupport
 		private final String entityType;
 		private final String id;
 		private final Map<String, JsonNode> contents;
-		
+
 		@JsonCreator
 		private JacksonIdValue(
 				@JsonProperty("entity-type")
 				String entityType,
 				@JsonProperty("id")
 				String id) {
-			Validate.notNull(id);
 			this.entityType = entityType;
-			this.id = id;
+			this.id = Objects.requireNonNull(id);
 			contents = new HashMap<>();
 		}
-		
+
 		@JsonProperty("entity-type")
 		@JsonInclude(Include.NON_NULL)
 		public String getEntityTypeString() {
 			return entityType;
 		}
-		
+
 		@JsonProperty("id")
 		public String getId() {
 			return id;
 		}
-		
+
 		@JsonAnyGetter
 		protected Map<String, JsonNode> getContents() {
 			return contents;
 		}
-		
+
 		@JsonAnySetter
 		protected void loadContents(String key, JsonNode value) {
 			this.contents.put(key, value);
 		}
 	}
-	
+
 	@Override
 	public String toString() {
 		return ToString.toString(this);
@@ -131,7 +130,7 @@ public class UnsupportedEntityIdValueImpl extends ValueImpl implements Unsupport
 	public String getId() {
 		return value.getId();
 	}
-	
+
 	@JsonProperty("value")
 	protected JacksonIdValue getInnerValue() {
 		return value;
@@ -159,12 +158,12 @@ public class UnsupportedEntityIdValueImpl extends ValueImpl implements Unsupport
 	public int hashCode() {
 		return Hash.hashCode(this);
 	}
-	
+
 	@Override
 	public boolean equals(Object other) {
 		return Equality.equalsEntityIdValue(this, other);
 	}
-	
+
 	@Override
 	public <T> T accept(ValueVisitor<T> valueVisitor) {
 		return valueVisitor.visit(this);

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedValueImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedValueImpl.java
@@ -31,8 +31,8 @@ import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Represents a value with an unsupported datatype.

--- a/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ValueSnakImpl.java
+++ b/wdtk-datamodel/src/main/java/org/wikidata/wdtk/datamodel/implementation/ValueSnakImpl.java
@@ -41,7 +41,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import tools.jackson.databind.annotation.JsonDeserialize;
 
 /**
  * Jackson implementation of {@link ValueSnak}.

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/JsonSerializerTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/helpers/JsonSerializerTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,7 +23,6 @@ package org.wikidata.wdtk.datamodel.helpers;
 import static org.junit.Assert.*;
 
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -45,15 +44,15 @@ import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
 import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.MappingIterator;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectReader;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.MappingIterator;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectReader;
 
 public class JsonSerializerTest {
 
 	@Test
-	public void testSerializer() throws IOException {
+	public void testSerializer() {
 		ByteArrayOutputStream out = new ByteArrayOutputStream();
 		JsonSerializer serializer = new JsonSerializer(out);
 
@@ -102,7 +101,7 @@ public class JsonSerializerTest {
 	}
 
 	@Test
-	public void testItemDocumentToJson() throws JsonProcessingException {
+	public void testItemDocumentToJson() {
 		ItemDocument id = Datamodel.makeItemDocument(
 				Datamodel.makeWikidataItemIdValue("Q42"),
 				Collections.emptyList(),
@@ -115,7 +114,7 @@ public class JsonSerializerTest {
 	}
 
 	@Test
-	public void testPropertyDocumentToJson() throws JsonProcessingException {
+	public void testPropertyDocumentToJson() {
 		PropertyDocument pd = Datamodel.makePropertyDocument(
 				Datamodel.makeWikidataPropertyIdValue("P1"),
 				Collections. emptyList(),
@@ -128,7 +127,7 @@ public class JsonSerializerTest {
 	}
 
 	@Test
-	public void testStatementToJson() throws JsonProcessingException {
+	public void testStatementToJson() {
 		Statement s = Datamodel.makeStatement(ItemIdValue.NULL,
 				Datamodel.makeNoValueSnak(Datamodel.makeWikidataPropertyIdValue("P1")),
 				Collections.emptyList(), Collections.emptyList(),
@@ -212,6 +211,6 @@ public class JsonSerializerTest {
 			}
 		};
 
-		assertThrows(JsonProcessingException.class, () -> JsonSerializer.getJsonString(obj));
+		assertThrows(JacksonException.class, () -> JsonSerializer.getJsonString(obj));
 	}
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/EntityRedirectDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/EntityRedirectDocumentImplTest.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,14 +20,11 @@ package org.wikidata.wdtk.datamodel.implementation;
  * #L%
  */
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.EntityRedirectDocument;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
-
-import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -90,12 +87,12 @@ public class EntityRedirectDocumentImplTest {
 	}
 
 	@Test
-	public void testRedirectToJson() throws JsonProcessingException {
+	public void testRedirectToJson() {
 		JsonComparator.compareJsonStrings(JSON_ITEM_REDIRECT, mapper.writeValueAsString(itemRedirect));
 	}
 
 	@Test
-	public void testLexemeToJava() throws IOException {
+	public void testLexemeToJava() {
 		assertEquals(itemRedirect, mapper.readValue(JSON_ITEM_REDIRECT, EntityRedirectDocumentImpl.class));
 	}
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/FormDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/FormDocumentImplTest.java
@@ -35,9 +35,9 @@ import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -46,8 +46,7 @@ import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
  * #L%
  */
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 public class FormDocumentImplTest {
 
@@ -221,7 +220,7 @@ public class FormDocumentImplTest {
 	}
 
 	@Test
-	public void testFormToJson() throws JsonProcessingException {
+	public void testFormToJson() {
 		JsonComparator.compareJsonStrings(JSON_FORM, mapper.writeValueAsString(fd1));
 	}
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/FormIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/FormIdValueImplTest.java
@@ -11,9 +11,9 @@ import static org.junit.Assert.*;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,16 +22,10 @@ import static org.junit.Assert.*;
  * #L%
  */
 
-
-import java.io.IOException;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
-
-import java.io.IOException;
 
 public class FormIdValueImplTest {
 
@@ -116,17 +110,17 @@ public class FormIdValueImplTest {
 	}
 
 	@Test
-	public void testToJson() throws JsonProcessingException {
+	public void testToJson() {
 		JsonComparator.compareJsonStrings(JSON_FORM_ID_VALUE, mapper.writeValueAsString(form1));
 	}
 
 	@Test
-	public void testToJava() throws IOException {
+	public void testToJava() {
 		assertEquals(form1, mapper.readValue(JSON_FORM_ID_VALUE, ValueImpl.class));
 	}
 
 	@Test
-	public void testToJavaWithoutNumericalID() throws IOException {
+	public void testToJavaWithoutNumericalID() {
 		assertEquals(form1, mapper.readValue(JSON_FORM_ID_VALUE_WITHOUT_TYPE, ValueImpl.class));
 	}
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/GlobeCoordinatesValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/GlobeCoordinatesValueImplTest.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,16 +22,16 @@ package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.junit.Assert.*;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.GlobeCoordinatesValue;
+
+import tools.jackson.databind.json.JsonMapper;
 
 import java.io.IOException;
 
 public class GlobeCoordinatesValueImplTest {
 
-	private final ObjectMapper mapper = new ObjectMapper();
+	private final JsonMapper mapper = new JsonMapper();
 
 	private final GlobeCoordinatesValue c1 = new GlobeCoordinatesValueImpl(12.3, 14.1,
 			GlobeCoordinatesValue.PREC_DEGREE,
@@ -48,10 +48,10 @@ public class GlobeCoordinatesValueImplTest {
 
 	@Test
 	public void dataIsCorrect() {
-		assertEquals(c1.getLatitude(), 12.3, 0);
-		assertEquals(c1.getLongitude(), 14.1, 0);
-		assertEquals(c1.getPrecision(), GlobeCoordinatesValue.PREC_DEGREE, 0);
-		assertEquals(c1.getGlobe(), GlobeCoordinatesValue.GLOBE_EARTH);
+		assertEquals(12.3, c1.getLatitude(), 0);
+		assertEquals(14.1, c1.getLongitude(), 0);
+		assertEquals(GlobeCoordinatesValue.PREC_DEGREE, c1.getPrecision(), 0);
+		assertEquals(GlobeCoordinatesValue.GLOBE_EARTH, c1.getGlobe());
 	}
 
 	@Test
@@ -136,7 +136,7 @@ public class GlobeCoordinatesValueImplTest {
 	}
 
 	@Test
-	public void testToJson() throws JsonProcessingException {
+	public void testToJson() {
 		JsonComparator.compareJsonStrings(JSON_GLOBE_COORDINATES_VALUE, mapper.writeValueAsString(c1));
 	}
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemDocumentImplTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,7 +22,6 @@ package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.junit.Assert.*;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -42,9 +41,8 @@ import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
 import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
 
 public class ItemDocumentImplTest {
 
@@ -251,7 +249,7 @@ public class ItemDocumentImplTest {
 		assertEquals(1235L, ir1.withRevisionId(1235L).getRevisionId());
 		assertEquals(ir1, ir1.withRevisionId(1325L).withRevisionId(ir1.getRevisionId()));
 	}
-	
+
 	@Test
 	public void testWithLabelInNewLanguage() {
 		MonolingualTextValue newLabel = new MonolingualTextValueImpl(
@@ -259,7 +257,7 @@ public class ItemDocumentImplTest {
 		ItemDocument withLabel = ir1.withLabel(newLabel);
 		assertEquals("Item Q42", withLabel.findLabel("fr"));
 	}
-	
+
 	@Test
 	public void testWithDescriptionInNewLanguage() {
 		MonolingualTextValue newDescription = new MonolingualTextValueImpl(
@@ -275,7 +273,7 @@ public class ItemDocumentImplTest {
 		ItemDocument withDescription = ir1.withDescription(newDescription);
 		assertEquals("eine viel bessere Beschreibung", withDescription.findDescription("de"));
 	}
-	
+
 	@Test
 	public void testWithAliasInNewLanguage() {
 		MonolingualTextValue newAlias = new MonolingualTextValueImpl(
@@ -292,7 +290,7 @@ public class ItemDocumentImplTest {
 		ItemDocument withAlias = ir1.withAliases("en", Collections.singletonList(newAlias));
 		assertEquals(Collections.singletonList(newAlias), withAlias.getAliases().get("en"));
 	}
-	
+
 	@Test
 	public void testAddStatement() {
 		Statement fresh = new StatementImpl("MyFreshId", StatementRank.NORMAL,
@@ -307,7 +305,7 @@ public class ItemDocumentImplTest {
 				claim.getMainSnak().getPropertyId(),
 				claim.getValue()));
 	}
-	
+
 	@Test
 	public void testDeleteStatements() {
 		Statement toRemove = statementGroups.get(0).getStatements().get(0);
@@ -316,7 +314,7 @@ public class ItemDocumentImplTest {
 	}
 
 	@Test
-	public void testLabelsToJson() throws JsonProcessingException {
+	public void testLabelsToJson() {
 		ItemDocumentImpl document = new ItemDocumentImpl(iid,
 				labelList, Collections.emptyList(), Collections.emptyList(),
 				Collections.emptyList(), Collections.emptyList(), 0);
@@ -324,7 +322,7 @@ public class ItemDocumentImplTest {
 	}
 
 	@Test
-	public void testLabelToJava() throws IOException {
+	public void testLabelToJava() {
 		ItemDocumentImpl document = new ItemDocumentImpl(iid,
 				labelList, Collections.emptyList(), Collections.emptyList(),
 				Collections.emptyList(), Collections.emptyList(), 0);
@@ -332,7 +330,7 @@ public class ItemDocumentImplTest {
 	}
 
 	@Test
-	public void testDescriptionsToJson() throws JsonProcessingException {
+	public void testDescriptionsToJson() {
 		ItemDocumentImpl document = new ItemDocumentImpl(iid,
 				Collections.emptyList(), descList, Collections.emptyList(),
 				Collections.emptyList(), Collections.emptyList(), 0);
@@ -340,7 +338,7 @@ public class ItemDocumentImplTest {
 	}
 
 	@Test
-	public void testDescriptionsToJava() throws IOException {
+	public void testDescriptionsToJava() {
 		ItemDocumentImpl document = new ItemDocumentImpl(iid,
 				Collections.emptyList(), descList, Collections.emptyList(),
 				Collections.emptyList(), Collections.emptyList(), 0);
@@ -348,7 +346,7 @@ public class ItemDocumentImplTest {
 	}
 
 	@Test
-	public void testAliasesToJson() throws JsonProcessingException {
+	public void testAliasesToJson() {
 		ItemDocumentImpl document = new ItemDocumentImpl(iid,
 				Collections.emptyList(), Collections.emptyList(), aliasList,
 				Collections.emptyList(), Collections.emptyList(), 0);
@@ -356,7 +354,7 @@ public class ItemDocumentImplTest {
 	}
 
 	@Test
-	public void testAliasesToJava() throws IOException {
+	public void testAliasesToJava() {
 		ItemDocumentImpl document = new ItemDocumentImpl(iid,
 				Collections.emptyList(), Collections.emptyList(), aliasList,
 				Collections.emptyList(), Collections.emptyList(), 0);
@@ -364,7 +362,7 @@ public class ItemDocumentImplTest {
 	}
 
 	@Test
-	public void testStatementsToJson() throws JsonProcessingException {
+	public void testStatementsToJson() {
 		ItemDocumentImpl document = new ItemDocumentImpl(iid,
 				Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
 				statementGroups, Collections.emptyList(), 0);
@@ -372,7 +370,7 @@ public class ItemDocumentImplTest {
 	}
 
 	@Test
-	public void testStatementsToJava() throws IOException {
+	public void testStatementsToJava() {
 		ItemDocumentImpl document = new ItemDocumentImpl(iid,
 				Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
 				statementGroups, Collections.emptyList(), 0);
@@ -380,7 +378,7 @@ public class ItemDocumentImplTest {
 	}
 
 	@Test
-	public void testSiteLinksToJson() throws JsonProcessingException {
+	public void testSiteLinksToJson() {
 		ItemDocumentImpl document = new ItemDocumentImpl(iid,
 				Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
 				Collections.emptyList(), sitelinks, 0);
@@ -388,7 +386,7 @@ public class ItemDocumentImplTest {
 	}
 
 	@Test
-	public void testSiteLinksToJava() throws IOException {
+	public void testSiteLinksToJava() {
 		ItemDocumentImpl document = new ItemDocumentImpl(iid,
 				Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
 				Collections.emptyList(), sitelinks, 0);
@@ -399,7 +397,7 @@ public class ItemDocumentImplTest {
 	 * Checks support of wrong serialization of empty object as empty array
 	 */
 	@Test
-	public void testEmptyArraysForTerms() throws IOException {
+	public void testEmptyArraysForTerms() {
 		ItemDocumentImpl document = new ItemDocumentImpl(iid,
 				Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
 				Collections.emptyList(), Collections.emptyList(), 0);
@@ -411,7 +409,7 @@ public class ItemDocumentImplTest {
 	}
 
 	@Test
-	public void testGetJsonId() throws Exception {
+	public void testGetJsonId() {
 		ItemDocument item = Datamodel.makeItemDocument(
 				Datamodel.makeWikidataItemIdValue("Q42"),
 				Collections.singletonList(Datamodel.makeMonolingualTextValue("en", "label")),

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/ItemIdValueImplTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,8 +22,6 @@ package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.junit.Assert.*;
 
-import java.io.IOException;
-
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
@@ -31,9 +29,8 @@ import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.UnsupportedEntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.Value;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.DatabindException;
+import tools.jackson.databind.ObjectMapper;
 
 public class ItemIdValueImplTest {
 
@@ -112,40 +109,40 @@ public class ItemIdValueImplTest {
 	}
 
 	@Test
-	public void testToJson() throws JsonProcessingException {
+	public void testToJson() {
 		JsonComparator.compareJsonStrings(JSON_ITEM_ID_VALUE, mapper.writeValueAsString(item1));
 	}
 
 	@Test
-	public void testToJava() throws IOException {
+	public void testToJava() {
 		assertEquals(item1, mapper.readValue(JSON_ITEM_ID_VALUE, ValueImpl.class));
 	}
 
 	@Test
-	public void testToJavaWithoutId() throws IOException {
+	public void testToJavaWithoutId() {
 		assertEquals(item1, mapper.readValue(JSON_ITEM_ID_VALUE_WITHOUT_ID, ValueImpl.class));
 	}
 
 	@Test
-	public void testToJavaWithoutNumericalId() throws IOException {
+	public void testToJavaWithoutNumericalId() {
 		assertEquals(item1, mapper.readValue(JSON_ITEM_ID_VALUE_WITHOUT_NUMERICAL_ID, ValueImpl.class));
 	}
-	
+
 	@Test
-	public void testToJavaWrongID() throws IOException {
+	public void testToJavaWrongID() {
 		Value unsupported = mapper.readValue(JSON_ITEM_ID_VALUE_WRONG_ID, ValueImpl.class);
 		assertTrue(unsupported instanceof UnsupportedEntityIdValue);
 	}
 
 	@Test
-	public void testToJavaUnsupportedType() throws IOException {
+	public void testToJavaUnsupportedType() {
 		Value unsupported = mapper.readValue(JSON_ITEM_ID_VALUE_UNSUPPORTED_TYPE, ValueImpl.class);
 		assertTrue(unsupported instanceof UnsupportedEntityIdValue);
 		assertEquals("foo", ((UnsupportedEntityIdValue)unsupported).getEntityTypeJsonString());
 	}
-	
-	@Test(expected = JsonMappingException.class)
-	public void testToJavaUnsupportedWithoutId() throws IOException {
+
+	@Test(expected = DatabindException.class)
+	public void testToJavaUnsupportedWithoutId() {
 		mapper.readValue(JSON_ITEM_ID_VALUE_UNSUPPORTED_NO_ID, ValueImpl.class);
 	}
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/JsonComparator.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/JsonComparator.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,12 +20,10 @@ package org.wikidata.wdtk.datamodel.implementation;
  * #L%
  */
 
-import java.io.IOException;
-
 import org.junit.Assert;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * A helper class for comparing JSON objects to each other.
@@ -34,7 +32,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class JsonComparator {
 
-	private static final ObjectMapper mapper = new ObjectMapper();
+	private static final JsonMapper mapper = new JsonMapper();
 
 	/**
 	 * Compares two JSON objects represented by Strings to each other. Both
@@ -42,12 +40,8 @@ public class JsonComparator {
 	 * tree is build and both trees are compared.
 	 */
 	public static void compareJsonStrings(String expected, String actual) {
-		try {
-			JsonNode tree1 = mapper.readTree(expected);
-			JsonNode tree2 = mapper.readTree(actual);
-			Assert.assertEquals(tree1, tree2);
-		} catch (IOException e) {
-			e.printStackTrace();
-		}
+		JsonNode tree1 = mapper.readTree(expected);
+		JsonNode tree2 = mapper.readTree(actual);
+		Assert.assertEquals(tree1, tree2);
 	}
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/JsonTestUtils.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/JsonTestUtils.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,59 +19,42 @@
  */
 package org.wikidata.wdtk.datamodel.implementation;
 
-import static org.junit.Assert.fail;
-
-import java.io.IOException;
 import java.util.TreeMap;
 
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.JsonNodeFactory;
+import tools.jackson.databind.node.ObjectNode;
 
 class JsonTestUtils {
 
-	private static final ObjectMapper mapper = new ObjectMapper();
+	/*
+	 * Sort fields by name to produce mostly canonical JSON.
+	 * https://cowtowncoder.medium.com/
+	 * jackson-tips-sorting-json-using-jsonnode-ce4476e37aee
+	 */
+	private static final JsonMapper mapper = JsonMapper.builder().nodeFactory(new JsonNodeFactory() {
 
-	static {
-		/*
-		 * Support for Optional properties.
-		 */
-		mapper.registerModule(new Jdk8Module());
-		/*
-		 * Sort fields by name to produce mostly canonical JSON.
-		 * https://cowtowncoder.medium.com/
-		 * jackson-tips-sorting-json-using-jsonnode-ce4476e37aee
-		 */
-		mapper.setNodeFactory(new JsonNodeFactory() {
+		private static final long serialVersionUID = 1L;
 
-			private static final long serialVersionUID = 1L;
+		@Override
+		public ObjectNode objectNode() {
+			return new ObjectNode(this, new TreeMap<String, JsonNode>());
+		}
 
-			@Override
-			public ObjectNode objectNode() {
-				return new ObjectNode(this, new TreeMap<String, JsonNode>());
-			}
-
-		});
-	}
+	}).build();
 
 	static String toJson(Object value) {
-		try {
-			String json = mapper.writeValueAsString(value);
-			/*
-			 * Canonical form.
-			 */
-			JsonNode tree = mapper.readTree(json);
-			return mapper.writeValueAsString(tree);
-		} catch (IOException ex) {
-			fail("JSON serialization failed.");
-			return null;
-		}
+		String json = mapper.writeValueAsString(value);
+		/*
+		 * Canonical form.
+		 */
+		JsonNode tree = mapper.readTree(json);
+		return mapper.writeValueAsString(tree);
 	}
 
 	private static class JsonMatcher<T> extends BaseMatcher<T> {

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeDocumentImplTest.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,15 +20,12 @@ package org.wikidata.wdtk.datamodel.implementation;
  * #L%
  */
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.*;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -300,17 +297,17 @@ public class LexemeDocumentImplTest {
 	}
 
 	@Test
-	public void testLexemeToJson() throws JsonProcessingException {
+	public void testLexemeToJson() {
 		JsonComparator.compareJsonStrings(JSON_LEXEME, mapper.writeValueAsString(ld1));
 	}
 
 	@Test
-	public void testLexemeToJava() throws IOException {
+	public void testLexemeToJava() {
 		assertEquals(ld1, mapper.readValue(JSON_LEXEME, LexemeDocumentImpl.class));
 	}
 
 	@Test
-	public void testDeserializeLexemeWithJsonObjectInPlaceOfEmptyList() throws JsonProcessingException {
+	public void testDeserializeLexemeWithJsonObjectInPlaceOfEmptyList() {
 		// test for https://github.com/Wikidata/Wikidata-Toolkit/issues/568
 		// phab: https://phabricator.wikimedia.org/T305660
 		assertEquals(ld3, mapper.readValue(JSON_LEXEME_FOR_ISSUE_568, LexemeDocumentImpl.class));

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/LexemeIdValueImplTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,15 +24,12 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 
-import java.io.IOException;
-
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 public class LexemeIdValueImplTest {
 
@@ -107,17 +104,17 @@ public class LexemeIdValueImplTest {
 	}
 
 	@Test
-	public void testToJson() throws JsonProcessingException {
+	public void testToJson() {
 		JsonComparator.compareJsonStrings(JSON_LEXEME_ID_VALUE, mapper.writeValueAsString(lexeme1));
 	}
 
 	@Test
-	public void testToJava() throws IOException {
+	public void testToJava() {
 		assertEquals(lexeme1, mapper.readValue(JSON_LEXEME_ID_VALUE, ValueImpl.class));
 	}
 
 	@Test
-	public void testToJavaWithoutNumericalID() throws IOException {
+	public void testToJavaWithoutNumericalID() {
 		assertEquals(lexeme1, mapper.readValue(JSON_LEXEME_ID_VALUE_WITHOUT_NUMERICAL_ID, ValueImpl.class));
 	}
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoDocumentImplTest.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,21 +20,17 @@ package org.wikidata.wdtk.datamodel.implementation;
  * #L%
  */
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
-import org.wikidata.wdtk.datamodel.interfaces.*;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
-import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.Claim;
 import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoDocument;
@@ -45,9 +41,6 @@ import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
 import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import static org.junit.Assert.*;
 
 public class MediaInfoDocumentImplTest {
@@ -90,10 +83,10 @@ public class MediaInfoDocumentImplTest {
 	public void equalityBasedOnContent() {
 		MediaInfoDocument irDiffLabel = new MediaInfoDocumentImpl(mid, Collections.emptyList(), statementGroups, 1234);
 		MediaInfoDocument irDiffStatementGroups = new MediaInfoDocumentImpl(mid,
-				labelList, 
+				labelList,
 				Collections.emptyList(), 1234);
 		MediaInfoDocument irDiffRevisions = new MediaInfoDocumentImpl(mid,
-				labelList, 
+				labelList,
 				statementGroups, 1235);
 
 		PropertyDocument pr = new PropertyDocumentImpl(
@@ -106,7 +99,7 @@ public class MediaInfoDocumentImplTest {
 		// based on different item ids with all other data being equal
 		MediaInfoDocument irDiffMediaInfoIdValue = new MediaInfoDocumentImpl(
 				new MediaInfoIdValueImpl("M23", "http://example.org/"),
-				labelList, 
+				labelList,
 				Collections.emptyList(), 1234);
 
 		assertEquals(mi1, mi1);
@@ -178,7 +171,7 @@ public class MediaInfoDocumentImplTest {
 		assertEquals(1235L, mi1.withRevisionId(1235L).getRevisionId());
 		assertEquals(mi1, mi1.withRevisionId(1325L).withRevisionId(mi1.getRevisionId()));
 	}
-	
+
 	@Test
 	public void testWithLabelInNewLanguage() {
 		MonolingualTextValue newLabel = new MonolingualTextValueImpl(
@@ -186,7 +179,7 @@ public class MediaInfoDocumentImplTest {
 		MediaInfoDocument withLabel = mi1.withLabel(newLabel);
 		assertEquals("MediaInfo M42", withLabel.findLabel("fr"));
 	}
-	
+
 	@Test
 	public void testAddStatement() {
 		Statement fresh = new StatementImpl("MyFreshId", StatementRank.NORMAL,
@@ -201,7 +194,7 @@ public class MediaInfoDocumentImplTest {
 				claim.getMainSnak().getPropertyId(),
 				claim.getValue()));
 	}
-	
+
 	@Test
 	public void testDeleteStatements() {
 		Statement toRemove = statementGroups.get(0).getStatements().get(0);
@@ -210,39 +203,39 @@ public class MediaInfoDocumentImplTest {
 	}
 
 	@Test
-	public void testLabelsToJson() throws JsonProcessingException {
+	public void testLabelsToJson() {
 		MediaInfoDocumentImpl document = new MediaInfoDocumentImpl(mid, labelList, Collections.emptyList(), 0);
 		JsonComparator.compareJsonStrings(JSON_MEDIA_INFO_LABEL, mapper.writeValueAsString(document));
 	}
 
 	@Test
-	public void testLabelToJava() throws IOException {
+	public void testLabelToJava() {
 		MediaInfoDocumentImpl document = new MediaInfoDocumentImpl(mid,
 				labelList, Collections.emptyList(), 0);
 		assertEquals(document, mapper.readValue(JSON_MEDIA_INFO_LABEL, EntityDocumentImpl.class));
 	}
 
 	@Test
-	public void testDescriptionsToJava() throws IOException {
+	public void testDescriptionsToJava() {
 		MediaInfoDocumentImpl document = new MediaInfoDocumentImpl(mid,
 				Collections.emptyList(), Collections.emptyList(), 0);
 		assertEquals(document, mapper.readValue(JSON_MEDIA_INFO_DESCRIPTION, EntityDocumentImpl.class));
 	}
 
 	@Test
-	public void testStatementsToJson() throws JsonProcessingException {
+	public void testStatementsToJson() {
 		MediaInfoDocumentImpl document = new MediaInfoDocumentImpl(mid, Collections.emptyList(), statementGroups,  0);
 		JsonComparator.compareJsonStrings(JSON_MEDIA_INFO_CLAIMS, mapper.writeValueAsString(document));
 	}
 
 	@Test
-	public void testStatementsToJava() throws IOException {
+	public void testStatementsToJava() {
 		MediaInfoDocumentImpl document = new MediaInfoDocumentImpl(mid, Collections.emptyList(), statementGroups, 0);
 		assertEquals(document, mapper.readValue(JSON_MEDIA_INFO_STATEMENTS, MediaInfoDocumentImpl.class));
 	}
 
 	@Test
-	public void testStatementsNamedClaimsToJava() throws IOException {
+	public void testStatementsNamedClaimsToJava() {
 		MediaInfoDocumentImpl document = new MediaInfoDocumentImpl(mid, Collections.emptyList(), statementGroups, 0);
 		assertEquals(document, mapper.readValue(JSON_MEDIA_INFO_CLAIMS, MediaInfoDocumentImpl.class));
 	}
@@ -251,7 +244,7 @@ public class MediaInfoDocumentImplTest {
 	 * Checks support of wrong serialization of empty object as empty array
 	 */
 	@Test
-	public void testEmptyArraysForTerms() throws IOException {
+	public void testEmptyArraysForTerms() {
 		MediaInfoDocumentImpl document = new MediaInfoDocumentImpl(mid, Collections.emptyList(), Collections.emptyList(), 0);
 
 		assertEquals(document, mapper.readerFor(MediaInfoDocumentImpl.class)

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MediaInfoIdValueImplTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,8 +29,7 @@ import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 public class MediaInfoIdValueImplTest {
 
@@ -105,7 +104,7 @@ public class MediaInfoIdValueImplTest {
 	}
 
 	@Test
-	public void testToJson() throws JsonProcessingException {
+	public void testToJson() {
 		JsonComparator.compareJsonStrings(JSON_MEDIA_INFO_ID_VALUE, mapper.writeValueAsString(mediaInfo1));
 	}
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MonolingualTextValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/MonolingualTextValueImplTest.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,16 +22,14 @@ package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.junit.Assert.*;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
 
-import java.io.IOException;
-
 public class MonolingualTextValueImplTest {
 
-	private final ObjectMapper mapper = new ObjectMapper();
+	private final JsonMapper mapper = new JsonMapper();
 
 	private final MonolingualTextValue mt1 = new MonolingualTextValueImpl("some string", "en");
 	private final MonolingualTextValue mt2 = new MonolingualTextValueImpl("some string", "en");
@@ -74,12 +72,12 @@ public class MonolingualTextValueImplTest {
 	}
 
 	@Test
-	public void testToJava() throws IOException {
+	public void testToJava() {
 		assertEquals(mt1, mapper.readValue(JSON_MONOLINGUAL_TEXT_VALUE, MonolingualTextValueImpl.class));
 	}
 
 	@Test
-	public void testToJson() throws JsonProcessingException {
+	public void testToJson() {
 		JsonComparator.compareJsonStrings(JSON_MONOLINGUAL_TEXT_VALUE, mapper.writeValueAsString(mt1));
 	}
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyDocumentImplTest.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,19 +22,15 @@ package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.junit.Assert.*;
 
-
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.*;
-
 
 public class PropertyDocumentImplTest {
 
@@ -204,7 +200,7 @@ public class PropertyDocumentImplTest {
 		assertEquals(1235L, pd1.withRevisionId(1235L).getRevisionId());
 		assertEquals(pd1, pd1.withRevisionId(1325L).withRevisionId(pd1.getRevisionId()));
 	}
-	
+
 	@Test
 	public void testWithLabelInNewLanguage() {
 		MonolingualTextValue newLabel = new MonolingualTextValueImpl(
@@ -221,7 +217,7 @@ public class PropertyDocumentImplTest {
 		PropertyDocument withLabel = pd1.withLabel(newLabel);
 		assertEquals("The P42 Property", withLabel.findLabel("en"));
 	}
-	
+
 	@Test
 	public void testWithIdenticalLabel() {
 		MonolingualTextValue newLabel = new MonolingualTextValueImpl(
@@ -229,7 +225,7 @@ public class PropertyDocumentImplTest {
 		PropertyDocument withLabel = pd1.withLabel(newLabel);
 		assertEquals(withLabel, pd1);
 	}
-	
+
 	@Test
 	public void testWithDescriptionInNewLanguage() {
 		MonolingualTextValue newDescription = new MonolingualTextValueImpl(
@@ -240,21 +236,21 @@ public class PropertyDocumentImplTest {
 	}
 
 	@Test
-	public void testPropertyToJson() throws JsonProcessingException {
+	public void testPropertyToJson() {
 		JsonComparator.compareJsonStrings(JSON_PROPERTY, mapper.writeValueAsString(pd1));
 	}
 
 	@Test
-	public void testPropertyToJava() throws IOException {
+	public void testPropertyToJava() {
 		assertEquals(pd1, mapper.readValue(JSON_PROPERTY, PropertyDocumentImpl.class));
 	}
 
 	@Test
-	public void testPropertyToJavaWithUnknownDatatype() throws JsonProcessingException {
+	public void testPropertyToJavaWithUnknownDatatype() {
 		PropertyDocumentImpl pd = mapper.readValue(JSON_PROPERTY_WITH_UNKNOWN_DATATYPE, PropertyDocumentImpl.class);
 		assertEquals("some-unknownDatatype", pd.getJsonDatatype());
 	}
-        
+
         @Test
 	public void testWithOverridenDescription() {
 		MonolingualTextValue newDescription = new MonolingualTextValueImpl(
@@ -262,7 +258,7 @@ public class PropertyDocumentImplTest {
 		PropertyDocument withDescription = pd1.withDescription(newDescription);
 		assertEquals("une meilleure description", withDescription.findDescription("fr"));
 	}
-	
+
 	@Test
 	public void testWithIdenticalDescription() {
 		MonolingualTextValue newDescription = new MonolingualTextValueImpl(
@@ -270,7 +266,7 @@ public class PropertyDocumentImplTest {
 		PropertyDocument withDescription = pd1.withDescription(newDescription);
 		assertEquals(withDescription, pd1);
 	}
-	
+
 	@Test
 	public void testWithAliasInNewLanguage() {
 		MonolingualTextValue newAlias = new MonolingualTextValueImpl(
@@ -287,7 +283,7 @@ public class PropertyDocumentImplTest {
 		PropertyDocument withAlias = pd1.withAliases("en", Collections.singletonList(newAlias));
 		assertEquals(Collections.singletonList(newAlias), withAlias.getAliases().get("en"));
 	}
-	
+
 	@Test
 	public void testAddStatement() {
 		Statement fresh = new StatementImpl("MyFreshId", StatementRank.NORMAL,
@@ -302,12 +298,12 @@ public class PropertyDocumentImplTest {
 				claim.getMainSnak().getPropertyId(),
 				claim.getValue()));
 	}
-	
+
 	@Test
 	public void testDeleteStatements() {
 		Statement toRemove = statementGroups.get(0).getStatements().get(0);
 		PropertyDocument withoutStatement = pd1.withoutStatementIds(Collections.singleton(toRemove.getStatementId()));
 		assertNotEquals(withoutStatement, pd1);
 	}
-	
+
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/PropertyIdValueImplTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,14 +22,11 @@ package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.junit.Assert.*;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
-
-import java.io.IOException;
 
 public class PropertyIdValueImplTest {
 
@@ -89,18 +86,17 @@ public class PropertyIdValueImplTest {
 	}
 
 	@Test
-	public void testToJson() throws JsonProcessingException {
+	public void testToJson() {
 		JsonComparator.compareJsonStrings(JSON_PROPERTY_ID_VALUE, mapper.writeValueAsString(prop1));
 	}
 
 	@Test
-	public void testToJava() throws
-			IOException {
+	public void testToJava() {
 		assertEquals(prop1, mapper.readValue(JSON_PROPERTY_ID_VALUE, ValueImpl.class));
 	}
 
 	@Test
-	public void testToJavaWithoutNumericalID() throws IOException {
+	public void testToJavaWithoutNumericalID() {
 		assertEquals(prop1, mapper.readValue(JSON_PROPERTY_ID_VALUE_WITHOUT_NUMERICAL_ID, ValueImpl.class));
 	}
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/QuantityValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/QuantityValueImplTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,20 +25,18 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 
-import java.io.IOException;
 import java.math.BigDecimal;
 
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.QuantityValue;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
+import tools.jackson.databind.exc.ValueInstantiationException;
+import tools.jackson.databind.json.JsonMapper;
 
 public class QuantityValueImplTest {
 
-	private final ObjectMapper mapper = new ObjectMapper();
+	private final JsonMapper mapper = new JsonMapper();
 
 	private final BigDecimal nv = new BigDecimal(
 			"0.123456789012345678901234567890123456789");
@@ -101,7 +99,7 @@ public class QuantityValueImplTest {
 		assertNotEquals(q1, null);
 		assertNotEquals(q1, this);
 	}
-	
+
 	@Test
 	public void equalityBasedOnRepresentation() {
 		BigDecimal amount1 = new BigDecimal("4.00");
@@ -111,7 +109,7 @@ public class QuantityValueImplTest {
 		QuantityValue quantity2 = new QuantityValueImpl(amount2, null, null, (ItemIdValue)null);
 		assertNotEquals(quantity1, quantity2);
 	}
-	
+
 	@Test
 	public void faithfulJsonSerialization() {
 		BigDecimal amount = new BigDecimal("4.00");
@@ -148,7 +146,7 @@ public class QuantityValueImplTest {
 	@Test
 	@SuppressWarnings("deprecation")
 	public void unitNotEmpty() {
-		assertThrows(IllegalArgumentException.class, () -> new QuantityValueImpl(nv, lb, ub, (String) ""));
+		assertThrows(IllegalArgumentException.class, () -> new QuantityValueImpl(nv, lb, ub, ""));
 	}
 
 	@Test
@@ -162,27 +160,27 @@ public class QuantityValueImplTest {
 	}
 
 	@Test
-	public void testToJson() throws JsonProcessingException {
+	public void testToJson() {
 		JsonComparator.compareJsonStrings(JSON_QUANTITY_VALUE, mapper.writeValueAsString(q1));
 	}
 
 	@Test
-	public void testToJava() throws IOException {
+	public void testToJava() {
 		assertEquals(q1, mapper.readValue(JSON_QUANTITY_VALUE, ValueImpl.class));
 	}
-	
+
 	@Test
-	public void testParseInvalidUnit() throws IOException {
+	public void testParseInvalidUnit() {
 	    assertThrows(ValueInstantiationException.class, () -> mapper.readValue(JSON_INVALID_UNIT, ValueImpl.class));
 	}
 
 	@Test
-	public void testUnboundedToJson() throws JsonProcessingException {
+	public void testUnboundedToJson() {
 		JsonComparator.compareJsonStrings(JSON_UNBOUNDED_QUANTITY_VALUE, mapper.writeValueAsString(q3));
 	}
 
 	@Test
-	public void testUnboundedToJava() throws IOException {
+	public void testUnboundedToJava() {
 		assertEquals(q3, mapper.readValue(JSON_UNBOUNDED_QUANTITY_VALUE, ValueImpl.class));
 	}
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SenseDocumentImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SenseDocumentImplTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
@@ -44,8 +43,7 @@ import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementGroup;
 import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 public class SenseDocumentImplTest {
 
@@ -192,12 +190,12 @@ public class SenseDocumentImplTest {
 
 
 	@Test
-	public void testSenseToJson() throws JsonProcessingException {
+	public void testSenseToJson() {
 		JsonComparator.compareJsonStrings(JSON_SENSE, mapper.writeValueAsString(sd1));
 	}
 
 	@Test
-	public void testSenseToJava() throws IOException {
+	public void testSenseToJava() {
 		assertEquals(sd1, mapper.readValue(JSON_SENSE, SenseDocumentImpl.class));
 	}
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SenseIdValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SenseIdValueImplTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,14 +24,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 
-import java.io.IOException;
-
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 public class SenseIdValueImplTest {
 
@@ -116,17 +113,17 @@ public class SenseIdValueImplTest {
 	}
 
 	@Test
-	public void testToJson() throws JsonProcessingException {
+	public void testToJson() {
 		JsonComparator.compareJsonStrings(JSON_SENSE_ID_VALUE, mapper.writeValueAsString(sense1));
 	}
 
 	@Test
-	public void testToJava() throws IOException {
+	public void testToJava() {
 		assertEquals(sense1, mapper.readValue(JSON_SENSE_ID_VALUE, ValueImpl.class));
 	}
 
 	@Test
-	public void testToJavaWithoutNumericalID() throws IOException {
+	public void testToJavaWithoutNumericalID() {
 		assertEquals(sense1, mapper.readValue(JSON_SENSE_ID_VALUE_WITHOUT_TYPE, ValueImpl.class));
 	}
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SiteLinkImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SiteLinkImplTest.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,13 +22,11 @@ package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.junit.Assert.*;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.ItemIdValue;
@@ -91,12 +89,12 @@ public class SiteLinkImplTest {
 	}
 
 	@Test
-	public void testToJson() throws JsonProcessingException {
+	public void testToJson() {
 		JsonComparator.compareJsonStrings(JSON_SITE_LINK, mapper.writeValueAsString(s1));
 	}
 
 	@Test
-	public void testToJava() throws IOException {
+	public void testToJava() {
 		assertEquals(s1, mapper.readValue(JSON_SITE_LINK, SiteLinkImpl.class));
 	}
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SnakImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/SnakImplTest.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,16 +22,13 @@ package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.junit.Assert.*;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.NoValueSnak;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.SomeValueSnak;
 import org.wikidata.wdtk.datamodel.interfaces.ValueSnak;
-
-import java.io.IOException;
 
 public class SnakImplTest {
 
@@ -57,7 +54,7 @@ public class SnakImplTest {
 	private final String JSON_MONOLINGUAL_TEXT_VALUE_SNAK = "{\"snaktype\":\"value\",\"property\":\"P42\",\"datatype\":\"monolingualtext\",\"datavalue\":{\"value\":{\"language\":\"en\",\"text\":\"foo\"},\"type\":\"monolingualtext\"}}";
 	private final String JSON_SNAK_UNKNOWN_ID = "{\"snaktype\":\"value\",\"property\":\"P42\",\"datatype\":\"wikibase-funkyid\",\"datavalue\":{\"value\":{\"id\":\"FUNKY42\",\"entity-type\":\"funky\"},\"type\":\"wikibase-entityid\"}}";
 	private final String JSON_SNAK_UNKNOWN_DATAVALUE = "{\"snaktype\":\"value\",\"property\":\"P42\",\"datatype\":\"groovy\",\"datavalue\":{\"foo\":\"bar\",\"type\":\"groovyvalue\"}}";
-	
+
 	@Test
 	public void fieldsAreCorrect() {
 		assertEquals(vs1.getPropertyId(), p1);
@@ -117,56 +114,56 @@ public class SnakImplTest {
 	}
 
 	@Test
-	public void testNoValueSnakToJava() throws IOException {
+	public void testNoValueSnakToJava() {
 		assertEquals(nvs1, mapper.readValue(JSON_NOVALUE_SNAK, SnakImpl.class));
 	}
 
 	@Test
-	public void testNoValueSnakToJson() throws JsonProcessingException {
+	public void testNoValueSnakToJson() {
 		JsonComparator.compareJsonStrings(JSON_NOVALUE_SNAK, mapper.writeValueAsString(nvs1));
 	}
 
 	@Test
-	public void testSomeValueSnakToJava() throws IOException {
+	public void testSomeValueSnakToJava() {
 		assertEquals(svs1, mapper.readValue(JSON_SOMEVALUE_SNAK, SnakImpl.class));
 	}
 
 	@Test
-	public void testSomeValueSnakToJson() throws JsonProcessingException {
+	public void testSomeValueSnakToJson() {
 		JsonComparator.compareJsonStrings(JSON_SOMEVALUE_SNAK, mapper.writeValueAsString(svs1));
 
 	}
 
 	@Test
-	public void testValueSnakToJava() throws IOException {
+	public void testValueSnakToJava() {
 		assertEquals(vs1, mapper.readValue(JSON_VALUE_SNAK, SnakImpl.class));
 	}
 
 	@Test
-	public void testValueSnakToJson() throws JsonProcessingException {
+	public void testValueSnakToJson() {
 		JsonComparator.compareJsonStrings(JSON_VALUE_SNAK, mapper.writeValueAsString(vs1));
 	}
 
 	@Test
-	public void testMonolingualTextValueSnakToJava() throws IOException {
+	public void testMonolingualTextValueSnakToJava() {
 		assertEquals(vsmt1, mapper.readValue(JSON_MONOLINGUAL_TEXT_VALUE_SNAK, SnakImpl.class));
 		assertEquals(vsmt2, mapper.readValue(JSON_MONOLINGUAL_TEXT_VALUE_SNAK, SnakImpl.class));
 	}
 
 	@Test
-	public void testMonolingualTextValueSnakToJson() throws JsonProcessingException {
+	public void testMonolingualTextValueSnakToJson() {
 		JsonComparator.compareJsonStrings(JSON_MONOLINGUAL_TEXT_VALUE_SNAK, mapper.writeValueAsString(vsmt1));
 		JsonComparator.compareJsonStrings(JSON_MONOLINGUAL_TEXT_VALUE_SNAK, mapper.writeValueAsString(vsmt2));
 	}
-	
+
 	@Test
-	public void testDeserializeUnknownIdSnak() throws IOException {
+	public void testDeserializeUnknownIdSnak() {
 		// We only require deserialization not to fail here
 		mapper.readValue(JSON_SNAK_UNKNOWN_ID, SnakImpl.class);
 	}
-	
+
 	@Test
-	public void testDeserializeUnknownDatavalueSnak() throws IOException {
+	public void testDeserializeUnknownDatavalueSnak() {
 		// We only require deserialization not to fail here
 		mapper.readValue(JSON_SNAK_UNKNOWN_DATAVALUE, SnakImpl.class);
 	}

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StatementImplTest.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,12 +22,10 @@ package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.junit.Assert.*;
 
-import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.interfaces.*;
@@ -90,7 +88,7 @@ public class StatementImplTest {
 				Collections.emptyList(), Collections.emptyList(), value);
 		assertEquals(statement.getStatementId(), "");
 	}
-	
+
 	@Test
 	public void withId() {
 		Statement statement = new StatementImpl(null, StatementRank.NORMAL, claim.getMainSnak(), claim.getQualifiers(), Collections.emptyList(), claim.getSubject());
@@ -128,22 +126,22 @@ public class StatementImplTest {
 	}
 
 	@Test
-	public void testStatementToJson() throws JsonProcessingException {
+	public void testStatementToJson() {
 		JsonComparator.compareJsonStrings(JSON_STATEMENT, mapper.writeValueAsString(s1));
 	}
 
 	@Test
-	public void testStatementToJava() throws IOException {
+	public void testStatementToJava() {
 		assertEquals(s1, mapper.readValue(JSON_STATEMENT, StatementImpl.PreStatement.class).withSubject(subjet));
 	}
 
 	@Test
-	public void testSmallStatementToJson() throws JsonProcessingException {
+	public void testSmallStatementToJson() {
 		JsonComparator.compareJsonStrings(JSON_SMALL_STATEMENT, mapper.writeValueAsString(smallStatement));
 	}
 
 	@Test
-	public void testSmallStatementToJava() throws IOException {
+	public void testSmallStatementToJava() {
 		assertEquals(smallStatement, mapper.readValue(JSON_SMALL_STATEMENT, StatementImpl.PreStatement.class).withSubject(subjet));
 	}
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StringValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/StringValueImplTest.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,8 +22,8 @@ package org.wikidata.wdtk.datamodel.implementation;
 
 import static org.junit.Assert.*;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.StringValue;
 
@@ -31,7 +31,7 @@ import java.io.IOException;
 
 public class StringValueImplTest {
 
-	private final ObjectMapper mapper = new ObjectMapper();
+	private final JsonMapper mapper = new JsonMapper();
 
 	private final StringValue s1 = new StringValueImpl("some string");
 	private final StringValue s2 = new StringValueImpl("some string");
@@ -64,7 +64,7 @@ public class StringValueImplTest {
 	}
 
 	@Test
-	public void testToJson() throws JsonProcessingException {
+	public void testToJson() {
 		JsonComparator.compareJsonStrings(JSON_STRING_VALUE, mapper.writeValueAsString(s1));
 	}
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TermImplTest.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,19 +20,17 @@ package org.wikidata.wdtk.datamodel.implementation;
  * #L%
  */
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.MonolingualTextValue;
-
-import java.io.IOException;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 public class TermImplTest {
 
-	private final ObjectMapper mapper = new ObjectMapper();
+	private final JsonMapper mapper = new JsonMapper();
 
 	private final MonolingualTextValue mt1 = new TermImpl("en", "some string");
 	private final MonolingualTextValue mt2 = new TermImpl("en", "some string");
@@ -75,12 +73,12 @@ public class TermImplTest {
 	}
 
 	@Test
-	public void testToJava() throws IOException {
+	public void testToJava() {
 		assertEquals(mt1, mapper.readValue(JSON_TERM, TermImpl.class));
 	}
 
 	@Test
-	public void testToJson() throws JsonProcessingException {
+	public void testToJson() {
 		JsonComparator.compareJsonStrings(JSON_TERM, mapper.writeValueAsString(mt1));
 	}
 }

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TimeValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/TimeValueImplTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,17 +23,14 @@ package org.wikidata.wdtk.datamodel.implementation;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
-import java.io.IOException;
-
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.interfaces.TimeValue;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 public class TimeValueImplTest {
 
-	private final ObjectMapper mapper = new ObjectMapper();
+	private final JsonMapper mapper = new JsonMapper();
 
 	private final TimeValue t1 = new TimeValueImpl(2007, (byte) 5, (byte) 12, (byte) 10, (byte) 45,
 			(byte) 0, TimeValue.PREC_SECOND, 0, 1, 60,
@@ -144,12 +141,12 @@ public class TimeValueImplTest {
 	}
 
 	@Test
-	public void testToJson() throws JsonProcessingException {
+	public void testToJson() {
 		JsonComparator.compareJsonStrings(JSON_TIME_VALUE, mapper.writeValueAsString(t1));
 	}
 
 	@Test
-	public void testToJava() throws IOException {
+	public void testToJava() {
 		assertEquals(t1, mapper.readValue(JSON_TIME_VALUE, ValueImpl.class));
 	}
 

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedEntityIdValueTest.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,8 +25,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNull;
 
-import java.io.IOException;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
@@ -35,8 +33,7 @@ import org.wikidata.wdtk.datamodel.interfaces.EntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.UnsupportedEntityIdValue;
 import org.wikidata.wdtk.datamodel.interfaces.Value;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 
 public class UnsupportedEntityIdValueTest {
 	private final ObjectMapper mapper = new DatamodelMapper("http://www.wikidata.org/entity/");
@@ -44,71 +41,71 @@ public class UnsupportedEntityIdValueTest {
 	private final String JSON_UNSUPPORTED_VALUE_1 = "{\"type\":\"wikibase-entityid\",\"value\":{\"entity-type\":\"funky\",\"id\":\"Z343\"}}";
 	private final String JSON_UNSUPPORTED_VALUE_2 = "{\"type\":\"wikibase-entityid\",\"value\":{\"entity-type\":\"shiny\",\"id\":\"R8989\",\"foo\":\"bar\"}}";
 	private final String JSON_UNSUPPORTED_VALUE_NO_TYPE = "{\"type\":\"wikibase-entityid\",\"value\":{\"id\":\"Z343\"}}";
-	
+
 	private UnsupportedEntityIdValue firstValue, secondValue, noType;
-	
+
 	@Before
-	public void deserializeValues() throws IOException {
+	public void deserializeValues() {
 		firstValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_1, UnsupportedEntityIdValueImpl.class);
 		secondValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_2, UnsupportedEntityIdValueImpl.class);
 		noType = mapper.readValue(JSON_UNSUPPORTED_VALUE_NO_TYPE, UnsupportedEntityIdValueImpl.class);
 	}
-	
+
 	@Test
-	public void testEquals() throws IOException {
+	public void testEquals() {
 		Value otherValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_1, ValueImpl.class);
 		assertEquals(firstValue, otherValue);
 		assertNotEquals(secondValue, otherValue);
 		assertNotEquals(firstValue, noType);
 		assertNotEquals(noType, secondValue);
 	}
-	
+
 	@Test
-	public void testHash() throws IOException {
+	public void testHash() {
 		Value otherValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_2, ValueImpl.class);
 		assertEquals(secondValue.hashCode(), otherValue.hashCode());
 	}
-	
+
 	@Test
-	public void testSerialize() throws JsonProcessingException {
+	public void testSerialize() {
 		JsonComparator.compareJsonStrings(JSON_UNSUPPORTED_VALUE_1, mapper.writeValueAsString(firstValue));
 		JsonComparator.compareJsonStrings(JSON_UNSUPPORTED_VALUE_2, mapper.writeValueAsString(secondValue));
 		JsonComparator.compareJsonStrings(JSON_UNSUPPORTED_VALUE_NO_TYPE, mapper.writeValueAsString(noType));
 	}
-	
+
 	@Test
 	public void testToString() {
 		assertEquals(ToString.toString(firstValue), firstValue.toString());
 		assertEquals(ToString.toString(secondValue), secondValue.toString());
 	}
-	
+
 	@Test
 	public void testGetTypeString() {
 		assertEquals("funky", firstValue.getEntityTypeJsonString());
 		assertEquals("shiny", secondValue.getEntityTypeJsonString());
 	}
-	
+
 	@Test
 	public void testGetIri() {
 		assertEquals("http://www.wikidata.org/entity/Z343", firstValue.getIri());
 		assertEquals("http://www.wikidata.org/entity/R8989", secondValue.getIri());
 		assertEquals("http://www.wikidata.org/entity/Z343", noType.getIri());
 	}
-	
+
 	@Test
 	public void testGetId() {
 		assertEquals("Z343", firstValue.getId());
 		assertEquals("R8989", secondValue.getId());
 		assertEquals("Z343", noType.getId());
 	}
-	
+
 	@Test
 	public void testGetEntityType() {
 		assertEquals("http://www.wikidata.org/ontology#Funky", firstValue.getEntityType());
 		assertEquals("http://www.wikidata.org/ontology#Shiny", secondValue.getEntityType());
 		assertEquals(EntityIdValue.ET_UNSUPPORTED, noType.getEntityType());
 	}
-	
+
 	@Test
 	public void testGetEntityTypeString() {
 		assertEquals("funky", firstValue.getEntityTypeJsonString());

--- a/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedValueImplTest.java
+++ b/wdtk-datamodel/src/test/java/org/wikidata/wdtk/datamodel/implementation/UnsupportedValueImplTest.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.datamodel.implementation;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,53 +25,51 @@ import org.wikidata.wdtk.datamodel.interfaces.UnsupportedValue;
 import org.wikidata.wdtk.datamodel.interfaces.Value;
 
 import static org.junit.Assert.*;
-import java.io.IOException;
 
 import org.junit.Before;
 import org.junit.Test;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 public class UnsupportedValueImplTest {
-	private final ObjectMapper mapper = new ObjectMapper();
+	private final JsonMapper mapper = new JsonMapper();
 
 	private final String JSON_UNSUPPORTED_VALUE_1 = "{\"type\":\"funky\",\"value\":\"groovy\"}";
 	private final String JSON_UNSUPPORTED_VALUE_2 = "{\"type\":\"shiny\",\"number\":42}";
-	
+
 	private UnsupportedValue firstValue, secondValue;
-	
+
 	@Before
-	public void deserializeFirstValue() throws IOException {
+	public void deserializeFirstValue() {
 		firstValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_1, UnsupportedValueImpl.class);
 		secondValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_2, UnsupportedValueImpl.class);
 	}
-	
+
 	@Test
-	public void testEquals() throws IOException {
+	public void testEquals() {
 		Value otherValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_1, ValueImpl.class);
 		assertEquals(firstValue, otherValue);
 		assertNotEquals(secondValue, otherValue);
 	}
-	
+
 	@Test
-	public void testHash() throws IOException {
+	public void testHash() {
 		Value otherValue = mapper.readValue(JSON_UNSUPPORTED_VALUE_2, ValueImpl.class);
 		assertEquals(secondValue.hashCode(), otherValue.hashCode());
 	}
-	
+
 	@Test
-	public void testSerialize() throws JsonProcessingException {
+	public void testSerialize() {
 		JsonComparator.compareJsonStrings(JSON_UNSUPPORTED_VALUE_1, mapper.writeValueAsString(firstValue));
 		JsonComparator.compareJsonStrings(JSON_UNSUPPORTED_VALUE_2, mapper.writeValueAsString(secondValue));
 	}
-	
+
 	@Test
 	public void testToString() {
 		assertEquals(ToString.toString(firstValue), firstValue.toString());
 		assertEquals(ToString.toString(secondValue), secondValue.toString());
 	}
-	
+
 	@Test
 	public void testGetTypeString() {
 		assertEquals("funky", firstValue.getTypeJsonString());

--- a/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/EntityTimerProcessor.java
+++ b/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/EntityTimerProcessor.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.dumpfiles;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,7 +25,6 @@ import org.slf4j.LoggerFactory;
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocumentDumpProcessor;
 import org.wikidata.wdtk.datamodel.interfaces.EntityDocumentProcessor;
 import org.wikidata.wdtk.datamodel.interfaces.ItemDocument;
-import org.wikidata.wdtk.datamodel.interfaces.LexemeDocument;
 import org.wikidata.wdtk.datamodel.interfaces.PropertyDocument;
 import org.wikidata.wdtk.util.Timer;
 

--- a/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/JsonDumpFileProcessor.java
+++ b/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/JsonDumpFileProcessor.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.dumpfiles;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,17 +25,15 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.wikidata.wdtk.datamodel.helpers.DatamodelMapper;
 import org.wikidata.wdtk.datamodel.implementation.EntityDocumentImpl;
 import org.wikidata.wdtk.datamodel.interfaces.*;
 
-import com.fasterxml.jackson.core.JsonParser.Feature;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.MappingIterator;
-import com.fasterxml.jackson.databind.ObjectReader;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.MappingIterator;
+import tools.jackson.databind.ObjectReader;
 
 /**
  * Processor for JSON dumpfiles.
@@ -55,9 +53,7 @@ public class JsonDumpFileProcessor implements MwDumpFileProcessor {
 	public JsonDumpFileProcessor(
 			EntityDocumentProcessor entityDocumentProcessor, String siteIri) {
 		this.entityDocumentProcessor = entityDocumentProcessor;
-		this.documentReader = new DatamodelMapper(siteIri)
-				.readerFor(EntityDocumentImpl.class)
-				.with(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT);
+		this.documentReader = new DatamodelMapper(siteIri).readerFor(EntityDocumentImpl.class);
 	}
 
 	/**
@@ -87,8 +83,8 @@ public class JsonDumpFileProcessor implements MwDumpFileProcessor {
 					handleDocument(document);
 				}
 				documentIterator.close();
-			} catch (JsonProcessingException e) {
-				logJsonProcessingException(e);
+			} catch (JacksonException e) {
+				logJacksonException(e);
 				processDumpFileContentsRecovery(inputStream);
 			}*/
 		} catch (IOException e) {
@@ -105,7 +101,7 @@ public class JsonDumpFileProcessor implements MwDumpFileProcessor {
 	 * @param exception
 	 *            the exception to log
 	 */
-	private void logJsonProcessingException(JsonProcessingException exception) {
+	private void logJacksonException(JacksonException exception) {
 		JsonDumpFileProcessor.logger
 				.error("Error when reading JSON for entity: "
 						+ exception.getMessage());
@@ -178,8 +174,8 @@ public class JsonDumpFileProcessor implements MwDumpFileProcessor {
 					document = documentReader.readValue(line);
 				}
 				handleDocument(document);
-			} catch (JsonProcessingException e) {
-				logJsonProcessingException(e);
+			} catch (JacksonException e) {
+				logJacksonException(e);
 				JsonDumpFileProcessor.logger.error("Problematic line was: "
 						+ line.substring(0, Math.min(50, line.length()))
 						+ "...");

--- a/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/WikibaseRevisionProcessor.java
+++ b/wdtk-dumpfiles/src/main/java/org/wikidata/wdtk/dumpfiles/WikibaseRevisionProcessor.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.dumpfiles;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,7 +20,6 @@ package org.wikidata.wdtk.dumpfiles;
  * #L%
  */
 
-import java.io.IOException;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -28,8 +27,8 @@ import org.slf4j.LoggerFactory;
 import org.wikidata.wdtk.datamodel.helpers.JsonDeserializer;
 import org.wikidata.wdtk.datamodel.interfaces.*;
 
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.databind.JsonMappingException;
+import tools.jackson.core.exc.StreamReadException;
+import tools.jackson.databind.DatabindException;
 
 /**
  * A revision processor that processes Wikibase entity content from a dump file.
@@ -97,16 +96,14 @@ public class WikibaseRevisionProcessor implements MwRevisionProcessor {
 		try {
 			ItemDocument document = jsonDeserializer.deserializeItemDocument(mwRevision.getText());
 			entityDocumentProcessor.processItemDocument(document);
-		} catch (JsonParseException e1) {
+		} catch (StreamReadException e1) {
 			logger.error("Failed to parse JSON for item "
 					+ mwRevision.getPrefixedTitle() + ": " + e1.getMessage());
-		} catch (JsonMappingException e1) {
+		} catch (DatabindException e1) {
 			logger.error("Failed to map JSON for item "
 					+ mwRevision.getPrefixedTitle() + ": " + e1.getMessage());
 			e1.printStackTrace();
 			System.out.print(mwRevision.getText());
-		} catch (IOException e1) {
-			logger.error("Failed to read revision: " + e1.getMessage());
 		}
 	}
 
@@ -119,16 +116,14 @@ public class WikibaseRevisionProcessor implements MwRevisionProcessor {
 		try {
 			PropertyDocument document = jsonDeserializer.deserializePropertyDocument(mwRevision.getText());
 			entityDocumentProcessor.processPropertyDocument(document);
-		} catch (JsonParseException e1) {
+		} catch (StreamReadException e1) {
 			logger.error("Failed to parse JSON for property "
 					+ mwRevision.getPrefixedTitle() + ": " + e1.getMessage());
-		} catch (JsonMappingException e1) {
+		} catch (DatabindException e1) {
 			logger.error("Failed to map JSON for property "
 					+ mwRevision.getPrefixedTitle() + ": " + e1.getMessage());
 			e1.printStackTrace();
 			System.out.print(mwRevision.getText());
-		} catch (IOException e1) {
-			logger.error("Failed to read revision: " + e1.getMessage());
 		}
 	}
 
@@ -141,16 +136,14 @@ public class WikibaseRevisionProcessor implements MwRevisionProcessor {
 		try {
 			LexemeDocument document = jsonDeserializer.deserializeLexemeDocument(mwRevision.getText());
 			entityDocumentProcessor.processLexemeDocument(document);
-		} catch (JsonParseException e1) {
+		} catch (StreamReadException e1) {
 			logger.error("Failed to parse JSON for lexeme "
 					+ mwRevision.getPrefixedTitle() + ": " + e1.getMessage());
-		} catch (JsonMappingException e1) {
+		} catch (DatabindException e1) {
 			logger.error("Failed to map JSON for lexeme "
 					+ mwRevision.getPrefixedTitle() + ": " + e1.getMessage());
 			e1.printStackTrace();
 			System.out.print(mwRevision.getText());
-		} catch (IOException e1) {
-			logger.error("Failed to read revision: " + e1.getMessage());
 		}
 	}
 
@@ -158,16 +151,14 @@ public class WikibaseRevisionProcessor implements MwRevisionProcessor {
 		try {
 			EntityRedirectDocument document = jsonDeserializer.deserializeEntityRedirectDocument(mwRevision.getText());
 			entityDocumentProcessor.processEntityRedirectDocument(document);
-		} catch (JsonParseException e1) {
+		} catch (StreamReadException e1) {
 			logger.error("Failed to parse JSON for redirect "
 					+ mwRevision.getPrefixedTitle() + ": " + e1.getMessage());
-		} catch (JsonMappingException e1) {
+		} catch (DatabindException e1) {
 			logger.error("Failed to map JSON for redirect "
 					+ mwRevision.getPrefixedTitle() + ": " + e1.getMessage());
 			e1.printStackTrace();
 			System.out.print(mwRevision.getText());
-		} catch (IOException e1) {
-			logger.error("Failed to read revision: " + e1.getMessage());
 		}
 	}
 

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/AbstractRdfConverter.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/AbstractRdfConverter.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.rdf;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -31,7 +31,6 @@ import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.rio.RDFHandlerException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wikidata.wdtk.datamodel.implementation.DatatypeIdImpl;
 import org.wikidata.wdtk.datamodel.interfaces.*;
 import org.wikidata.wdtk.rdf.values.AnyValueConverter;
 
@@ -404,7 +403,7 @@ abstract public class AbstractRdfConverter {
 			return languageCode;
 		}
 	}
-	
+
 	public static Value getMonolingualTextValueLiteral(
 			MonolingualTextValue value, RdfWriter rdfWriter) {
 		String languageCode;

--- a/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/PropertyRegister.java
+++ b/wdtk-rdf/src/main/java/org/wikidata/wdtk/rdf/PropertyRegister.java
@@ -11,9 +11,9 @@ import java.io.IOException;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,8 +29,9 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.Map.Entry;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
+
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.ValueFactory;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
@@ -415,7 +416,7 @@ public class PropertyRegister {
 			connection.setRequestMethod("GET");
 			connection.setRequestProperty("User-Agent", "Wikidata-Toolkit PropertyRegister");
 
-			final ObjectMapper mapper = new ObjectMapper();
+			final JsonMapper mapper = new JsonMapper();
 			JsonNode root = mapper.readTree(connection.getInputStream());
 			JsonNode bindings = root.path("results").path("bindings");
 

--- a/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/AbstractRdfConverterTest.java
+++ b/wdtk-rdf/src/test/java/org/wikidata/wdtk/rdf/AbstractRdfConverterTest.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.rdf;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,7 +23,6 @@ package org.wikidata.wdtk.rdf;
 import org.junit.Test;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.implementation.DatatypeIdImpl;
-import org.wikidata.wdtk.datamodel.interfaces.DatatypeIdValue;
 
 import static org.junit.Assert.assertEquals;
 
@@ -111,7 +110,7 @@ public class AbstractRdfConverterTest {
                 AbstractRdfConverter.getDatatypeIri(Datamodel.makeDatatypeIdValueFromJsonString(DatatypeIdImpl.JSON_DT_MONOLINGUAL_TEXT)),
                 Vocabulary.DT_MONOLINGUAL_TEXT);
     }
-    
+
     @Test
     public void testIriForEdtf() {
         assertEquals(

--- a/wdtk-util/src/test/java/org/wikidata/wdtk/util/DirectoryManagerTest.java
+++ b/wdtk-util/src/test/java/org/wikidata/wdtk/util/DirectoryManagerTest.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.util;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -108,8 +108,9 @@ public class DirectoryManagerTest {
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
 		InputStream cin = dm.getCompressorInputStream(in, CompressionType.GZIP);
 
-		assertEquals("Test data",
-				new BufferedReader(new InputStreamReader(cin)).readLine());
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(cin))) {
+			assertEquals("Test data", reader.readLine());
+		}
 	}
 
 	@Test
@@ -123,7 +124,8 @@ public class DirectoryManagerTest {
 		ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
 		InputStream cin = dm.getCompressorInputStream(in, CompressionType.BZ2);
 
-		assertEquals("Test data",
-				new BufferedReader(new InputStreamReader(cin)).readLine());
+		try (BufferedReader reader = new BufferedReader(new InputStreamReader(cin))) {
+			assertEquals("Test data", reader.readLine());
+		}
 	}
 }

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnection.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/BasicApiConnection.java
@@ -32,7 +32,7 @@ import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import org.wikidata.wdtk.wikibaseapi.apierrors.TokenErrorException;
 
 import static org.wikidata.wdtk.wikibaseapi.LoginValue.*;
@@ -155,7 +155,7 @@ public class BasicApiConnection extends ApiConnection {
 			throws LoginFailedException {
 		login(username, password, this::confirmLogin);
 	}
-	
+
 	/**
 	 * Logs in using the main user credentials. After successful login, the
 	 * API connection remains in a logged in state, and future actions will be
@@ -172,7 +172,7 @@ public class BasicApiConnection extends ApiConnection {
 
 	/***
 	 * Login function that contains token logic and a function as parameter
-	 * 
+	 *
 	 * @param username the name of the user to log in
 	 * @param password the password of the user
 	 * @param loginFunction the functional interface to log in with
@@ -219,7 +219,7 @@ public class BasicApiConnection extends ApiConnection {
 
 		JsonNode root = sendJsonRequest("POST", params);
 
-		String result = root.path("login").path("result").textValue();
+		String result = root.path("login").path("result").stringValue();
 		if (LOGIN_RESULT_SUCCESS.getLoginText().equals(result)) {
 			this.loggedIn = true;
 			this.username = username;
@@ -227,8 +227,8 @@ public class BasicApiConnection extends ApiConnection {
 		} else {
 			String message = null;
 			if (FAILED.getLoginText().equals(result)) {
-				message = root.path("login").path("reason").textValue();
-			} 
+				message = root.path("login").path("reason").stringValue();
+			}
 			if (message == null) { // Not 'FAILED' or no 'reason' node
 				message = LoginValue.of(result).getMessage(result);
 			}
@@ -266,7 +266,7 @@ public class BasicApiConnection extends ApiConnection {
 
 		JsonNode root = sendJsonRequest("POST", params);
 
-		String result = root.path("clientlogin").path("status").textValue();
+		String result = root.path("clientlogin").path("status").stringValue();
 		if ("PASS".equals(result)) {
 			this.loggedIn = true;
 			this.username = username;
@@ -274,9 +274,9 @@ public class BasicApiConnection extends ApiConnection {
 		} else {
 			String messagecode;
 			if ("FAIL".equals(result)) {
-				messagecode = root.path("clientlogin").path("messagecode").textValue();
+				messagecode = root.path("clientlogin").path("messagecode").stringValue();
 			} else {
-				messagecode = root.path("error").path("code").textValue();
+				messagecode = root.path("error").path("code").stringValue();
 			}
 			String message = LoginValue.of(messagecode).getMessage(messagecode);
 			logger.warn(message);
@@ -311,6 +311,7 @@ public class BasicApiConnection extends ApiConnection {
 	 *
 	 * @throws IOException
 	 */
+	@Override
 	public void logout() throws IOException, MediaWikiApiErrorException {
 		if (this.loggedIn) {
 			Map<String, String> params = new HashMap<>();

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/MalformedResponseException.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/MalformedResponseException.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.wikibaseapi;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,19 +20,19 @@ package org.wikidata.wdtk.wikibaseapi;
  * #L%
  */
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import tools.jackson.core.JacksonException;
 
 /**
  * Exception thrown when response from Wikibase API cannot be parsed.
- * This exception may be thrown in addition to other {@link JsonProcessingException} exceptions.
+ * This exception may be thrown in addition to other {@link JacksonException} exceptions.
  */
-public class MalformedResponseException extends JsonProcessingException {
+public class MalformedResponseException extends JacksonException {
 	private static final long serialVersionUID = -4697019897395095678L;
 
 	/**
 	 * Constructs {@code MalformedResponseException} with the specified detail
 	 * message.
-	 * 
+	 *
 	 * @param message the detail message, which can be later retrieved via
 	 *                {@link #getMessage()}
 	 */
@@ -43,7 +43,7 @@ public class MalformedResponseException extends JsonProcessingException {
 	/**
 	 * Constructs {@code MalformedResponseException} with the specified detail
 	 * message and cause.
-	 * 
+	 *
 	 * @param message the detail message, which can be later retrieved via
 	 *                {@link #getMessage()}
 	 * @param cause   the cause, which can be later retrieved via

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/MediaInfoIdQueryAction.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/MediaInfoIdQueryAction.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.wikibaseapi;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,14 +20,15 @@ package org.wikidata.wdtk.wikibaseapi;
  * #L%
  */
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ArrayNode;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.node.ArrayNode;
 import org.wikidata.wdtk.datamodel.helpers.Datamodel;
 import org.wikidata.wdtk.datamodel.interfaces.MediaInfoIdValue;
 import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
 
 import java.io.IOException;
 import java.util.*;
+import java.util.Map.Entry;
 
 /**
  * Action for MediaInfoId retrieval.
@@ -83,11 +84,9 @@ public class MediaInfoIdQueryAction {
 		Map<String, String> normalizedMap = new HashMap<>();
 		if (query.has("normalized")) {
 			ArrayNode normalized = (ArrayNode) query.get("normalized");
-			Iterator<JsonNode> iterator = normalized.elements();
-			while (iterator.hasNext()) {
-				JsonNode next = iterator.next();
-				String from = next.get("from").asText();
-				String to = next.get("to").asText();
+			for (JsonNode elem : normalized.elements()) {
+				String from = elem.get("from").asString();
+				String to = elem.get("to").asString();
 				normalizedMap.put(from, to);
 			}
 		}
@@ -95,11 +94,9 @@ public class MediaInfoIdQueryAction {
 		// normalized file name => Mid
 		Map<String, MediaInfoIdValue> midMap = new HashMap<>();
 		JsonNode pages = query.get("pages");
-		Iterator<Map.Entry<String, JsonNode>> iterator = pages.fields();
-		while (iterator.hasNext()) {
-			Map.Entry<String, JsonNode> page = iterator.next();
+		for (Entry<String, JsonNode> page : pages.properties()) {
 			String pageId = page.getKey();
-			String title = page.getValue().get("title").textValue();
+			String title = page.getValue().get("title").stringValue();
 			if (!pageId.startsWith("-")) { // negative keys such as "-1", "-2", ... mean not found
 				midMap.put(title, Datamodel.makeMediaInfoIdValue("M" + pageId, siteIri));
 			}

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/OAuthApiConnection.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/OAuthApiConnection.java
@@ -22,7 +22,7 @@ package org.wikidata.wdtk.wikibaseapi;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 import okhttp3.OkHttpClient;
 import org.wikidata.wdtk.wikibaseapi.apierrors.AssertUserFailedException;
 import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
@@ -177,7 +177,7 @@ public class OAuthApiConnection extends ApiConnection {
             if (nameNode.isMissingNode()) {
                 throw new AssertUserFailedException("The path \"query/userinfo/name\" doesn't exist in the json response");
             }
-            username = nameNode.textValue();
+            username = nameNode.stringValue();
         } catch (IOException | MediaWikiApiErrorException e) {
             logger.warn("An error occurred when retrieving the username with OAuth credentials, the username is set to \"\" automatically: " + e.getMessage());
             username = "";

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdate.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/TermStatementUpdate.java
@@ -42,7 +42,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 /**
  * @deprecated Use {@link WikibaseDataEditor#editEntityDocument(EntityUpdate, boolean, String, List)} instead.

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbEditingAction.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbEditingAction.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -35,9 +35,8 @@ import org.wikidata.wdtk.wikibaseapi.apierrors.MaxlagErrorException;
 import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
 import org.wikidata.wdtk.wikibaseapi.apierrors.TokenErrorException;
 
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Java implementation for the wbeditentity API action.
@@ -60,11 +59,11 @@ public class WbEditingAction {
      * The IRI that identifies the site that the data is from.
      */
 	final String siteIri;
-	
+
 	/**
 	 * Mapper object used for deserializing JSON data.
 	 */
-	final ObjectMapper mapper;
+	final JsonMapper mapper;
 
 	/**
 	 * Value in seconds of MediaWiki's maxlag parameter. Shorter is nicer,
@@ -81,7 +80,7 @@ public class WbEditingAction {
 	/**
 	 * Initial wait time in milliseconds, when an edit fails for the first
 	 * time because of a high lag. This wait time is going to be multiplied
-	 * by maxLagBackOffFactor for the subsequent waits. 
+	 * by maxLagBackOffFactor for the subsequent waits.
 	 */
 	int maxLagFirstWaitTime = 1000;
 
@@ -90,7 +89,7 @@ public class WbEditingAction {
 	 * multiplied at each attempt.
 	 */
 	double maxLagBackOffFactor = 1.5;
-	
+
 	/**
 	 * Number of recent editing times to monitor in order to avoid editing too
 	 * fast. Wikidata.org seems to block fast editors after 9 edits, so this
@@ -163,7 +162,7 @@ public class WbEditingAction {
 	public void setMaxLag(int maxLag) {
 		this.maxLag = maxLag;
 	}
-	
+
 	/**
 	 * Returns the number of edits that will be performed before entering
 	 * simulation mode, or -1 if there is no limit on the number of edits
@@ -304,12 +303,12 @@ public class WbEditingAction {
 		if (clear) {
 			parameters.put("clear", "");
 		}
-		
+
 		JsonNode response = performAPIAction("wbeditentity", id, site, title,
 				newEntity, parameters, summary, tags, baserevid, bot);
 		return getEntityDocumentFromResponse(response);
 	}
-	
+
 	/**
 	 * Executes the API action "wbsetlabel" for the given parameters.
 	 * @param id
@@ -364,7 +363,7 @@ public class WbEditingAction {
 					throws IOException, MediaWikiApiErrorException {
 		Validate.notNull(language,
 				"Language parameter cannot be null when setting a label");
-		
+
 		Map<String, String> parameters = new HashMap<>();
 		parameters.put("language", language);
 		if (value != null) {
@@ -374,7 +373,7 @@ public class WbEditingAction {
 		return performAPIAction("wbsetlabel", id, site, title, newEntity,
 				parameters, summary, tags, baserevid, bot);
 	}
-	
+
 	/**
 	 * Executes the API action "wbsetlabel" for the given parameters.
 	 * @param id
@@ -430,7 +429,7 @@ public class WbEditingAction {
 					throws IOException, MediaWikiApiErrorException {
 		Validate.notNull(language,
 				"Language parameter cannot be null when setting a description");
-		
+
 		Map<String, String> parameters = new HashMap<>();
 		parameters.put("language", language);
 		if (value != null) {
@@ -440,10 +439,10 @@ public class WbEditingAction {
 		return performAPIAction("wbsetdescription", id, site, title,
 				newEntity, parameters, summary, tags, baserevid, bot);
 	}
-	
+
 	/**
 	 * Executes the API action "wbsetaliases" for the given parameters.
-	 * 
+	 *
 	 * @param id
 	 *            the id of the entity to be edited; if used, the site and title
 	 *            parameters must be null
@@ -506,7 +505,7 @@ public class WbEditingAction {
 					throws IOException, MediaWikiApiErrorException {
 		Validate.notNull(language,
 				"Language parameter cannot be null when setting aliases");
-		
+
 		Map<String, String> parameters = new HashMap<>();
 		parameters.put("language", language);
 		if (set != null) {
@@ -525,10 +524,10 @@ public class WbEditingAction {
 
 		return performAPIAction("wbsetaliases", id, site, title, newEntity, parameters, summary, tags, baserevid, bot);
 	}
-	
+
 	/**
 	 * Executes the API action "wbsetclaim" for the given parameters.
-	 * 
+	 *
 	 * @param statement
 	 *            the JSON serialization of claim to add or delete.
      * @param bot
@@ -563,17 +562,17 @@ public class WbEditingAction {
 					throws IOException, MediaWikiApiErrorException {
 		Validate.notNull(statement,
 				"Statement parameter cannot be null when adding or changing a statement");
-		
-		
+
+
 		Map<String, String> parameters = new HashMap<>();
 		parameters.put("claim", statement);
-		
+
 		return performAPIAction("wbsetclaim", null, null, null, null, parameters, summary, tags, baserevid, bot);
 	}
-	
+
 	/**
 	 * Executes the API action "wbremoveclaims" for the given parameters.
-	 * 
+	 *
 	 * @param statementIds
 	 *            the statement ids to delete
 	 * @param bot
@@ -612,13 +611,13 @@ public class WbEditingAction {
 				"statement ids to delete must be non-empty when deleting statements");
 		Validate.isTrue(statementIds.size() <= 50,
 				"At most 50 statements can be deleted at once");
-		
+
 		Map<String, String> parameters = new HashMap<>();
 		parameters.put("claim", String.join("|", statementIds));
-		
+
 		return performAPIAction("wbremoveclaims", null, null, null, null, parameters, summary, tags, baserevid, bot);
 	}
-	
+
 	/**
 	 * Executes an editing API action for the given parameters. The resulting
 	 * entity returned by Wikibase is returned as a result.
@@ -682,9 +681,9 @@ public class WbEditingAction {
 			long baserevid,
 			boolean bot)
 			throws IOException, MediaWikiApiErrorException {
-		
+
 		parameters.put(ApiConnection.PARAM_ACTION, action);
-		
+
 		if (newEntity != null) {
 			parameters.put("new", newEntity);
 			if (title != null || site != null || id != null) {
@@ -708,19 +707,19 @@ public class WbEditingAction {
 			throw new IllegalArgumentException(
 					"This action must create a new item, or specify an id, or specify a site and title.");
 		}
-		
+
 		if (bot) {
 			parameters.put("bot", "");
 		}
-		
+
 		if (baserevid != 0) {
 			parameters.put("baserevid", Long.toString(baserevid));
 		}
-		
+
 		if (summary != null) {
 			parameters.put("summary", summary);
 		}
-		
+
 		if (tags != null && !tags.isEmpty()) {
 			parameters.put("tags", String.join("|", tags));
 		}
@@ -738,7 +737,7 @@ public class WbEditingAction {
 
 		checkEditSpeed();
 		JsonNode result = null;
-		
+
 		int retry = getMaxLagMaxRetries();
 		int maxLagSleepTime = getMaxLagFirstWaitTime();
 		MediaWikiApiErrorException lastException = null;
@@ -771,7 +770,7 @@ public class WbEditingAction {
 
 		return result;
 	}
-	
+
 	/**
 	 * TODO: TO BE REFACTORED
 	 * @param root
@@ -796,7 +795,7 @@ public class WbEditingAction {
 					"No entity document found in API response.");
 		}
 	}
-	
+
 	/**
 	 * Parse a JSON response to extract an entity document.
 	 * <p>
@@ -810,9 +809,7 @@ public class WbEditingAction {
 	 * @throws IOException
 	 */
 	private EntityDocument parseJsonResponse(JsonNode entityNode) throws IOException {
-		return mapper.readerFor(EntityDocumentImpl.class)
-				.with(DeserializationFeature.ACCEPT_EMPTY_ARRAY_AS_NULL_OBJECT)
-				.readValue(entityNode);
+		return mapper.readerFor(EntityDocumentImpl.class).readValue(entityNode);
 	}
 
 	/**
@@ -843,7 +840,7 @@ public class WbEditingAction {
 		this.recentEditTimes[nextIndex] = currentTime;
 		this.curEditTimeSlot = nextIndex;
 	}
-	
+
 	/**
 	 * Number of times we should retry if an editing action fails because
 	 * the lag is too high.
@@ -863,7 +860,7 @@ public class WbEditingAction {
 	/**
 	 * Initial wait time in milliseconds, when an edit fails for the first
 	 * time because of a high lag. This wait time is going to be multiplied
-	 * by maxLagBackOffFactor for the subsequent waits. 
+	 * by maxLagBackOffFactor for the subsequent waits.
 	 */
 	public int getMaxLagFirstWaitTime() {
 		return maxLagFirstWaitTime;
@@ -872,7 +869,7 @@ public class WbEditingAction {
 	/**
 	 * Initial wait time in milliseconds, when an edit fails for the first
 	 * time because of a high lag. This wait time is going to be multiplied
-	 * by maxLagBackOffFactor for the subsequent waits. 
+	 * by maxLagBackOffFactor for the subsequent waits.
 	 */
 	public void setMaxLagFirstWaitTime(int time) {
 		maxLagFirstWaitTime = time;
@@ -896,13 +893,13 @@ public class WbEditingAction {
 
 	/**
 	 * Retrieves the current lag from the target site, by making an API call.
-	 * 
+	 *
 	 * @throws MediaWikiApiErrorException
 	 * 		when an unexpected MediaWiki API error happened (not the spurious
 	 *      one normally returned by MediaWiki when retrieving lag).
 	 * @throws IOException
 	 *      when communication with the server failed.
-	 *      
+	 *
 	 */
 	public double getCurrentLag() throws IOException, MediaWikiApiErrorException {
 		Map<String,String> parameters = new HashMap<>();

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesAction.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WbSearchEntitiesAction.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -28,9 +28,9 @@ import java.util.Map;
 
 import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * Java implementation of the wbsearchentities action.
@@ -48,7 +48,7 @@ public class WbSearchEntitiesAction {
 	/**
 	 * Mapper object used for deserializing JSON data.
 	 */
-	private final ObjectMapper mapper = new ObjectMapper();
+	private final JsonMapper mapper = new JsonMapper();
 
 	/**
 	 * Creates an object to fetch data from the given ApiConnection. The site
@@ -73,7 +73,7 @@ public class WbSearchEntitiesAction {
 	}
 
 	/**
-	 * Keeping this for backwards compatibility, the real action happens in 
+	 * Keeping this for backwards compatibility, the real action happens in
 	 * {@link WbSearchEntitiesAction#wbSearchEntities(String, String, Boolean, String, Long, Long, String)}
 	 */
 	public List<WbSearchEntitiesResult> wbSearchEntities(String search, String language,
@@ -113,7 +113,7 @@ public class WbSearchEntitiesAction {
 	 *            (optional) offset where to continue a search
 	 *            Default: 0
 	 *            this parameter is called "continue" in the API (which is a Java keyword)
-	 * @param uselang        
+	 * @param uselang
 	 *            (optional) the response should have this language, default en
 	 * @return list of matching entities retrieved via the API URL
 	 * @throws MediaWikiApiErrorException
@@ -123,7 +123,7 @@ public class WbSearchEntitiesAction {
 	 * @throws MalformedResponseException
 	 *             if response JSON cannot be parsed
 	 */
-	public List<WbSearchEntitiesResult> wbSearchEntities(String search, String language, 
+	public List<WbSearchEntitiesResult> wbSearchEntities(String search, String language,
 			Boolean strictLanguage, String type, Long limit, Long offset, String uselang)
 					throws MediaWikiApiErrorException, IOException {
 
@@ -172,9 +172,9 @@ public class WbSearchEntitiesAction {
 				JacksonWbSearchEntitiesResult ed = mapper.treeToValue(entityNode,
 						JacksonWbSearchEntitiesResult.class);
 				results.add(ed);
-			} catch (JsonProcessingException e) {
+			} catch (JacksonException e) {
 				throw new MalformedResponseException(
-						"Error when reading JSON for entity " + entityNode.path("id").asText("UNKNOWN"), e);
+						"Error when reading JSON for entity " + entityNode.path("id").asString("UNKNOWN"), e);
 			}
 		}
 

--- a/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
+++ b/wdtk-wikibaseapi/src/main/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditor.java
@@ -7,9 +7,9 @@
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -56,8 +56,7 @@ import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocument;
 import org.wikidata.wdtk.datamodel.interfaces.TermedStatementDocumentUpdate;
 import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Class that provides high-level editing functionality for Wikibase data.
@@ -77,7 +76,7 @@ public class WikibaseDataEditor {
 	 * before editing.
 	 */
 	final WikibaseDataFetcher wikibaseDataFetcher;
-	
+
 	/**
 	 * GUID generator, for editing actions that require generating fresh GUIDs
 	 * client-side.
@@ -114,7 +113,7 @@ public class WikibaseDataEditor {
 		this.siteIri = siteUri;
 		this.guidGenerator = new RandomGuidGenerator();
 	}
-	
+
 	/**
 	 * Creates an object to edit data via the Web API of the given
 	 * {@link ApiConnection} object. The site URI is necessary to create data
@@ -190,7 +189,7 @@ public class WikibaseDataEditor {
 	public void setMaxLag(int maxLag) {
 		this.wbEditingAction.setMaxLag(maxLag);
 	}
-	
+
 	/**
 	 * Number of times we should retry if an editing action fails because
 	 * the lag is too high.
@@ -210,7 +209,7 @@ public class WikibaseDataEditor {
 	/**
 	 * Initial wait time in milliseconds, when an edit fails for the first
 	 * time because of a high lag. This wait time is going to be multiplied
-	 * by maxLagBackOffFactor for the subsequent waits. 
+	 * by maxLagBackOffFactor for the subsequent waits.
 	 */
 	public int getMaxLagFirstWaitTime() {
 		return this.wbEditingAction.getMaxLagFirstWaitTime();
@@ -219,7 +218,7 @@ public class WikibaseDataEditor {
 	/**
 	 * Initial wait time in milliseconds, when an edit fails for the first
 	 * time because of a high lag. This wait time is going to be multiplied
-	 * by maxLagBackOffFactor for the subsequent waits. 
+	 * by maxLagBackOffFactor for the subsequent waits.
 	 */
 	public void setMaxLagFirstWaitTime(int time) {
 		this.wbEditingAction.setMaxLagFirstWaitTime(time);
@@ -303,7 +302,7 @@ public class WikibaseDataEditor {
 		return this.wbEditingAction.wbEditEntity(
 				null, null, null, type, data, false, editAsBot, 0, summary, tags);
 	}
-	
+
 	/**
 	 * Creates new entity document. Provided entity document must use a local item ID,
 	 * such as {@link ItemIdValue#NULL}, and its revision ID must be 0.
@@ -831,8 +830,8 @@ public class WikibaseDataEditor {
 		return updateStatements(currentDocument, addStatements,
 				deleteStatements, summary, tags);
 	}
-	
-	
+
+
 	/**
 	 * @deprecated Use {@link #editEntityDocument(EntityUpdate, boolean, String, List)} instead.
 	 * Updates the terms and statements of the item document identified by the
@@ -840,7 +839,7 @@ public class WikibaseDataEditor {
 	 * found online, making sure that no redundant deletions or duplicate insertions
 	 * happen. The references of duplicate statements will be merged. The labels
 	 * and aliases in a given language are kept distinct.
-	 * 
+	 *
 	 * @param itemIdValue
 	 * 			id of the document to be updated
 	 * @param addLabels
@@ -886,7 +885,7 @@ public class WikibaseDataEditor {
 			List<String> tags) throws MediaWikiApiErrorException, IOException {
 		ItemDocument currentDocument = (ItemDocument) this.wikibaseDataFetcher
 				.getEntityDocument(itemIdValue.getId());
-		
+
 		return updateTermsStatements(currentDocument, addLabels,
 				addDescriptions, addAliases, deleteAliases,
 				addStatements, deleteStatements, summary, tags);
@@ -982,7 +981,7 @@ public class WikibaseDataEditor {
 		StatementUpdate statementUpdate = new StatementUpdate(currentDocument,
 				addStatements, deleteStatements);
 		statementUpdate.setGuidGenerator(guidGenerator);
-		
+
 		if (statementUpdate.isEmptyEdit()) {
 			return currentDocument;
 		} else {
@@ -992,7 +991,7 @@ public class WikibaseDataEditor {
 				.getRevisionId(), summary, tags);
 		}
 	}
-	
+
 	/**
 	 * @deprecated Use {@link #editEntityDocument(EntityUpdate, boolean, String, List)} instead.
 	 * Updates the terms and statements of the current document.
@@ -1000,7 +999,7 @@ public class WikibaseDataEditor {
 	 * making sure that no redundant deletions or duplicate insertions
 	 * happen. The references of duplicate statements will be merged. The labels
 	 * and aliases in a given language are kept distinct.
-	 * 
+	 *
      * @param currentDocument
 	 * 			the document to be updated; needs to have a correct revision id and
 	 * 			entity id
@@ -1046,20 +1045,20 @@ public class WikibaseDataEditor {
 			List<Statement> addStatements, List<Statement> deleteStatements,
 			String summary, List<String> tags)
 					throws MediaWikiApiErrorException, IOException {
-		
+
 		TermStatementUpdate termStatementUpdate = new TermStatementUpdate(
 				currentDocument,
 				addStatements, deleteStatements,
 				addLabels, addDescriptions, addAliases, deleteAliases);
 		termStatementUpdate.setGuidGenerator(guidGenerator);
-		
+
 		return  (T) termStatementUpdate.performEdit(wbEditingAction, editAsBot, summary, tags);
 	}
-	
+
 	/**
 	 * Performs a null edit on an entity. This has some effects on Wikibase, such as
 	 * refreshing the labels of the referred items in the UI.
-	 * 
+	 *
 	 * @param entityId
 	 *            the document to perform a null edit on
 	 * @throws MediaWikiApiErrorException
@@ -1075,12 +1074,12 @@ public class WikibaseDataEditor {
 	 * @deprecated Use {@link #nullEdit(EntityIdValue)} instead.
 	 * Performs a null edit on an item. This has some effects on Wikibase,
 	 * such as refreshing the labels of the referred items in the UI.
-	 * 
+	 *
 	 * @param itemId
 	 * 			the document to perform a null edit on
 	 * @throws MediaWikiApiErrorException
 	 * 	        if the API returns errors
-	 * @throws IOException 
+	 * @throws IOException
 	 * 		    if there are any IO errors, such as missing network connection
 	 */
 	@Deprecated
@@ -1088,20 +1087,20 @@ public class WikibaseDataEditor {
 			throws IOException, MediaWikiApiErrorException {
 		ItemDocument currentDocument = (ItemDocument) this.wikibaseDataFetcher
 				.getEntityDocument(itemId.getId());
-		
+
 		nullEdit(currentDocument);
 	}
-	
+
 	/**
 	 * @deprecated Use {@link #nullEdit(EntityIdValue)} instead.
 	 * Performs a null edit on a property. This has some effects on Wikibase,
 	 * such as refreshing the labels of the referred items in the UI.
-	 * 
+	 *
 	 * @param propertyId
 	 * 			the document to perform a null edit on
 	 * @throws MediaWikiApiErrorException
 	 * 	        if the API returns errors
-	 * @throws IOException 
+	 * @throws IOException
 	 * 		    if there are any IO errors, such as missing network connection
 	 */
 	@Deprecated
@@ -1109,14 +1108,14 @@ public class WikibaseDataEditor {
 			throws IOException, MediaWikiApiErrorException {
 		PropertyDocument currentDocument = (PropertyDocument) this.wikibaseDataFetcher
 				.getEntityDocument(propertyId.getId());
-		
+
 		nullEdit(currentDocument);
 	}
-	
+
 	/**
 	 * Performs a null edit on an entity. This has some effects on Wikibase, such as
 	 * refreshing the labels of the referred items in the UI.
-	 * 
+	 *
 	 * @param currentDocument
 	 *            the document to perform a null edit on
 	 * @return new version of the document returned by Wikibase API
@@ -1136,14 +1135,14 @@ public class WikibaseDataEditor {
     /**
      * Extracts the last revision id from the JSON response returned
      * by the API after an edit
-     * 
+     *
      * @param response
      *      the response as returned by Mediawiki
      * @return
      *      the new revision id of the edited entity
-     * @throws JsonProcessingException 
+     * @throws MalformedResponseException
      */
-    protected long getRevisionIdFromResponse(JsonNode response) throws JsonProcessingException {
+    protected long getRevisionIdFromResponse(JsonNode response) {
         if(response == null) {
             throw new MalformedResponseException("API response is null");
         }
@@ -1152,7 +1151,7 @@ public class WikibaseDataEditor {
             entity = response.path("entity");
         } else if(response.has("pageinfo")) {
             entity = response.path("pageinfo");
-        } 
+        }
         if(entity != null && entity.has("lastrevid")) {
             return entity.path("lastrevid").asLong();
         }

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/OAuthApiConnectionTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/OAuthApiConnectionTest.java
@@ -21,7 +21,7 @@ package org.wikidata.wdtk.wikibaseapi;
  */
 
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.ObjectMapper;
 import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/StatementUpdateTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/StatementUpdateTest.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.wikibaseapi;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -42,9 +41,8 @@ import org.wikidata.wdtk.datamodel.interfaces.Reference;
 import org.wikidata.wdtk.datamodel.interfaces.Statement;
 import org.wikidata.wdtk.datamodel.interfaces.StatementRank;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 @Deprecated
 public class StatementUpdateTest {
@@ -217,7 +215,7 @@ public class StatementUpdateTest {
 	}
 
 	@Test
-	public void testAddStatements() throws JsonProcessingException {
+	public void testAddStatements() {
 		// Inserting new P2 statements won't touch existing P1 statement
 		Statement s1 = StatementBuilder.forSubjectAndProperty(Q1, P1)
 				.withValue(Q1).withId("ID-s1").build();
@@ -306,7 +304,7 @@ public class StatementUpdateTest {
 		assertFalse(su.toKeep.get(P1).get(1).write);
 		assertFalse(su.isEmptyEdit());
 	}
-	
+
 	@Test
 	public void testNullEdit() {
 		Statement s1 = StatementBuilder.forSubjectAndProperty(Q1, P1)
@@ -315,14 +313,14 @@ public class StatementUpdateTest {
 				.withValue(Q1).build();
 		Statement s2 = StatementBuilder.forSubjectAndProperty(Q1, P1)
 				.withValue(Q1).withId("ID-s2").build();
-		
+
 		ItemDocument currentDocument = ItemDocumentBuilder.forItemId(Q1)
 				.withStatement(s1).build();
-		
+
 		StatementUpdate su = new StatementUpdate(currentDocument,
 				Collections.singletonList(s1dup), Collections.singletonList(s2));
 		assertTrue(su.isEmptyEdit());
-		
+
 	}
 
 	@Test
@@ -349,7 +347,7 @@ public class StatementUpdateTest {
 	}
 
 	@Test
-	public void testDelete() throws IOException {
+	public void testDelete() {
 		Statement s1 = StatementBuilder.forSubjectAndProperty(Q1, P1)
 				.withValue(Q1).withId("ID-s1").build();
 		Statement s2 = StatementBuilder.forSubjectAndProperty(Q1, P1)
@@ -372,7 +370,7 @@ public class StatementUpdateTest {
 		StatementUpdate su = new StatementUpdate(currentDocument,
 				Collections.emptyList(), Arrays.asList(s2, s3, s4,
 						s5));
-		
+
 		ObjectMapper mapper = new ObjectMapper();
 		JsonNode expectedJson = mapper.readTree("{\"claims\":[{\"id\":\"ID-s2\",\"remove\":\"\"},{\"id\":\"ID-s5\",\"remove\":\"\"}]}");
 		JsonNode actualJson = mapper.readTree(su.getJsonUpdateString());

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditorTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/WikibaseDataEditorTest.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.wikibaseapi;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,7 +25,6 @@ import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
-import static org.wikidata.wdtk.datamodel.helpers.Datamodel.makeStringValue;
 import static org.wikidata.wdtk.datamodel.helpers.Datamodel.makeQuantityValue;
 import static org.wikidata.wdtk.datamodel.helpers.Datamodel.makeWikidataFormIdValue;
 import static org.wikidata.wdtk.datamodel.helpers.Datamodel.makeWikidataItemIdValue;
@@ -79,8 +78,9 @@ import org.wikidata.wdtk.wikibaseapi.apierrors.MediaWikiApiErrorException;
 import org.wikidata.wdtk.wikibaseapi.apierrors.TagsApplyNotAllowedException;
 import org.wikidata.wdtk.wikibaseapi.apierrors.TokenErrorException;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.exc.InvalidTypeIdException;
 
 import static org.junit.Assert.*;
 
@@ -113,7 +113,7 @@ public class WikibaseDataEditorTest {
 		wde.setMaxLag(3);
 		assertEquals(3, wde.getMaxLag());
 	}
-	
+
 	@Test
 	public void testSetMaxLagFirstWaitTime() {
 		WikibaseDataEditor wde = new WikibaseDataEditor(this.con,
@@ -121,7 +121,7 @@ public class WikibaseDataEditorTest {
 		wde.setMaxLagFirstWaitTime(5432);
 		assertEquals(5432, wde.getMaxLagFirstWaitTime());
 	}
-	
+
 	@Test
 	public void testSetMaxLagBackOffFactor() {
 		WikibaseDataEditor wde = new WikibaseDataEditor(this.con,
@@ -129,7 +129,7 @@ public class WikibaseDataEditorTest {
 		wde.setMaxLagBackOffFactor(2.7);
 		assertTrue(2.69 < wde.getMaxLagBackOffFactor() && 2.71 > wde.getMaxLagBackOffFactor());
 	}
-	
+
 	@Test
 	public void testSetMaxLagMaxRetries() {
 		WikibaseDataEditor wde = new WikibaseDataEditor(this.con,
@@ -326,7 +326,7 @@ public class WikibaseDataEditorTest {
 		assertEquals(expectedResultDocument, result);
 	}
 
-	@Test(expected = IOException.class)
+	@Test(expected = InvalidTypeIdException.class)
 	public void testCreateItemBadEntityDocumentJson() throws IOException,
 			MediaWikiApiErrorException {
 		// Test what happens if the API returns JSON without an actual entity
@@ -352,7 +352,7 @@ public class WikibaseDataEditorTest {
 		wde.createItemDocument(itemDocument, "My summary", null);
 	}
 
-	@Test(expected = IOException.class)
+	@Test(expected = MalformedResponseException.class)
 	public void testCreateItemMissingEntityDocumentJson() throws IOException,
 			MediaWikiApiErrorException {
 		WikibaseDataEditor wde = new WikibaseDataEditor(this.con,
@@ -446,7 +446,7 @@ public class WikibaseDataEditorTest {
 
 		assertEquals(expectedResultDocument, result);
 	}
-	
+
 	@Test
 	public void testCreateMediaInfo() {
 		WikibaseDataEditor wde = new WikibaseDataEditor(this.con,
@@ -454,7 +454,7 @@ public class WikibaseDataEditorTest {
 
 		MediaInfoDocument mediaInfoDocument = Datamodel.makeMediaInfoDocument(MediaInfoIdValue.NULL)
 				.withLabel(Datamodel.makeMonolingualTextValue("test", "en"));
-		
+
 		assertThrows(UnsupportedOperationException.class, () -> wde.createEntityDocument(mediaInfoDocument, "summary", Collections.emptyList()));
 	}
 
@@ -492,7 +492,7 @@ public class WikibaseDataEditorTest {
 
 		assertEquals(expectedResultDocument, result);
 	}
-	
+
 	@Test
 	@Deprecated
 	public void testStatementUpdateWithoutChanges() throws MediaWikiApiErrorException, IOException {
@@ -512,21 +512,21 @@ public class WikibaseDataEditorTest {
 		ItemDocument itemDocument = ItemDocumentBuilder.forItemId(id)
 				.withStatement(s1)
 				.withRevisionId(1234).build();
-		
+
 		wde.setRemainingEdits(10);
-		
+
 		ItemDocument editedItemDocument = wde.updateStatements(
 				itemDocument,
 				Collections.singletonList(s1dup),
 				Collections.singletonList(s2),
 				"Doing spurious changes",
 				null);
-		
+
 		// no edit was made at all
 		assertEquals(itemDocument, editedItemDocument);
 		assertEquals(10, wde.getRemainingEdits());
 	}
-	
+
 	@Test
 	@Deprecated
 	public void testTermStatementUpdateWithoutChanges() throws MediaWikiApiErrorException, IOException {
@@ -549,9 +549,9 @@ public class WikibaseDataEditorTest {
 				.withDescription(description)
 				.withStatement(s1)
 				.withRevisionId(1234).build();
-		
+
 		wde.setRemainingEdits(10);
-		
+
 		ItemDocument editedItemDocument = wde.updateTermsStatements(
 				itemDocument,
 				Collections.singletonList(label),
@@ -562,27 +562,27 @@ public class WikibaseDataEditorTest {
 				Collections.singletonList(s2),
 				"Doing spurious changes",
 				null);
-		
+
 		// no edit was made at all
 		assertEquals(itemDocument, editedItemDocument);
 		assertEquals(10, wde.getRemainingEdits());
 	}
-	
-	
+
+
 	@Test
 	public void testNullEdit() throws IOException, MediaWikiApiErrorException {
 		WikibaseDataEditor wde = new WikibaseDataEditor(this.con,
 				Datamodel.SITE_WIKIDATA);
 		wde.setRemainingEdits(10);
-		
+
 		ItemIdValue id = Datamodel.makeWikidataItemIdValue("Q1234");
-		
+
 		Statement s1 = StatementBuilder.forSubjectAndProperty(id, P31)
 				.withValue(Q5).withId("ID-s1").build();
 		ItemDocument itemDocument = ItemDocumentBuilder.forItemId(id)
 				.withStatement(s1)
 				.withRevisionId(1234).build();
-		
+
 		Map<String, String> params = new HashMap<>();
 		params.put("action", "wbeditentity");
 		params.put("id", "Q1234");
@@ -594,13 +594,13 @@ public class WikibaseDataEditorTest {
 		String data = JsonSerializer.getJsonString(itemDocument);
 		String expectedResult = "{\"entity\":"+data+",\"success\":1}";
 		con.setWebResource(params, expectedResult);
-		
+
 		ItemDocument nullEditedItemDocument = wde.nullEdit(itemDocument);
-		
+
 		assertEquals(itemDocument, nullEditedItemDocument);
 		assertEquals(9, wde.getRemainingEdits());
 	}
-	
+
 	@Test
 	@Deprecated
 	public void testLabelEdit() throws MediaWikiApiErrorException, IOException {
@@ -619,7 +619,7 @@ public class WikibaseDataEditorTest {
 				.withStatement(s1)
 				.withRevisionId(1235)
 				.build();
-		
+
 		Map<String, String> params = new HashMap<>();
 		params.put("action", "wbsetlabel");
 		params.put("id", "Q1234");
@@ -641,7 +641,7 @@ public class WikibaseDataEditorTest {
 
 		assertEquals(expectedDocument, editedDocument);
 	}
-	
+
 	@Test
 	@Deprecated
 	public void testDescriptionEdit() throws MediaWikiApiErrorException, IOException {
@@ -660,7 +660,7 @@ public class WikibaseDataEditorTest {
 				.withStatement(s1)
 				.withRevisionId(1235L)
 				.build();
-		
+
 		Map<String, String> params = new HashMap<>();
 		params.put("action", "wbsetdescription");
 		params.put("id", "Q1234");
@@ -682,7 +682,7 @@ public class WikibaseDataEditorTest {
 
 		assertEquals(expectedDocument, editedDocument);
 	}
-	
+
 	@Test
 	@Deprecated
 	public void testAliasEdit() throws MediaWikiApiErrorException, IOException {
@@ -706,7 +706,7 @@ public class WikibaseDataEditorTest {
 				.withAlias(addedAlias)
 				.withRevisionId(1235)
 				.build();
-		
+
 		Map<String, String> params = new HashMap<>();
 		params.put("action", "wbsetaliases");
 		params.put("id", "Q1234");
@@ -729,7 +729,7 @@ public class WikibaseDataEditorTest {
 
 		assertEquals(expectedDocument, editedDocument);
 	}
-	
+
 	@Test
 	@Deprecated
 	public void testNewSingleStatement() throws MediaWikiApiErrorException, IOException {
@@ -748,7 +748,7 @@ public class WikibaseDataEditorTest {
 				.withStatement(s2)
 				.withRevisionId(1235)
 				.build();
-		
+
 		String statementJson = JsonSerializer.getJsonString(s2);
 		Map<String, String> params = new HashMap<>();
 		params.put("action", "wbsetclaim");
@@ -769,7 +769,7 @@ public class WikibaseDataEditorTest {
 
 		assertEquals(expectedDocument, editedDocument);
 	}
-	
+
 	@Test
 	@Deprecated
 	public void testDeleteStatements() throws MediaWikiApiErrorException, IOException {
@@ -789,9 +789,9 @@ public class WikibaseDataEditorTest {
 		ItemDocument expectedDocument = ItemDocumentBuilder.forItemId(id)
 				.withRevisionId(1235)
 				.build();
-		
+
 		List<String> statementIds = Arrays.asList("Q1234$"+guid1, "Q1234$"+guid2);
-		
+
 		String statementsList = String.join("|", statementIds);
 		Map<String, String> params = new HashMap<>();
 		params.put("action", "wbremoveclaims");
@@ -849,7 +849,7 @@ public class WikibaseDataEditorTest {
 
 		assertEquals(expectedResultDocument, result);
 	}
-	
+
 	@Deprecated
 	@SuppressWarnings("deprecation")
 	@Test(expected = TagsApplyNotAllowedException.class)
@@ -894,7 +894,7 @@ public class WikibaseDataEditorTest {
 		WikibaseDataEditor wde = new WikibaseDataEditor(action, fetcher, Datamodel.SITE_WIKIDATA, guids);
 		return wde.editEntityDocument(update, false, "test summary", Arrays.asList("tag1"));
 	}
-	
+
 	private JsonNode json(String resourceFileName) {
 	    try {
     	    String contents = MockStringContentFactory
@@ -916,13 +916,13 @@ public class WikibaseDataEditorTest {
 		when(action.wbSetClaim(
                 JsonSerializer.getJsonString(statementWithId), false, 123, "test summary", Arrays.asList("tag1")))
 		    .thenReturn(json("/wbsetclaim.json"));
-		
+
 		EditingResult result = mockEntityUpdate(action, ItemUpdateBuilder.forBaseRevisionId(subject, 123)
 				.updateStatements(StatementUpdateBuilder.create()
 						.add(statement)
 						.build())
 				.build());
-		
+
 		assertEquals(result, new EditingResult(1234L));
 		verify(action, only()).wbSetClaim(
 				JsonSerializer.getJsonString(statementWithId), false, 123, "test summary", Arrays.asList("tag1"));
@@ -939,11 +939,11 @@ public class WikibaseDataEditorTest {
 		when(action.wbSetClaim(
                 JsonSerializer.getJsonString(statement), false, 123, "test summary", Arrays.asList("tag1")))
             .thenReturn(json("/wbsetclaim.json"));
-		
+
         EditingResult result = mockEntityUpdate(action, ItemUpdateBuilder.forBaseRevisionId(subject, 123)
 				.updateStatements(StatementUpdateBuilder.create().replace(statement).build())
 				.build());
-        
+
         assertEquals(result, new EditingResult(1234L));
 		verify(action, only()).wbSetClaim(
 				JsonSerializer.getJsonString(statement), false, 123, "test summary", Arrays.asList("tag1"));
@@ -956,11 +956,11 @@ public class WikibaseDataEditorTest {
 		WbEditingAction action = mock(WbEditingAction.class);
 		when(action.wbRemoveClaims(Arrays.asList(id), false, 123, "test summary", Arrays.asList("tag1")))
 		    .thenReturn(json("/wbremoveclaims.json"));
-		
+
         EditingResult result = mockEntityUpdate(action, ItemUpdateBuilder.forBaseRevisionId(subject, 123)
 				.updateStatements(StatementUpdateBuilder.create().remove(id).build())
 				.build());
-        
+
         assertEquals(result, new EditingResult(1234L));
 		verify(action, only()).wbRemoveClaims(Arrays.asList(id), false, 123, "test summary", Arrays.asList("tag1"));
 	}
@@ -971,14 +971,14 @@ public class WikibaseDataEditorTest {
 		when(action.wbSetLabel(
                 "Q1", null, null, null, "en", "hello", false, 123, "test summary", Arrays.asList("tag1")))
 		    .thenReturn(json("/wbsetlabel.json"));
-		
+
         EditingResult result = mockEntityUpdate(action, ItemUpdateBuilder
 				.forBaseRevisionId(makeWikidataItemIdValue("Q1"), 123)
 				.updateLabels(TermUpdateBuilder.create()
 						.put(Datamodel.makeMonolingualTextValue("hello", "en"))
 						.build())
 				.build());
-        
+
         assertEquals(result, new EditingResult(1234L));
 		verify(action, only()).wbSetLabel(
 				"Q1", null, null, null, "en", "hello", false, 123, "test summary", Arrays.asList("tag1"));
@@ -990,12 +990,12 @@ public class WikibaseDataEditorTest {
 		when(action.wbSetLabel(
                 "Q1", null, null, null, "en", null, false, 123, "test summary", Arrays.asList("tag1")))
 		    .thenReturn(json("/wbsetlabel-null.json"));
-		
+
         EditingResult result = mockEntityUpdate(action, ItemUpdateBuilder
 				.forBaseRevisionId(makeWikidataItemIdValue("Q1"), 123)
 				.updateLabels(TermUpdateBuilder.create().remove("en").build())
 				.build());
-        
+
         assertEquals(result, new EditingResult(1234L));
 		verify(action, only()).wbSetLabel(
 				"Q1", null, null, null, "en", null, false, 123, "test summary", Arrays.asList("tag1"));
@@ -1007,14 +1007,14 @@ public class WikibaseDataEditorTest {
 		when(action.wbSetDescription(
                 "Q1", null, null, null, "en", "hello", false, 123, "test summary", Arrays.asList("tag1")))
 		    .thenReturn(json("/wbsetdescription.json"));
-		
+
         EditingResult result = mockEntityUpdate(action, ItemUpdateBuilder
 				.forBaseRevisionId(makeWikidataItemIdValue("Q1"), 123)
 				.updateDescriptions(TermUpdateBuilder.create()
 						.put(Datamodel.makeMonolingualTextValue("hello", "en"))
 						.build())
 				.build());
-        
+
         assertEquals(result, new EditingResult(1234L));
 		verify(action, only()).wbSetDescription(
 				"Q1", null, null, null, "en", "hello", false, 123, "test summary", Arrays.asList("tag1"));
@@ -1026,12 +1026,12 @@ public class WikibaseDataEditorTest {
 		when(action.wbSetDescription(
                 "Q1", null, null, null, "en", null, false, 123, "test summary", Arrays.asList("tag1")))
 		    .thenReturn(json("/wbsetdescription-null.json"));
-		
+
         EditingResult result = mockEntityUpdate(action, ItemUpdateBuilder
 				.forBaseRevisionId(makeWikidataItemIdValue("Q1"), 123)
 				.updateDescriptions(TermUpdateBuilder.create().remove("en").build())
 				.build());
-        
+
         assertEquals(result, new EditingResult(1234L));
 		verify(action, only()).wbSetDescription(
 				"Q1", null, null, null, "en", null, false, 123, "test summary", Arrays.asList("tag1"));
@@ -1043,7 +1043,7 @@ public class WikibaseDataEditorTest {
 		when(action.wbSetAliases("Q1", null, null, null, "en",
                 Arrays.asList("hello"), Arrays.asList("bye"), null, false, 123, "test summary", Arrays.asList("tag1")))
 		    .thenReturn(json("/wbsetaliases-add-remove.json"));
-		
+
         EditingResult result = mockEntityUpdate(action, ItemUpdateBuilder
 				.forBaseRevisionId(makeWikidataItemIdValue("Q1"), 123)
 				.updateAliases("en", AliasUpdateBuilder.create()
@@ -1051,7 +1051,7 @@ public class WikibaseDataEditorTest {
 						.remove(Datamodel.makeMonolingualTextValue("bye", "en"))
 						.build())
 				.build());
-        
+
         assertEquals(result, new EditingResult(1234L));
 		verify(action, only()).wbSetAliases("Q1", null, null, null, "en",
 				Arrays.asList("hello"), Arrays.asList("bye"), null, false, 123, "test summary", Arrays.asList("tag1"));
@@ -1069,12 +1069,12 @@ public class WikibaseDataEditorTest {
 		when(action.wbEditEntity("L1-S1", null, null, null, JsonSerializer.getJsonString(update),
                 false, false, 123, "test summary", Arrays.asList("tag1")))
 		    .thenReturn(senseDocument);
-		
+
         EditingResult result = mockEntityUpdate(action, LexemeUpdateBuilder
 				.forBaseRevisionId(makeWikidataLexemeIdValue("L1"), 123)
 				.updateSense(update)
 				.build());
-        
+
         assertEquals(result, new EditingResult(1234L));
 		verify(action, only()).wbEditEntity("L1-S1", null, null, null, JsonSerializer.getJsonString(update),
 				false, false, 123, "test summary", Arrays.asList("tag1"));
@@ -1092,12 +1092,12 @@ public class WikibaseDataEditorTest {
 		when(action.wbEditEntity("L1-F1", null, null, null, JsonSerializer.getJsonString(update),
                 false, false, 123, "test summary", Arrays.asList("tag1")))
 		    .thenReturn(formDocument);
-		
+
         EditingResult result = mockEntityUpdate(action, LexemeUpdateBuilder
 				.forBaseRevisionId(makeWikidataLexemeIdValue("L1"), 123)
 				.updateForm(update)
 				.build());
-        
+
         assertEquals(result, new EditingResult(1234L));
 		verify(action, only()).wbEditEntity("L1-F1", null, null, null, JsonSerializer.getJsonString(update),
 				false, false, 123, "test summary", Arrays.asList("tag1"));
@@ -1115,9 +1115,9 @@ public class WikibaseDataEditorTest {
 		when(action.wbEditEntity("L1", null, null, null, JsonSerializer.getJsonString(update),
                 false, false, 123, "test summary", Arrays.asList("tag1")))
 		    .thenReturn(lexemeDocument);
-		
+
         EditingResult result = mockEntityUpdate(action, update);
-        
+
         assertEquals(result, new EditingResult(1234L));
 		verify(action, only()).wbEditEntity("L1", null, null, null, JsonSerializer.getJsonString(update),
 				false, false, 123, "test summary", Arrays.asList("tag1"));
@@ -1137,9 +1137,9 @@ public class WikibaseDataEditorTest {
 		    .thenReturn(itemDocument);
 		WikibaseDataFetcher fetcher = new WikibaseDataFetcher(con, Datamodel.SITE_WIKIDATA);
 		WikibaseDataEditor wde = new WikibaseDataEditor(action, fetcher, Datamodel.SITE_WIKIDATA, guids);
-		
+
 		EditingResult result = wde.editEntityDocument(update, true, "test summary", Arrays.asList("tag1"));
-		
+
         assertEquals(result, new EditingResult(1234L));
 		verify(action, only()).wbEditEntity("Q1", null, null, null, JsonSerializer.getJsonString(update),
 				true, false, 123, "test summary", Arrays.asList("tag1"));
@@ -1151,7 +1151,7 @@ public class WikibaseDataEditorTest {
 	    EditingResult result = mockEntityUpdate(action, LexemeUpdateBuilder
                 .forBaseRevisionId(makeWikidataLexemeIdValue("L1"), 123)
                 .build());
-	    
+
 	    assertEquals(result, new EditingResult(0L));
 		verifyNoInteractions(action);
 	}

--- a/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/apierrors/MediaWikiErrorMessageTest.java
+++ b/wdtk-wikibaseapi/src/test/java/org/wikidata/wdtk/wikibaseapi/apierrors/MediaWikiErrorMessageTest.java
@@ -9,9 +9,9 @@ package org.wikidata.wdtk.wikibaseapi.apierrors;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -22,21 +22,20 @@ package org.wikidata.wdtk.wikibaseapi.apierrors;
 
 import static org.junit.Assert.*;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
 import org.junit.Test;
 
 public class MediaWikiErrorMessageTest {
 
     @Test
-    public void testDeserialize() throws JsonMappingException, JsonProcessingException {
+    public void testDeserialize() {
         String json = "{\"name\": \"wikibase-api-failed-save\","
                 + "\"html\": {\"*\": \"The save has failed\"}}";
-        
-        ObjectMapper mapper = new ObjectMapper();
+
+        JsonMapper mapper = new JsonMapper();
         MediaWikiErrorMessage message = mapper.readValue(json, MediaWikiErrorMessage.class);
-        
+
         assertEquals("The save has failed", message.getHTMLText());
         assertEquals("wikibase-api-failed-save", message.getName());
     }


### PR DESCRIPTION
Update to Jackson 3 + Java 17 as new baseline.

Reference:
- https://github.com/FasterXML/jackson/wiki/Jackson-Release-3.0
- https://github.com/FasterXML/jackson/blob/main/jackson3/MIGRATING_TO_JACKSON_3.md
- https://spring.io/blog/2025/10/07/introducing-jackson-3-support-in-spring
- https://github.com/don-vip/Wikidata-Toolkit/actions/runs/19602442390