### PR TITLE
ci: fix permissions of release workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,12 @@
 name: Maven Release
 
-
 on:
   release:
     types: [published]
+
+# For the publication of javadocs as gh-pages, this is necessary
+permissions:
+  contents: write
 
 jobs:
   build:


### PR DESCRIPTION
Additional permissions are required to publish the javadocs as gh-pages.

See: https://github.com/JamesIves/github-pages-deploy-action#getting-started-airplane

Failing job: https://github.com/Wikidata-Toolkit/Wikidata-Toolkit/actions/runs/26742353835/job/78809197186